### PR TITLE
Add desktop installers and auto-update support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,11 +197,25 @@ jobs:
           --dart-define=APP_WORKFLOW_NIGHTLY_ID=${{ env.APP_WORKFLOW_NIGHTLY_ID }}
           --dart-define=APP_NIGHTLY_ARTIFACT=windows-release
 
+      - name: Install NSIS
+        shell: pwsh
+        run: |
+          choco install nsis -y
+          makensis /VERSION
+
+      - name: Build Windows installer
+        shell: pwsh
+        run: |
+          makensis `
+            /DVERSION=nightly-${{ github.run_number }} `
+            /DSOURCE_DIR=build\windows\x64\runner\Release `
+            windows\installer\yabus.nsi
+
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v6
         with:
           name: windows-release
-          path: build/windows/x64/runner/Release
+          path: windows/installer/YABus-nightly-${{ github.run_number }}-windows-x64-setup.exe
 
   build-linux:
     name: Build Linux
@@ -215,7 +229,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev libnotify-dev
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev libnotify-dev dpkg-dev
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -241,11 +255,20 @@ jobs:
           --dart-define=APP_WORKFLOW_NIGHTLY_ID=${{ env.APP_WORKFLOW_NIGHTLY_ID }}
           --dart-define=APP_NIGHTLY_ARTIFACT=linux-release
 
+      - name: Package Linux installers
+        shell: bash
+        run: |
+          chmod +x linux/installer/create_linux_packages.sh
+          bash linux/installer/create_linux_packages.sh \
+            build/linux/x64/release/bundle \
+            nightly-${{ github.run_number }} \
+            build/linux/output
+
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v6
         with:
           name: linux-release
-          path: build/linux/x64/release/bundle
+          path: build/linux/output
 
   build-macos:
     name: Build macOS
@@ -280,7 +303,7 @@ jobs:
           --dart-define=APP_WORKFLOW_NIGHTLY_ID=${{ env.APP_WORKFLOW_NIGHTLY_ID }}
           --dart-define=APP_NIGHTLY_ARTIFACT=macos-release
 
-      - name: Package macOS app bundle
+      - name: Package macOS DMG
         shell: bash
         run: |
           APP_PATH=$(find build/macos/Build/Products/Release -maxdepth 1 -name "*.app" -type d | head -1)
@@ -288,13 +311,15 @@ jobs:
             echo "No macOS .app bundle found."
             exit 1
           fi
-          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" build/macos/YABus-macos.zip
+          mkdir -p build/macos/output
+          chmod +x macos/installer/create_dmg.sh
+          bash macos/installer/create_dmg.sh "$APP_PATH" nightly-${{ github.run_number }} build/macos/output
 
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v6
         with:
           name: macos-release
-          path: build/macos/YABus-macos.zip
+          path: build/macos/output/YABus-nightly-${{ github.run_number }}-macos.dmg
 
   build-ios-ipa:
     name: Build iOS unsigned IPA

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,22 +201,26 @@ jobs:
         shell: pwsh
         run: |
           choco install nsis -y
-            $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
-            if (-not (Test-Path $nsisExe)) {
-              throw "makensis.exe not found at $nsisExe"
-            }
-            & $nsisExe /VERSION
+          $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
+          if (-not (Test-Path $nsisExe)) {
+            throw "makensis.exe not found at $nsisExe"
+          }
+          & $nsisExe /VERSION
 
       - name: Build Windows installer
         shell: pwsh
         run: |
-            $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
-            if (-not (Test-Path $nsisExe)) {
-              throw "makensis.exe not found at $nsisExe"
-            }
-            & $nsisExe `
-            /DVERSION=nightly-${{ github.run_number }} `
-            /DSOURCE_DIR=build\windows\x64\runner\Release `
+          $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
+          $sourceDir = Join-Path $env:GITHUB_WORKSPACE 'build\windows\x64\runner\Release'
+          if (-not (Test-Path $nsisExe)) {
+            throw "makensis.exe not found at $nsisExe"
+          }
+          if (-not (Test-Path $sourceDir)) {
+            throw "Windows build output not found at $sourceDir"
+          }
+          & $nsisExe `
+            "/DVERSION=nightly-${{ github.run_number }}" `
+            "/DSOURCE_DIR=$sourceDir" `
             windows\installer\yabus.nsi
 
       - name: Upload Windows artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,12 +201,20 @@ jobs:
         shell: pwsh
         run: |
           choco install nsis -y
-          makensis /VERSION
+            $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
+            if (-not (Test-Path $nsisExe)) {
+              throw "makensis.exe not found at $nsisExe"
+            }
+            & $nsisExe /VERSION
 
       - name: Build Windows installer
         shell: pwsh
         run: |
-          makensis `
+            $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
+            if (-not (Test-Path $nsisExe)) {
+              throw "makensis.exe not found at $nsisExe"
+            }
+            & $nsisExe `
             /DVERSION=nightly-${{ github.run_number }} `
             /DSOURCE_DIR=build\windows\x64\runner\Release `
             windows\installer\yabus.nsi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,12 +183,19 @@ jobs:
         shell: pwsh
         run: |
           choco install nsis -y
-          # Verify makensis is on PATH
-          makensis /VERSION
+            $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
+            if (-not (Test-Path $nsisExe)) {
+              throw "makensis.exe not found at $nsisExe"
+            }
+            & $nsisExe /VERSION
       - name: Build NSIS installer
         shell: pwsh
         run: |
-          makensis `
+            $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
+            if (-not (Test-Path $nsisExe)) {
+              throw "makensis.exe not found at $nsisExe"
+            }
+            & $nsisExe `
             /DVERSION=${{ inputs.version }} `
             /DSOURCE_DIR=build\windows\x64\runner\Release `
             windows\installer\yabus.nsi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,21 +183,25 @@ jobs:
         shell: pwsh
         run: |
           choco install nsis -y
-            $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
-            if (-not (Test-Path $nsisExe)) {
-              throw "makensis.exe not found at $nsisExe"
-            }
-            & $nsisExe /VERSION
+          $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
+          if (-not (Test-Path $nsisExe)) {
+            throw "makensis.exe not found at $nsisExe"
+          }
+          & $nsisExe /VERSION
       - name: Build NSIS installer
         shell: pwsh
         run: |
-            $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
-            if (-not (Test-Path $nsisExe)) {
-              throw "makensis.exe not found at $nsisExe"
-            }
-            & $nsisExe `
-            /DVERSION=${{ inputs.version }} `
-            /DSOURCE_DIR=build\windows\x64\runner\Release `
+          $nsisExe = Join-Path ${env:ProgramFiles(x86)} 'NSIS\makensis.exe'
+          $sourceDir = Join-Path $env:GITHUB_WORKSPACE 'build\windows\x64\runner\Release'
+          if (-not (Test-Path $nsisExe)) {
+            throw "makensis.exe not found at $nsisExe"
+          }
+          if (-not (Test-Path $sourceDir)) {
+            throw "Windows build output not found at $sourceDir"
+          }
+          & $nsisExe `
+            "/DVERSION=${{ inputs.version }}" `
+            "/DSOURCE_DIR=$sourceDir" `
             windows\installer\yabus.nsi
       - name: Upload Windows installer artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,20 +179,24 @@ jobs:
           --dart-define=APP_WORKFLOW_API_ID=${{ env.APP_WORKFLOW_API_ID }}
           --dart-define=APP_WORKFLOW_NIGHTLY_ID=${{ env.APP_WORKFLOW_NIGHTLY_ID }}
           --dart-define=APP_NIGHTLY_ARTIFACT=windows-release
-      - name: Package Windows artifact
+      - name: Install NSIS
         shell: pwsh
         run: |
-          $stageRoot = 'build/windows/package'
-          $stageDir = Join-Path $stageRoot 'YABus-${{ inputs.version }}-windows-x64'
-          Remove-Item $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path $stageDir -Force | Out-Null
-          Copy-Item -Recurse -Force 'build/windows/x64/runner/Release/*' $stageDir
-          Compress-Archive -Path $stageDir -DestinationPath 'build/windows/YABus-${{ inputs.version }}-windows-x64.zip' -Force
-      - name: Upload Windows artifact
+          choco install nsis -y
+          # Verify makensis is on PATH
+          makensis /VERSION
+      - name: Build NSIS installer
+        shell: pwsh
+        run: |
+          makensis `
+            /DVERSION=${{ inputs.version }} `
+            /DSOURCE_DIR=build\windows\x64\runner\Release `
+            windows\installer\yabus.nsi
+      - name: Upload Windows installer artifact
         uses: actions/upload-artifact@v6
         with:
           name: windows-release
-          path: build/windows/YABus-${{ inputs.version }}-windows-x64.zip
+          path: windows/installer/YABus-${{ inputs.version }}-windows-x64-setup.exe
 
   build-linux:
     name: Build Linux
@@ -203,7 +207,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev libnotify-dev
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev libnotify-dev dpkg-dev
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -229,20 +233,24 @@ jobs:
           --dart-define=APP_WORKFLOW_API_ID=${{ env.APP_WORKFLOW_API_ID }}
           --dart-define=APP_WORKFLOW_NIGHTLY_ID=${{ env.APP_WORKFLOW_NIGHTLY_ID }}
           --dart-define=APP_NIGHTLY_ARTIFACT=linux-release
-      - name: Package Linux artifact
+      - name: Package Linux .deb and AppImage
         shell: bash
         run: |
-          PACKAGE_ROOT="build/linux/package"
-          PACKAGE_DIR="$PACKAGE_ROOT/YABus-${{ inputs.version }}-linux-x64"
-          rm -rf "$PACKAGE_ROOT"
-          mkdir -p "$PACKAGE_DIR"
-          cp -R build/linux/x64/release/bundle/. "$PACKAGE_DIR/"
-          tar -C "$PACKAGE_ROOT" -czf build/linux/YABus-${{ inputs.version }}-linux-x64.tar.gz "YABus-${{ inputs.version }}-linux-x64"
-      - name: Upload Linux artifact
+          chmod +x linux/installer/create_linux_packages.sh
+          bash linux/installer/create_linux_packages.sh \
+            build/linux/x64/release/bundle \
+            ${{ inputs.version }} \
+            build/linux/output
+      - name: Upload Linux .deb artifact
         uses: actions/upload-artifact@v6
         with:
-          name: linux-release
-          path: build/linux/YABus-${{ inputs.version }}-linux-x64.tar.gz
+          name: linux-deb-release
+          path: build/linux/output/*.deb
+      - name: Upload Linux AppImage artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-appimage-release
+          path: build/linux/output/*.AppImage
 
   build-macos:
     name: Build macOS
@@ -275,7 +283,7 @@ jobs:
           --dart-define=APP_WORKFLOW_API_ID=${{ env.APP_WORKFLOW_API_ID }}
           --dart-define=APP_WORKFLOW_NIGHTLY_ID=${{ env.APP_WORKFLOW_NIGHTLY_ID }}
           --dart-define=APP_NIGHTLY_ARTIFACT=macos-release
-      - name: Package macOS app bundle
+      - name: Package macOS DMG
         shell: bash
         run: |
           APP_PATH=$(find build/macos/Build/Products/Release -maxdepth 1 -name "*.app" -type d | head -1)
@@ -283,12 +291,14 @@ jobs:
             echo "No macOS .app bundle found."
             exit 1
           fi
-          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "build/macos/YABus-${{ inputs.version }}-macos.zip"
+          mkdir -p build/macos/output
+          chmod +x macos/installer/create_dmg.sh
+          bash macos/installer/create_dmg.sh "$APP_PATH" ${{ inputs.version }} build/macos/output
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v6
         with:
           name: macos-release
-          path: build/macos/YABus-${{ inputs.version }}-macos.zip
+          path: build/macos/output/YABus-${{ inputs.version }}-macos.dmg
 
   build-ios-ipa:
     name: Build iOS unsigned IPA
@@ -397,17 +407,22 @@ jobs:
         with:
           name: ios-unsigned-ipa
           path: release-assets
-      - name: Download Windows package
+      - name: Download Windows installer
         uses: actions/download-artifact@v5
         with:
           name: windows-release
           path: release-assets
-      - name: Download Linux package
+      - name: Download Linux .deb
         uses: actions/download-artifact@v5
         with:
-          name: linux-release
+          name: linux-deb-release
           path: release-assets
-      - name: Download macOS package
+      - name: Download Linux AppImage
+        uses: actions/download-artifact@v5
+        with:
+          name: linux-appimage-release
+          path: release-assets
+      - name: Download macOS DMG
         uses: actions/download-artifact@v5
         with:
           name: macos-release
@@ -448,7 +463,8 @@ jobs:
           files: |
             release-assets/YABus-${{ inputs.version }}.apk
             release-assets/YABus-${{ inputs.version }}.ipa
-            release-assets/YABus-${{ inputs.version }}-windows-x64.zip
-            release-assets/YABus-${{ inputs.version }}-linux-x64.tar.gz
-            release-assets/YABus-${{ inputs.version }}-macos.zip
+            release-assets/YABus-${{ inputs.version }}-windows-x64-setup.exe
+            release-assets/YABus-${{ inputs.version }}-linux-amd64.deb
+            release-assets/YABus-${{ inputs.version }}-linux-x86_64.AppImage
+            release-assets/YABus-${{ inputs.version }}-macos.dmg
             release-assets/YABus-${{ inputs.version }}-web.zip

--- a/lib/core/app_update_installer_io.dart
+++ b/lib/core/app_update_installer_io.dart
@@ -166,6 +166,46 @@ class IoAppUpdateInstaller extends AppUpdateInstaller {
     return outputFile;
   }
 
+  Future<File> _extractPackagedInstaller(
+    File zipFile,
+    Directory outputDirectory,
+    AppUpdatePackageFormat format,
+  ) async {
+    final archive = ZipDecoder().decodeBytes(
+      await zipFile.readAsBytes(),
+      verify: false,
+    );
+    final suffix = switch (format) {
+      AppUpdatePackageFormat.exe => '.exe',
+      AppUpdatePackageFormat.dmg => '.dmg',
+      AppUpdatePackageFormat.deb => '.deb',
+      AppUpdatePackageFormat.appImage => '.appimage',
+      AppUpdatePackageFormat.apk => '.apk',
+      AppUpdatePackageFormat.zip => '.zip',
+    };
+
+    ArchiveFile? installerEntry;
+    for (final file in archive) {
+      if (file.isFile && file.name.toLowerCase().endsWith(suffix)) {
+        installerEntry = file;
+        break;
+      }
+    }
+
+    if (installerEntry == null) {
+      throw FormatException('nightly 壓縮檔裡找不到 ${suffix.toUpperCase()} 安裝檔。');
+    }
+
+    final outputFile = File(
+      p.join(outputDirectory.path, p.basename(installerEntry.name)),
+    );
+    await outputFile.writeAsBytes(
+      installerEntry.content as List<int>,
+      flush: true,
+    );
+    return outputFile;
+  }
+
   // ── Desktop update: download installer, then launch it ──────
   Future<AppUpdateInstallResult> _installDesktopUpdate(
     AppUpdateInfo update, {
@@ -194,25 +234,35 @@ class IoAppUpdateInstaller extends AppUpdateInstaller {
         onProgress: onProgress,
       );
 
+      var installerFile = downloadFile;
+      if (p.extension(downloadFile.path).toLowerCase() == '.zip') {
+        onProgress?.call(null, '整理安裝檔中…');
+        installerFile = await _extractPackagedInstaller(
+          downloadFile,
+          updateDirectory,
+          update.packageFormat,
+        );
+      }
+
       onProgress?.call(null, '啟動安裝程式…');
 
       if (defaultTargetPlatform == TargetPlatform.windows) {
         // NSIS silent install: /S means one-click auto-install
-        await Process.run(downloadFile.path, ['/S']);
+        await Process.run(installerFile.path, ['/S']);
       } else if (defaultTargetPlatform == TargetPlatform.macOS) {
         // Open the DMG so the user can drag to Applications
-        await Process.run('open', [downloadFile.path]);
+        await Process.run('open', [installerFile.path]);
       } else if (defaultTargetPlatform == TargetPlatform.linux) {
         if (update.packageFormat == AppUpdatePackageFormat.appImage) {
           // Replace the current AppImage in-place
           final currentExe = Platform.resolvedExecutable;
           final installDir = p.dirname(currentExe);
           final targetPath = p.join(installDir, p.basename(currentExe));
-          await File(downloadFile.path).rename(targetPath);
+          await File(installerFile.path).rename(targetPath);
           await Process.run('chmod', ['+x', targetPath]);
         } else {
           // deb: open with software center or dpkg
-          await Process.run('xdg-open', [downloadFile.path]);
+          await Process.run('xdg-open', [installerFile.path]);
         }
       }
 

--- a/lib/core/app_update_installer_io.dart
+++ b/lib/core/app_update_installer_io.dart
@@ -19,7 +19,11 @@ class IoAppUpdateInstaller extends AppUpdateInstaller {
 
   @override
   bool get supportsInAppInstall =>
-      !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.windows ||
+          defaultTargetPlatform == TargetPlatform.macOS ||
+          defaultTargetPlatform == TargetPlatform.linux);
 
   @override
   Future<AppUpdateInstallResult> installUpdate(
@@ -43,6 +47,14 @@ class IoAppUpdateInstaller extends AppUpdateInstaller {
       );
     }
 
+    // Desktop platforms: download installer and launch it.
+    if (defaultTargetPlatform == TargetPlatform.windows ||
+        defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.linux) {
+      return _installDesktopUpdate(update, onProgress: onProgress);
+    }
+
+    // Android path below.
     final updateDirectory = await _prepareUpdateDirectory();
     final downloadPath = p.join(
       updateDirectory.path,
@@ -67,6 +79,7 @@ class IoAppUpdateInstaller extends AppUpdateInstaller {
           downloadFile,
           updateDirectory,
         ),
+        _ => downloadFile,
       };
 
       onProgress?.call(null, '啟動安裝程式…');
@@ -151,6 +164,68 @@ class IoAppUpdateInstaller extends AppUpdateInstaller {
     );
     await outputFile.writeAsBytes(apkEntry.content as List<int>, flush: true);
     return outputFile;
+  }
+
+  // ── Desktop update: download installer, then launch it ──────
+  Future<AppUpdateInstallResult> _installDesktopUpdate(
+    AppUpdateInfo update, {
+    AppUpdateInstallProgressCallback? onProgress,
+  }) async {
+    final updateDirectory = await _prepareUpdateDirectory();
+
+    // Derive local filename from download URL or package format.
+    final uriName = p.basename(Uri.parse(update.downloadUrl).path);
+    final localName = uriName.isNotEmpty
+        ? uriName
+        : switch (update.packageFormat) {
+            AppUpdatePackageFormat.exe => 'YABus-setup.exe',
+            AppUpdatePackageFormat.dmg => 'YABus-update.dmg',
+            AppUpdatePackageFormat.deb => 'YABus-update.deb',
+            AppUpdatePackageFormat.appImage => 'YABus-update.AppImage',
+            _ => 'YABus-update.zip',
+          };
+    final downloadFile = File(p.join(updateDirectory.path, localName));
+
+    try {
+      onProgress?.call(0, '下載更新中…');
+      await _downloadFile(
+        update.downloadUrl,
+        downloadFile,
+        onProgress: onProgress,
+      );
+
+      onProgress?.call(null, '啟動安裝程式…');
+
+      if (defaultTargetPlatform == TargetPlatform.windows) {
+        // NSIS silent install: /S means one-click auto-install
+        await Process.run(downloadFile.path, ['/S']);
+      } else if (defaultTargetPlatform == TargetPlatform.macOS) {
+        // Open the DMG so the user can drag to Applications
+        await Process.run('open', [downloadFile.path]);
+      } else if (defaultTargetPlatform == TargetPlatform.linux) {
+        if (update.packageFormat == AppUpdatePackageFormat.appImage) {
+          // Replace the current AppImage in-place
+          final currentExe = Platform.resolvedExecutable;
+          final installDir = p.dirname(currentExe);
+          final targetPath = p.join(installDir, p.basename(currentExe));
+          await File(downloadFile.path).rename(targetPath);
+          await Process.run('chmod', ['+x', targetPath]);
+        } else {
+          // deb: open with software center or dpkg
+          await Process.run('xdg-open', [downloadFile.path]);
+        }
+      }
+
+      return const AppUpdateInstallResult(
+        status: AppUpdateInstallStatus.launchedInstaller,
+        message: '安裝程式已啟動。請依照指示完成安裝後重新開啟 App。',
+      );
+    } catch (error) {
+      return AppUpdateInstallResult(
+        status: AppUpdateInstallStatus.failed,
+        message: '下載或安裝更新失敗：$error',
+      );
+    }
   }
 }
 

--- a/lib/core/app_update_service.dart
+++ b/lib/core/app_update_service.dart
@@ -39,6 +39,16 @@ AppUpdatePackageFormat _packageFormatFromAssetName(String name) {
   return AppUpdatePackageFormat.zip;
 }
 
+AppUpdatePackageFormat get _nightlyPackageFormat {
+  if (kIsWeb) return AppUpdatePackageFormat.zip;
+  return switch (defaultTargetPlatform) {
+    TargetPlatform.windows => AppUpdatePackageFormat.exe,
+    TargetPlatform.macOS => AppUpdatePackageFormat.dmg,
+    TargetPlatform.linux => AppUpdatePackageFormat.deb,
+    _ => AppUpdatePackageFormat.zip,
+  };
+}
+
 class AppUpdateInfo {
   const AppUpdateInfo({
     required this.channel,
@@ -171,7 +181,7 @@ class AppUpdateService {
         title: 'Nightly 更新：$latestShortSha',
         summary: commitMessage,
         downloadUrl: downloadUrl,
-        packageFormat: AppUpdatePackageFormat.zip,
+        packageFormat: _nightlyPackageFormat,
         detailsUrl: compareUrl,
         notes: '目前版本：${buildInfo.shortGitSha}\n最新版本：$latestShortSha',
       ),

--- a/lib/core/app_update_service.dart
+++ b/lib/core/app_update_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 import 'api_user_agent.dart';
@@ -8,7 +9,35 @@ import 'models.dart';
 
 enum AppUpdateStatus { unavailable, upToDate, updateAvailable }
 
-enum AppUpdatePackageFormat { apk, zip }
+enum AppUpdatePackageFormat {
+  apk,
+  zip,
+  exe,
+  dmg,
+  deb,
+  appImage,
+}
+
+/// The preferred asset suffix for the current platform when checking
+/// GitHub Release assets for a downloadable update.
+String get _platformAssetSuffix {
+  if (kIsWeb) return '';
+  if (defaultTargetPlatform == TargetPlatform.windows) return '-windows-x64-setup.exe';
+  if (defaultTargetPlatform == TargetPlatform.macOS) return '-macos.dmg';
+  if (defaultTargetPlatform == TargetPlatform.linux) return '-linux-amd64.deb';
+  return '.apk';
+}
+
+/// Map a release asset filename to the corresponding package format.
+AppUpdatePackageFormat _packageFormatFromAssetName(String name) {
+  final lower = name.toLowerCase();
+  if (lower.endsWith('.apk')) return AppUpdatePackageFormat.apk;
+  if (lower.endsWith('setup.exe')) return AppUpdatePackageFormat.exe;
+  if (lower.endsWith('.dmg')) return AppUpdatePackageFormat.dmg;
+  if (lower.endsWith('.deb')) return AppUpdatePackageFormat.deb;
+  if (lower.endsWith('.appimage')) return AppUpdatePackageFormat.appImage;
+  return AppUpdatePackageFormat.zip;
+}
 
 class AppUpdateInfo {
   const AppUpdateInfo({
@@ -171,25 +200,33 @@ class AppUpdateService {
     }
 
     final assets = payload['assets'] as List<dynamic>? ?? const [];
-    Map<String, dynamic>? apkAsset;
-    for (final asset in assets.whereType<Map<String, dynamic>>()) {
-      final name = (asset['name'] as String? ?? '').toLowerCase();
-      if (name.endsWith('.apk')) {
-        apkAsset = asset;
-        break;
+
+    // Find the best-matching asset for the current platform.
+    Map<String, dynamic>? platformAsset;
+    final suffix = _platformAssetSuffix;
+    if (suffix.isNotEmpty) {
+      for (final asset in assets.whereType<Map<String, dynamic>>()) {
+        final name = asset['name'] as String? ?? '';
+        if (name.contains(suffix)) {
+          platformAsset = asset;
+          break;
+        }
       }
     }
 
-    if (apkAsset == null) {
-      return AppUpdateCheckResult(
-        status: AppUpdateStatus.unavailable,
-        message: '發現新 release $latestTag，但沒有 Android APK 可下載。',
-      );
-    }
+    // Fallback: try APK for mobile, generic zip otherwise.
+    platformAsset ??= assets.whereType<Map<String, dynamic>>().firstWhere(
+      (asset) => (asset['name'] as String? ?? '').toLowerCase().endsWith('.apk'),
+      orElse: () => assets.whereType<Map<String, dynamic>>().firstWhere(
+        (asset) => (asset['name'] as String? ?? '').toLowerCase().endsWith('.zip'),
+        orElse: () => throw StateError('no matching asset'),
+      ),
+    );
 
+    final assetName = platformAsset['name'] as String? ?? '';
     final body = (payload['body'] as String? ?? '').trim();
     final releaseUrl = payload['html_url'] as String?;
-    final downloadUrl = apkAsset['browser_download_url'] as String? ?? '';
+    final downloadUrl = platformAsset['browser_download_url'] as String? ?? '';
     if (downloadUrl.isEmpty) {
       return AppUpdateCheckResult(
         status: AppUpdateStatus.unavailable,
@@ -207,7 +244,7 @@ class AppUpdateService {
         title: 'Release 更新：$latestTag',
         summary: body.isEmpty ? '新的 release 已可下載。' : body.split('\n').first,
         downloadUrl: downloadUrl,
-        packageFormat: AppUpdatePackageFormat.apk,
+        packageFormat: _packageFormatFromAssetName(assetName),
         detailsUrl: releaseUrl,
         notes: body.isEmpty ? null : body,
       ),

--- a/linux/installer/create_linux_packages.sh
+++ b/linux/installer/create_linux_packages.sh
@@ -16,6 +16,14 @@ MAINTAINER="AvianJay"
 DESCRIPTION="台灣公車即時動態查詢"
 DEPS="libgtk-3-0, libglib2.0-0, libpango-1.0-0, libharfbuzz0b, libc6, libstdc++6"
 
+SANITIZED_DEB_VERSION="$(printf '%s' "${VERSION}" | sed 's/[^A-Za-z0-9.+:~_-]/./g')"
+NORMALIZED_DEB_VERSION="$(printf '%s' "${SANITIZED_DEB_VERSION}" | tr '-' '.')"
+if [[ "${NORMALIZED_DEB_VERSION}" =~ ^[0-9] ]]; then
+  DEB_VERSION="${NORMALIZED_DEB_VERSION}"
+else
+  DEB_VERSION="0~${NORMALIZED_DEB_VERSION}"
+fi
+
 mkdir -p "${OUTPUT_DIR}"
 
 # ── .deb package ────────────────────────────────────────────
@@ -61,7 +69,7 @@ fi
 INSTALLED_SIZE=$(du -sk "${DEB_STAGING}" | cut -f1)
 cat > "${DEB_STAGING}/DEBIAN/control" <<CONTROL
 Package: ${APP_NAME}
-Version: ${VERSION}
+Version: ${DEB_VERSION}
 Architecture: ${ARCH}
 Maintainer: ${MAINTAINER}
 Description: ${DESCRIPTION}

--- a/linux/installer/create_linux_packages.sh
+++ b/linux/installer/create_linux_packages.sh
@@ -148,7 +148,7 @@ fi
 
 # Build AppImage
 APPIMAGE_FILE="${OUTPUT_DIR}/YABus-${VERSION}-linux-x86_64.AppImage"
-"${APPIMAGETOOL}" "${APPDIR}" "${APPIMAGE_FILE}"
+APPIMAGE_EXTRACT_AND_RUN=1 "${APPIMAGETOOL}" "${APPDIR}" "${APPIMAGE_FILE}"
 echo "AppImage created: ${APPIMAGE_FILE}"
 
 rm -rf "${APPDIR}"

--- a/linux/installer/create_linux_packages.sh
+++ b/linux/installer/create_linux_packages.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# YABus Linux packaging: .deb and AppImage
+# Usage: create_linux_packages.sh <bundle_dir> <version> <output_dir>
+
+set -euo pipefail
+
+BUNDLE_DIR="${1:?Usage: create_linux_packages.sh <bundle_dir> <version> <output_dir>}"
+VERSION="${2:?Version required}"
+OUTPUT_DIR="${3:?Output directory required}"
+ARCH="amd64"
+
+APP_NAME="yabus"
+APP_DISPLAY_NAME="YABus"
+APP_ID="tw.avianjay.taiwanbus.flutter"
+MAINTAINER="AvianJay"
+DESCRIPTION="台灣公車即時動態查詢"
+DEPS="libgtk-3-0, libglib2.0-0, libpango-1.0-0, libharfbuzz0b, libc6, libstdc++6"
+
+mkdir -p "${OUTPUT_DIR}"
+
+# ── .deb package ────────────────────────────────────────────
+DEB_STAGING="$(mktemp -d)"
+trap "rm -rf ${DEB_STAGING}" EXIT
+
+INSTALL_DIR="/opt/${APP_NAME}"
+mkdir -p "${DEB_STAGING}${INSTALL_DIR}"
+mkdir -p "${DEB_STAGING}/usr/bin"
+mkdir -p "${DEB_STAGING}/usr/share/applications"
+mkdir -p "${DEB_STAGING}/usr/share/icons/hicolor/256x256/apps"
+mkdir -p "${DEB_STAGING}/DEBIAN"
+
+# Copy app bundle
+cp -R "${BUNDLE_DIR}/." "${DEB_STAGING}${INSTALL_DIR}/"
+
+# Wrapper script
+cat > "${DEB_STAGING}/usr/bin/${APP_NAME}" <<SCRIPT
+#!/bin/sh
+exec ${INSTALL_DIR}/${APP_NAME} "\$@"
+SCRIPT
+chmod +x "${DEB_STAGING}/usr/bin/${APP_NAME}"
+
+# .desktop entry
+cat > "${DEB_STAGING}/usr/share/applications/${APP_ID}.desktop" <<DESKTOP
+[Desktop Entry]
+Type=Application
+Name=${APP_DISPLAY_NAME}
+Comment=${DESCRIPTION}
+Exec=${APP_NAME}
+Icon=${APP_NAME}
+Categories=Utility;Maps;
+Terminal=false
+DESKTOP
+
+# Copy icon if available (placeholder otherwise)
+if [ -f "${BUNDLE_DIR}/data/flutter_assets/assets/branding/icon_transparent.png" ]; then
+  cp "${BUNDLE_DIR}/data/flutter_assets/assets/branding/icon_transparent.png" \
+     "${DEB_STAGING}/usr/share/icons/hicolor/256x256/apps/${APP_NAME}.png"
+fi
+
+# Control file
+INSTALLED_SIZE=$(du -sk "${DEB_STAGING}" | cut -f1)
+cat > "${DEB_STAGING}/DEBIAN/control" <<CONTROL
+Package: ${APP_NAME}
+Version: ${VERSION}
+Architecture: ${ARCH}
+Maintainer: ${MAINTAINER}
+Description: ${DESCRIPTION}
+Depends: ${DEPS}
+Installed-Size: ${INSTALLED_SIZE}
+Section: utils
+Priority: optional
+Homepage: https://github.com/AvianJay/yetanotherbusapp
+CONTROL
+
+# Post-install: update desktop database
+cat > "${DEB_STAGING}/DEBIAN/postinst" <<POSTINST
+#!/bin/sh
+update-desktop-database /usr/share/applications 2>/dev/null || true
+POSTINST
+chmod 755 "${DEB_STAGING}/DEBIAN/postinst"
+
+# Build .deb
+DEB_FILE="${OUTPUT_DIR}/YABus-${VERSION}-linux-${ARCH}.deb"
+dpkg-deb --build "${DEB_STAGING}" "${DEB_FILE}"
+echo "DEB created: ${DEB_FILE}"
+
+rm -rf "${DEB_STAGING}"
+
+# ── AppImage ────────────────────────────────────────────────
+# Download appimagetool if not present
+APPIMAGETOOL="$(command -v appimagetool 2>/dev/null || echo '')"
+if [ -z "${APPIMAGETOOL}" ]; then
+  APPIMAGETOOL="/tmp/appimagetool"
+  if [ ! -x "${APPIMAGETOOL}" ]; then
+    echo "Downloading appimagetool..."
+    curl -fsSL "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" \
+      -o "${APPIMAGETOOL}"
+    chmod +x "${APPIMAGETOOL}"
+  fi
+fi
+
+APPDIR="$(mktemp -d)"
+trap "rm -rf ${APPDIR}" EXIT
+
+mkdir -p "${APPDIR}/usr/bin"
+mkdir -p "${APPDIR}/usr/share/applications"
+mkdir -p "${APPDIR}/usr/share/icons/hicolor/256x256/apps"
+mkdir -p "${APPDIR}/usr/lib"
+
+# Copy app bundle
+cp -R "${BUNDLE_DIR}/." "${APPDIR}/usr/lib/${APP_NAME}/"
+
+# AppRun
+cat > "${APPDIR}/AppRun" <<APPRUN
+#!/bin/sh
+SELF=\$(readlink -f "\$0")
+HERE=\$(dirname "\$SELF")
+exec "\$HERE/usr/lib/${APP_NAME}/${APP_NAME}" "\$@"
+APPRUN
+chmod +x "${APPDIR}/AppRun"
+
+# .desktop entry (AppDir root)
+cat > "${APPDIR}/${APP_ID}.desktop" <<DESKTOP
+[Desktop Entry]
+Type=Application
+Name=${APP_DISPLAY_NAME}
+Comment=${DESCRIPTION}
+Exec=${APP_NAME}
+Icon=${APP_NAME}
+Categories=Utility;Maps;
+Terminal=false
+DESKTOP
+
+# Icon
+if [ -f "${BUNDLE_DIR}/data/flutter_assets/assets/branding/icon_transparent.png" ]; then
+  cp "${BUNDLE_DIR}/data/flutter_assets/assets/branding/icon_transparent.png" \
+     "${APPDIR}/usr/share/icons/hicolor/256x256/apps/${APP_NAME}.png"
+  ln -sf "usr/share/icons/hicolor/256x256/apps/${APP_NAME}.png" "${APPDIR}/${APP_NAME}.png"
+fi
+
+# Build AppImage
+APPIMAGE_FILE="${OUTPUT_DIR}/YABus-${VERSION}-linux-x86_64.AppImage"
+"${APPIMAGETOOL}" "${APPDIR}" "${APPIMAGE_FILE}"
+echo "AppImage created: ${APPIMAGE_FILE}"
+
+rm -rf "${APPDIR}"
+
+echo "All Linux packages created successfully."

--- a/macos/installer/create_dmg.sh
+++ b/macos/installer/create_dmg.sh
@@ -34,6 +34,7 @@ codesign --verify --deep --strict "${APP_PATH}"
 # then we rename it to our preferred naming scheme.
 create-dmg \
   --overwrite \
+  --no-code-sign \
   --dmg-title="YABus" \
   "${APP_PATH}" \
   "${OUTPUT_DIR}"

--- a/macos/installer/create_dmg.sh
+++ b/macos/installer/create_dmg.sh
@@ -9,14 +9,26 @@ set -euo pipefail
 APP_PATH="${1:?Usage: create_dmg.sh <app_path> <version> <output_dir>}"
 VERSION="${2:?Version required}"
 OUTPUT_DIR="${3:?Output directory required}"
+FINAL_DMG_PATH="${OUTPUT_DIR}/YABus-${VERSION}-macos.dmg"
 
 mkdir -p "${OUTPUT_DIR}"
+
+if ! command -v codesign &>/dev/null; then
+  echo "codesign is required to package the macOS DMG."
+  exit 1
+fi
 
 # Install create-dmg via npm if not present
 if ! command -v create-dmg &>/dev/null; then
   echo "Installing create-dmg…"
   npm install --global create-dmg
 fi
+
+# create-dmg expects a signed app bundle. Use ad-hoc signing in CI when
+# no Developer ID certificate is configured.
+echo "Ad-hoc signing app bundle…"
+codesign --force --deep --sign - "${APP_PATH}"
+codesign --verify --deep --strict "${APP_PATH}"
 
 # create-dmg generates the DMG filename automatically from the app name,
 # then we rename it to our preferred naming scheme.
@@ -28,8 +40,15 @@ create-dmg \
 
 # create-dmg outputs "YABus {version}.dmg" — rename to our format
 GENERATED_DMG="$(find "${OUTPUT_DIR}" -maxdepth 1 -name "YABus *.dmg" -type f | head -1)"
-if [ -n "${GENERATED_DMG}" ]; then
-  mv "${GENERATED_DMG}" "${OUTPUT_DIR}/YABus-${VERSION}-macos.dmg"
+if [ -z "${GENERATED_DMG}" ]; then
+  echo "create-dmg did not produce a DMG file."
+  exit 1
 fi
 
-echo "DMG created: ${OUTPUT_DIR}/YABus-${VERSION}-macos.dmg"
+mv "${GENERATED_DMG}" "${FINAL_DMG_PATH}"
+
+echo "Ad-hoc signing DMG…"
+codesign --force --sign - "${FINAL_DMG_PATH}"
+codesign --verify --strict "${FINAL_DMG_PATH}"
+
+echo "DMG created: ${FINAL_DMG_PATH}"

--- a/macos/installer/create_dmg.sh
+++ b/macos/installer/create_dmg.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# YABus macOS DMG builder
+# Usage: create_dmg.sh <app_path> <version> <output_dir>
+# Uses sindresorhus/create-dmg for a polished DMG with
+# auto-positioned app icon + Applications shortcut.
+
+set -euo pipefail
+
+APP_PATH="${1:?Usage: create_dmg.sh <app_path> <version> <output_dir>}"
+VERSION="${2:?Version required}"
+OUTPUT_DIR="${3:?Output directory required}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+# Install create-dmg via npm if not present
+if ! command -v create-dmg &>/dev/null; then
+  echo "Installing create-dmg…"
+  npm install --global create-dmg
+fi
+
+# create-dmg generates the DMG filename automatically from the app name,
+# then we rename it to our preferred naming scheme.
+create-dmg \
+  --overwrite \
+  --dmg-title="YABus" \
+  "${APP_PATH}" \
+  "${OUTPUT_DIR}"
+
+# create-dmg outputs "YABus {version}.dmg" — rename to our format
+GENERATED_DMG="$(find "${OUTPUT_DIR}" -maxdepth 1 -name "YABus *.dmg" -type f | head -1)"
+if [ -n "${GENERATED_DMG}" ]; then
+  mv "${GENERATED_DMG}" "${OUTPUT_DIR}/YABus-${VERSION}-macos.dmg"
+fi
+
+echo "DMG created: ${OUTPUT_DIR}/YABus-${VERSION}-macos.dmg"

--- a/windows/installer/yabus.nsi
+++ b/windows/installer/yabus.nsi
@@ -1,0 +1,110 @@
+; YABus Windows NSIS Installer
+
+!include "MUI2.nsh"
+!include "LogicLib.nsh"
+!include "FileFunc.nsh"
+!include "x64.nsh"
+
+!define APPNAME "YABus"
+!define APPNAMEINTERNAL "YetAnotherBusApp"
+!define COMPANYNAME "AvianJay"
+!define APPID "tw.avianjay.taiwanbus.flutter"
+!define DESCRIPTION "台灣公車即時動態查詢"
+
+; These will be overridden by CI via /D command-line flags
+!ifndef VERSION
+  !define VERSION "0.0.0"
+!endif
+!ifndef SOURCE_DIR
+  !define SOURCE_DIR "..\build\windows\x64\runner\Release"
+!endif
+
+Name "${APPNAME} ${VERSION}"
+OutFile "YABus-${VERSION}-windows-x64-setup.exe"
+InstallDir "$LOCALAPPDATA\${APPNAME}"
+RequestExecutionLevel user
+ShowInstDetails nevershow
+ShowUninstDetails nevershow
+
+; ── Modern UI ──────────────────────────────────────────────
+!define MUI_ICON "..\..\windows\runner\resources\app_icon.ico"
+!define MUI_UNICON "..\..\windows\runner\resources\app_icon.ico"
+!define MUI_ABORTWARNING
+
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_LANGUAGE "TradChinese"
+
+; ── Install ─────────────────────────────────────────────────
+Section "Install"
+  SetOutPath $INSTDIR
+
+  ; Remove old install
+  RMDir /r "$INSTDIR"
+
+  ; Copy all files
+  File /r "${SOURCE_DIR}\*.*"
+
+  ; Write uninstaller
+  WriteUninstaller "$INSTDIR\uninstall.exe"
+
+  ; Registry entries for Add/Remove Programs
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPID}" \
+    "DisplayName" "${APPNAME}"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPID}" \
+    "DisplayVersion" "${VERSION}"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPID}" \
+    "Publisher" "${COMPANYNAME}"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPID}" \
+    "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPID}" \
+    "InstallLocation" "$INSTDIR"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPID}" \
+    "DisplayIcon" "$INSTDIR\${APPNAMEINTERNAL}.exe"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPID}" \
+    "NoRepair" "1"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPID}" \
+    "NoModify" "1"
+
+  ; Estimate size
+  ${GetSize} "$INSTDIR" "/S=0K" $0
+  IntFmt $0 "0x%08X" $0
+  WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPID}" \
+    "EstimatedSize" "$0"
+
+  ; Start Menu shortcut
+  CreateShortcut "$SMPROGRAMS\${APPNAME}.lnk" "$INSTDIR\${APPNAMEINTERNAL}.exe" "" \
+    "$INSTDIR\${APPNAMEINTERNAL}.exe" 0
+
+  ; Desktop shortcut
+  CreateShortcut "$DESKTOP\${APPNAME}.lnk" "$INSTDIR\${APPNAMEINTERNAL}.exe" "" \
+    "$INSTDIR\${APPNAMEINTERNAL}.exe" 0
+
+  ; Auto-start flag: /S = silent (auto-update), run after install
+  ${If} ${Silent}
+    Exec '"$INSTDIR\${APPNAMEINTERNAL}.exe"'
+  ${EndIf}
+SectionEnd
+
+; ── Uninstall ───────────────────────────────────────────────
+Section "Uninstall"
+  ; Kill running process if any
+  ExecWait "taskkill /IM ${APPNAMEINTERNAL}.exe /F"
+
+  ; Remove files
+  RMDir /r "$INSTDIR"
+
+  ; Remove shortcuts
+  Delete "$SMPROGRAMS\${APPNAME}.lnk"
+  Delete "$DESKTOP\${APPNAME}.lnk"
+
+  ; Remove registry entries
+  DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPID}"
+SectionEnd
+
+; ── Init ────────────────────────────────────────────────────
+Function .onInit
+  ${If} ${RunningX64}
+    SetRegView 64
+  ${EndIf}
+FunctionEnd

--- a/windows/installer/yabus.nsi
+++ b/windows/installer/yabus.nsi
@@ -16,7 +16,7 @@
   !define VERSION "0.0.0"
 !endif
 !ifndef SOURCE_DIR
-  !define SOURCE_DIR "..\build\windows\x64\runner\Release"
+  !define SOURCE_DIR "..\..\build\windows\x64\runner\Release"
 !endif
 
 Name "${APPNAME} ${VERSION}"

--- a/windows/installer/yabus.nsi
+++ b/windows/installer/yabus.nsi
@@ -67,7 +67,7 @@ Section "Install"
     "NoModify" "1"
 
   ; Estimate size
-  ${GetSize} "$INSTDIR" "/S=0K" $0
+  ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
   IntFmt $0 "0x%08X" $0
   WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPID}" \
     "EstimatedSize" "$0"

--- a/windows/installer/yabus.nsi
+++ b/windows/installer/yabus.nsi
@@ -80,10 +80,8 @@ Section "Install"
   CreateShortcut "$DESKTOP\${APPNAME}.lnk" "$INSTDIR\${APPNAMEINTERNAL}.exe" "" \
     "$INSTDIR\${APPNAMEINTERNAL}.exe" 0
 
-  ; Auto-start flag: /S = silent (auto-update), run after install
-  ${If} ${Silent}
-    Exec '"$INSTDIR\${APPNAMEINTERNAL}.exe"'
-  ${EndIf}
+  ; Launch the app after a successful install, including silent updates.
+  Exec '"$INSTDIR\${APPNAMEINTERNAL}.exe"'
 SectionEnd
 
 ; ── Uninstall ───────────────────────────────────────────────


### PR DESCRIPTION
- Windows: NSIS one-click installer (yabus.nsi) with silent /S mode for auto-updates, start menu + desktop shortcuts, per-user install
- macOS: DMG builder using sindresorhus/create-dmg (npm) with Applications folder shortcut
- Linux: .deb package and AppImage builder script with .desktop entry
- Extend AppUpdatePackageFormat with exe/dmg/deb/appImage
- Update release checker to find platform-matching assets instead of only .apk
- Desktop auto-update: download installer and launch it (NSIS /S on Windows, open DMG on macOS, xdg-open/replace AppImage on Linux)
- Update release.yml to build and attach installer artifacts