### PR TITLE
feat: add announcement feature with detailed pages and legal documents

### DIFF
--- a/lib/app/bus_app.dart
+++ b/lib/app/bus_app.dart
@@ -4,8 +4,10 @@ import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../core/announcement_models.dart';
 import '../core/app_controller.dart';
 import '../core/app_analytics.dart';
+import '../core/app_routes.dart';
 import '../core/app_launch_service.dart';
 import '../core/android_home_integration.dart';
 import '../core/desktop_discord_presence_service.dart';
@@ -17,11 +19,21 @@ import '../core/web_update_checker_stub.dart'
     if (dart.library.html) '../core/web_update_checker_web.dart'
     as web_update;
 
+import '../screens/account_screen.dart';
+import '../screens/announcement_detail_page.dart';
+import '../screens/announcements_page.dart';
+import '../screens/database_settings_screen.dart';
 import '../screens/favorites_screen.dart';
 import '../screens/main_transit_shell.dart';
+import '../screens/nearby_screen.dart';
 import '../screens/onboarding_screen.dart';
-import '../screens/route_detail_screen.dart';
+import '../screens/privacy_policy_page.dart';
+import '../screens/route_detail_navigation.dart';
+import '../screens/search_screen.dart';
+import '../screens/settings_screen.dart';
+import '../screens/terms_of_service_page.dart';
 import '../widgets/app_update_dialog.dart';
+import '../widgets/announcement_popup_dialog.dart';
 import '../widgets/database_update_dialog.dart';
 
 class BusApp extends StatelessWidget {
@@ -57,6 +69,11 @@ class BusApp extends StatelessWidget {
                   DesktopDiscordRouteObserver(controller),
                   if (analytics.observer != null) analytics.observer!,
                 ],
+                onGenerateRoute: (settings) =>
+                    _buildAppRoute(settings, controller),
+                onGenerateInitialRoutes: (initialRoute) =>
+                    _buildInitialRoutes(initialRoute, controller),
+                onUnknownRoute: (_) => _buildHomeRoute(controller),
                 home: _AppHome(controller: controller),
               );
             },
@@ -176,6 +193,115 @@ class BusApp extends StatelessWidget {
   }
 }
 
+Route<dynamic> _buildHomeRoute(AppController controller) {
+  return MaterialPageRoute<void>(
+    settings: const RouteSettings(name: AppRoutes.home),
+    builder: (_) => _AppHome(controller: controller),
+  );
+}
+
+Route<dynamic>? _buildAppRoute(
+  RouteSettings settings,
+  AppController controller,
+) {
+  final intent = parseAppRoute(settings.name);
+  switch (intent.kind) {
+    case AppRouteKind.home:
+      return _buildHomeRoute(controller);
+    case AppRouteKind.search:
+      return MaterialPageRoute<void>(
+        settings: const RouteSettings(name: AppRoutes.search),
+        builder: (_) => const SearchScreen(),
+      );
+    case AppRouteKind.favorites:
+      return MaterialPageRoute<void>(
+        settings: const RouteSettings(name: AppRoutes.favorites),
+        builder: (_) => const FavoritesScreen(),
+      );
+    case AppRouteKind.nearby:
+      return MaterialPageRoute<void>(
+        settings: const RouteSettings(name: AppRoutes.nearby),
+        builder: (_) => const NearbyScreen(),
+      );
+    case AppRouteKind.settings:
+      return MaterialPageRoute<void>(
+        settings: const RouteSettings(name: AppRoutes.settings),
+        builder: (_) => const SettingsScreen(),
+      );
+    case AppRouteKind.account:
+      return MaterialPageRoute<void>(
+        settings: const RouteSettings(name: AppRoutes.account),
+        builder: (_) => const AccountScreen(),
+      );
+    case AppRouteKind.databaseSettings:
+      return MaterialPageRoute<void>(
+        settings: const RouteSettings(name: AppRoutes.databaseSettings),
+        builder: (_) => const DatabaseSettingsScreen(),
+      );
+    case AppRouteKind.termsOfService:
+      return MaterialPageRoute<void>(
+        settings: const RouteSettings(name: AppRoutes.termsOfService),
+        builder: (_) => const TermsOfServicePage(),
+      );
+    case AppRouteKind.privacyPolicy:
+      return MaterialPageRoute<void>(
+        settings: const RouteSettings(name: AppRoutes.privacyPolicy),
+        builder: (_) => const PrivacyPolicyPage(),
+      );
+    case AppRouteKind.announcements:
+      return MaterialPageRoute<void>(
+        settings: const RouteSettings(name: AppRoutes.announcements),
+        builder: (_) => const AnnouncementsPage(),
+      );
+    case AppRouteKind.announcementDetail:
+      final announcementId = intent.announcementId;
+      if (announcementId == null || announcementId.isEmpty) {
+        return null;
+      }
+      return MaterialPageRoute<void>(
+        settings: RouteSettings(name: intent.location),
+        builder: (_) => AnnouncementDetailPage(announcementId: announcementId),
+      );
+    case AppRouteKind.routeDetail:
+      final provider = intent.provider;
+      final routeKey = intent.routeKey;
+      if (provider == null || routeKey == null) {
+        return null;
+      }
+      return buildRouteDetailRoute(
+        routeKey: routeKey,
+        provider: provider,
+        initialPathId: intent.pathId,
+        initialStopId: intent.stopId,
+        initialDestinationPathId: intent.destinationPathId,
+        initialDestinationStopId: intent.destinationStopId,
+      );
+    case AppRouteKind.stopDetail:
+    case AppRouteKind.unknown:
+      return null;
+  }
+}
+
+List<Route<dynamic>> _buildInitialRoutes(
+  String initialRoute,
+  AppController controller,
+) {
+  final intent = parseAppRoute(initialRoute);
+  final homeRoute = _buildHomeRoute(controller);
+  if (intent.kind == AppRouteKind.home) {
+    return [homeRoute];
+  }
+
+  final leafRoute = _buildAppRoute(
+    RouteSettings(name: intent.location),
+    controller,
+  );
+  if (leafRoute == null) {
+    return [homeRoute];
+  }
+  return [homeRoute, leafRoute];
+}
+
 class _AppHome extends StatefulWidget {
   const _AppHome({required this.controller});
 
@@ -188,7 +314,10 @@ class _AppHome extends StatefulWidget {
 class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
   bool _startupCheckScheduled = false;
   bool _widgetSyncScheduled = false;
+  bool _announcementCheckScheduled = false;
+  bool _showingAnnouncementPopup = false;
   AppLaunchAction? _pendingLaunchAction;
+  final Set<String> _deferredAnnouncementPopupIds = <String>{};
   StreamSubscription<AppLaunchAction>? _launchSubscription;
   StreamSubscription<web_update.WebUpdateCheckResult>? _webUpdateSubscription;
 
@@ -263,6 +392,7 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
     super.didChangeDependencies();
     _maybeScheduleStartupCheck();
     _maybeScheduleLaunchAction();
+    _maybeScheduleAnnouncementChecks();
   }
 
   @override
@@ -270,6 +400,7 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
     super.didUpdateWidget(oldWidget);
     _maybeScheduleStartupCheck();
     _maybeScheduleLaunchAction();
+    _maybeScheduleAnnouncementChecks();
   }
 
   void _maybeScheduleStartupCheck() {
@@ -312,6 +443,70 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _consumeLaunchAction();
     });
+  }
+
+  void _maybeScheduleAnnouncementChecks() {
+    if (_announcementCheckScheduled || widget.controller.needsOnboarding) {
+      return;
+    }
+
+    _announcementCheckScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _announcementCheckScheduled = false;
+      unawaited(_syncAnnouncementsAndMaybeShowPopup());
+    });
+  }
+
+  Future<void> _syncAnnouncementsAndMaybeShowPopup() async {
+    await widget.controller.ensureAnnouncementsLoaded();
+    if (!mounted) {
+      return;
+    }
+    await _maybeShowAnnouncementPopup();
+  }
+
+  Future<void> _maybeShowAnnouncementPopup() async {
+    if (!mounted || _showingAnnouncementPopup || widget.controller.needsOnboarding) {
+      return;
+    }
+
+    final announcement = widget.controller.nextPendingAnnouncementPopup(
+      sessionDeferredIds: _deferredAnnouncementPopupIds,
+    );
+    if (announcement == null) {
+      return;
+    }
+
+    _showingAnnouncementPopup = true;
+    final result = await showAnnouncementPopupDialog(
+      context,
+      announcement: announcement,
+    );
+    await widget.controller.markAnnouncementPopupShown(announcement);
+    if (!mounted) {
+      _showingAnnouncementPopup = false;
+      return;
+    }
+
+    switch (result) {
+      case AnnouncementPopupResult.dismissForever:
+        await widget.controller.dismissAnnouncementPopup(announcement);
+      case AnnouncementPopupResult.viewDetails:
+        await Navigator.of(
+          context,
+        ).pushNamed(AppRoutes.announcementDetailPath(announcement.id));
+      case AnnouncementPopupResult.later:
+        if (announcement.behavior.popup == AnnouncementRepeatBehavior.forever) {
+          _deferredAnnouncementPopupIds.add(announcement.id);
+        }
+    }
+
+    _showingAnnouncementPopup = false;
+    if (mounted) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        unawaited(_maybeShowAnnouncementPopup());
+      });
+    }
   }
 
   Future<void> _consumeLaunchAction() async {
@@ -361,15 +556,13 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
           return;
         }
         await navigator.push(
-          MaterialPageRoute<void>(
-            builder: (_) => RouteDetailScreen(
-              routeKey: routeKey,
-              provider: provider,
-              initialPathId: action.pathId,
-              initialStopId: action.stopId,
-              initialDestinationPathId: action.destinationPathId,
-              initialDestinationStopId: action.destinationStopId,
-            ),
+          buildRouteDetailRoute(
+            routeKey: routeKey,
+            provider: provider,
+            initialPathId: action.pathId,
+            initialStopId: action.stopId,
+            initialDestinationPathId: action.destinationPathId,
+            initialDestinationStopId: action.destinationStopId,
           ),
         );
       case AppLaunchTarget.favoritesGroup:

--- a/lib/core/announcement_models.dart
+++ b/lib/core/announcement_models.dart
@@ -1,6 +1,6 @@
 import 'dart:collection';
 
-enum AnnouncementRepeatBehavior { once, forever }
+enum AnnouncementRepeatBehavior { none, once, forever }
 
 class AnnouncementBehavior {
   const AnnouncementBehavior({
@@ -201,9 +201,11 @@ class AnnouncementLocalState {
 }
 
 AnnouncementRepeatBehavior _behaviorFromString(Object? value) {
-  return '${value ?? 'once'}'.trim().toLowerCase() == 'forever'
-      ? AnnouncementRepeatBehavior.forever
-      : AnnouncementRepeatBehavior.once;
+  return switch ('${value ?? 'once'}'.trim().toLowerCase()) {
+    'none' => AnnouncementRepeatBehavior.none,
+    'forever' => AnnouncementRepeatBehavior.forever,
+    _ => AnnouncementRepeatBehavior.once,
+  };
 }
 
 Map<String, dynamic>? _stringKeyedMap(Object? value) {

--- a/lib/core/announcement_models.dart
+++ b/lib/core/announcement_models.dart
@@ -1,0 +1,251 @@
+import 'dart:collection';
+
+enum AnnouncementRepeatBehavior { once, forever }
+
+class AnnouncementBehavior {
+  const AnnouncementBehavior({
+    this.redDot = AnnouncementRepeatBehavior.once,
+    this.popup = AnnouncementRepeatBehavior.once,
+  });
+
+  factory AnnouncementBehavior.fromJson(Map<String, dynamic> json) {
+    return AnnouncementBehavior(
+      redDot: _behaviorFromString(json['red_dot']),
+      popup: _behaviorFromString(json['popup']),
+    );
+  }
+
+  final AnnouncementRepeatBehavior redDot;
+  final AnnouncementRepeatBehavior popup;
+}
+
+class AnnouncementTargets {
+  const AnnouncementTargets({this.platforms, this.versionConstraint});
+
+  factory AnnouncementTargets.fromJson(Map<String, dynamic> json) {
+    final rawPlatforms = json['platforms'];
+    final platforms = rawPlatforms is List
+        ? rawPlatforms
+              .map((entry) => '$entry'.trim().toLowerCase())
+              .where((entry) => entry.isNotEmpty)
+              .toSet()
+              .toList(growable: false)
+        : null;
+    final versionConstraint = '${json['version_constraint'] ?? ''}'.trim();
+    return AnnouncementTargets(
+      platforms: platforms == null || platforms.isEmpty ? null : platforms,
+      versionConstraint: versionConstraint.isEmpty ? null : versionConstraint,
+    );
+  }
+
+  final List<String>? platforms;
+  final String? versionConstraint;
+}
+
+class AnnouncementEmbed {
+  const AnnouncementEmbed({required this.type, required this.url});
+
+  factory AnnouncementEmbed.fromJson(Map<String, dynamic> json) {
+    return AnnouncementEmbed(
+      type: '${json['type'] ?? ''}'.trim(),
+      url: '${json['url'] ?? ''}'.trim(),
+    );
+  }
+
+  final String type;
+  final String url;
+}
+
+class AnnouncementAction {
+  const AnnouncementAction({
+    required this.type,
+    required this.label,
+    required this.url,
+  });
+
+  factory AnnouncementAction.fromJson(Map<String, dynamic> json) {
+    return AnnouncementAction(
+      type: '${json['type'] ?? ''}'.trim(),
+      label: '${json['label'] ?? ''}'.trim(),
+      url: '${json['url'] ?? ''}'.trim(),
+    );
+  }
+
+  final String type;
+  final String label;
+  final String url;
+}
+
+class AppAnnouncement {
+  const AppAnnouncement({
+    required this.id,
+    required this.title,
+    required this.content,
+    required this.contentType,
+    required this.createdAt,
+    required this.behavior,
+    this.author,
+    this.expireAt,
+    this.targets,
+    this.soundUrl,
+    this.embed,
+    this.actions = const <AnnouncementAction>[],
+  });
+
+  factory AppAnnouncement.fromJson(Map<String, dynamic> json) {
+    final rawBehavior = _stringKeyedMap(json['behavior']);
+    final rawTargets = _stringKeyedMap(json['targets']);
+    final rawEmbed = _stringKeyedMap(json['embed']);
+    final rawActions = json['actions'];
+    return AppAnnouncement(
+      id: '${json['id'] ?? ''}'.trim(),
+      title: '${json['title'] ?? ''}'.trim(),
+      content: '${json['content'] ?? ''}',
+      contentType: '${json['content_type'] ?? 'markdown'}'.trim(),
+      author: _normalizedNullableText(json['author']),
+      createdAt: _parseUnixSeconds(json['created_at']),
+      expireAt: _parseNullableUnixSeconds(json['expire_at']),
+      behavior: rawBehavior == null
+          ? const AnnouncementBehavior()
+          : AnnouncementBehavior.fromJson(rawBehavior),
+      targets: rawTargets == null
+          ? null
+          : AnnouncementTargets.fromJson(rawTargets),
+      soundUrl: _normalizedNullableText(json['sound_url']),
+      embed: rawEmbed == null ? null : AnnouncementEmbed.fromJson(rawEmbed),
+      actions: rawActions is List
+          ? rawActions
+                .whereType<Map>()
+                .map(
+                  (entry) => AnnouncementAction.fromJson(
+                    entry.map(
+                      (key, value) => MapEntry(key.toString(), value),
+                    ),
+                  ),
+                )
+                .where(
+                  (entry) =>
+                      entry.type.isNotEmpty &&
+                      entry.label.isNotEmpty &&
+                      entry.url.isNotEmpty,
+                )
+                .toList(growable: false)
+          : const <AnnouncementAction>[],
+    );
+  }
+
+  final String id;
+  final String title;
+  final String content;
+  final String contentType;
+  final String? author;
+  final int createdAt;
+  final int? expireAt;
+  final AnnouncementBehavior behavior;
+  final AnnouncementTargets? targets;
+  final String? soundUrl;
+  final AnnouncementEmbed? embed;
+  final List<AnnouncementAction> actions;
+
+  DateTime get createdAtDateTime => DateTime.fromMillisecondsSinceEpoch(
+    createdAt * 1000,
+  );
+
+  DateTime? get expireAtDateTime => expireAt == null
+      ? null
+      : DateTime.fromMillisecondsSinceEpoch(expireAt! * 1000);
+}
+
+class AnnouncementLocalState {
+  const AnnouncementLocalState({
+    this.viewedRedDotIds = const <String>{},
+    this.shownPopupIds = const <String>{},
+    this.dismissedPopupIds = const <String>{},
+  });
+
+  factory AnnouncementLocalState.empty() {
+    return const AnnouncementLocalState();
+  }
+
+  factory AnnouncementLocalState.fromJson(Map<String, dynamic> json) {
+    return AnnouncementLocalState(
+      viewedRedDotIds: _readIdSet(json['viewed_red_dot_ids']),
+      shownPopupIds: _readIdSet(json['shown_popup_ids']),
+      dismissedPopupIds: _readIdSet(json['dismissed_popup_ids']),
+    );
+  }
+
+  final Set<String> viewedRedDotIds;
+  final Set<String> shownPopupIds;
+  final Set<String> dismissedPopupIds;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'viewed_red_dot_ids': _sortedList(viewedRedDotIds),
+      'shown_popup_ids': _sortedList(shownPopupIds),
+      'dismissed_popup_ids': _sortedList(dismissedPopupIds),
+    };
+  }
+
+  AnnouncementLocalState copyWith({
+    Set<String>? viewedRedDotIds,
+    Set<String>? shownPopupIds,
+    Set<String>? dismissedPopupIds,
+  }) {
+    return AnnouncementLocalState(
+      viewedRedDotIds: viewedRedDotIds ?? this.viewedRedDotIds,
+      shownPopupIds: shownPopupIds ?? this.shownPopupIds,
+      dismissedPopupIds: dismissedPopupIds ?? this.dismissedPopupIds,
+    );
+  }
+}
+
+AnnouncementRepeatBehavior _behaviorFromString(Object? value) {
+  return '${value ?? 'once'}'.trim().toLowerCase() == 'forever'
+      ? AnnouncementRepeatBehavior.forever
+      : AnnouncementRepeatBehavior.once;
+}
+
+Map<String, dynamic>? _stringKeyedMap(Object? value) {
+  if (value is! Map) {
+    return null;
+  }
+  return value.map((key, entry) => MapEntry(key.toString(), entry));
+}
+
+String? _normalizedNullableText(Object? value) {
+  final normalized = '${value ?? ''}'.trim();
+  return normalized.isEmpty ? null : normalized;
+}
+
+int _parseUnixSeconds(Object? value) {
+  if (value is int) {
+    return value;
+  }
+  if (value is num) {
+    return value.toInt();
+  }
+  return int.tryParse('${value ?? ''}'.trim()) ?? 0;
+}
+
+int? _parseNullableUnixSeconds(Object? value) {
+  if (value == null) {
+    return null;
+  }
+  return _parseUnixSeconds(value);
+}
+
+Set<String> _readIdSet(Object? value) {
+  if (value is! List) {
+    return const <String>{};
+  }
+  return HashSet<String>.from(
+    value.map((entry) => '$entry'.trim()).where((entry) => entry.isNotEmpty),
+  );
+}
+
+List<String> _sortedList(Set<String> ids) {
+  final values = ids.toList(growable: false);
+  values.sort();
+  return values;
+}

--- a/lib/core/announcement_service.dart
+++ b/lib/core/announcement_service.dart
@@ -1,0 +1,268 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import 'announcement_models.dart';
+import 'api_config.dart';
+import 'api_user_agent.dart';
+import 'app_build_info.dart';
+
+class AnnouncementService {
+  AnnouncementService({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  Future<List<AppAnnouncement>> fetchAnnouncements({
+    required AppBuildInfo buildInfo,
+  }) async {
+    final platform = currentPlatform;
+    final version = _normalizedVersion(buildInfo.version);
+    final queryParameters = <String, String>{'platform': platform};
+    if (version != null) {
+      queryParameters['version'] = version;
+    }
+
+    final uri = Uri.parse(
+      '${ApiConfig.baseUrl}/api/v1/announcements',
+    ).replace(queryParameters: queryParameters);
+    final response = await _client.get(
+      uri,
+      headers: ApiUserAgent.applyTo(const {
+        'Accept': 'application/json',
+        'Accept-Encoding': 'gzip',
+      }),
+    );
+    if (response.statusCode != 200) {
+      throw Exception(_errorMessage(response, '公告載入失敗。'));
+    }
+
+    final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+    if (decoded is! List) {
+      throw const FormatException('Invalid announcements payload.');
+    }
+
+    return decoded
+        .whereType<Map>()
+        .map(
+          (entry) => AppAnnouncement.fromJson(
+            entry.map((key, value) => MapEntry(key.toString(), value)),
+          ),
+        )
+        .where((announcement) => announcement.id.isNotEmpty)
+        .where((announcement) => matchesCurrentClient(announcement, buildInfo))
+        .toList(growable: false);
+  }
+
+  bool matchesCurrentClient(
+    AppAnnouncement announcement,
+    AppBuildInfo buildInfo,
+  ) {
+    final targets = announcement.targets;
+    if (targets == null) {
+      return true;
+    }
+
+    final platforms = targets.platforms;
+    if (platforms != null && platforms.isNotEmpty) {
+      if (!platforms.contains(currentPlatform)) {
+        return false;
+      }
+    }
+
+    final versionConstraint = targets.versionConstraint;
+    final currentVersion = _normalizedVersion(buildInfo.version);
+    if (versionConstraint != null && currentVersion != null) {
+      return _matchesVersionConstraint(currentVersion, versionConstraint);
+    }
+    if (versionConstraint != null && currentVersion == null) {
+      return false;
+    }
+    return true;
+  }
+
+  bool shouldShowRedDot(
+    AppAnnouncement announcement,
+    AnnouncementLocalState localState,
+  ) {
+    switch (announcement.behavior.redDot) {
+      case AnnouncementRepeatBehavior.forever:
+        return true;
+      case AnnouncementRepeatBehavior.once:
+        return !localState.viewedRedDotIds.contains(announcement.id);
+    }
+  }
+
+  List<AppAnnouncement> pendingPopups(
+    Iterable<AppAnnouncement> announcements,
+    AnnouncementLocalState localState, {
+    Set<String> sessionDeferredIds = const <String>{},
+  }) {
+    final pending = announcements.where((announcement) {
+      if (sessionDeferredIds.contains(announcement.id)) {
+        return false;
+      }
+      switch (announcement.behavior.popup) {
+        case AnnouncementRepeatBehavior.once:
+          return !localState.shownPopupIds.contains(announcement.id);
+        case AnnouncementRepeatBehavior.forever:
+          return !localState.dismissedPopupIds.contains(announcement.id);
+      }
+    }).toList(growable: false);
+    pending.sort((left, right) => right.createdAt.compareTo(left.createdAt));
+    return pending;
+  }
+
+  AnnouncementLocalState markListViewed(
+    AnnouncementLocalState localState,
+    Iterable<AppAnnouncement> announcements,
+  ) {
+    final nextViewed = {...localState.viewedRedDotIds};
+    var changed = false;
+    for (final announcement in announcements) {
+      if (announcement.behavior.redDot != AnnouncementRepeatBehavior.once) {
+        continue;
+      }
+      changed = nextViewed.add(announcement.id) || changed;
+    }
+    if (!changed) {
+      return localState;
+    }
+    return localState.copyWith(viewedRedDotIds: nextViewed);
+  }
+
+  AnnouncementLocalState markPopupShown(
+    AnnouncementLocalState localState,
+    AppAnnouncement announcement,
+  ) {
+    if (announcement.behavior.popup != AnnouncementRepeatBehavior.once) {
+      return localState;
+    }
+    final nextShown = {...localState.shownPopupIds};
+    if (!nextShown.add(announcement.id)) {
+      return localState;
+    }
+    return localState.copyWith(shownPopupIds: nextShown);
+  }
+
+  AnnouncementLocalState dismissPopup(
+    AnnouncementLocalState localState,
+    AppAnnouncement announcement,
+  ) {
+    if (announcement.behavior.popup != AnnouncementRepeatBehavior.forever) {
+      return localState;
+    }
+    final nextDismissed = {...localState.dismissedPopupIds};
+    if (!nextDismissed.add(announcement.id)) {
+      return localState;
+    }
+    return localState.copyWith(dismissedPopupIds: nextDismissed);
+  }
+
+  String get currentPlatform {
+    if (kIsWeb) {
+      return 'web';
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return 'android';
+      case TargetPlatform.iOS:
+        return 'ios';
+      case TargetPlatform.macOS:
+        return 'macos';
+      case TargetPlatform.windows:
+        return 'windows';
+      case TargetPlatform.linux:
+        return 'linux';
+      case TargetPlatform.fuchsia:
+        return 'fuchsia';
+    }
+  }
+}
+
+String _errorMessage(http.Response response, String fallback) {
+  try {
+    final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+    if (decoded is Map && decoded['detail'] != null) {
+      final detail = '${decoded['detail']}'.trim();
+      if (detail.isNotEmpty) {
+        return detail;
+      }
+    }
+  } catch (_) {
+    // Ignore malformed error payloads and keep the fallback.
+  }
+  return fallback;
+}
+
+String? _normalizedVersion(String rawVersion) {
+  final normalized = rawVersion.trim();
+  if (!RegExp(r'^\d+(?:\.\d+)*$').hasMatch(normalized)) {
+    return null;
+  }
+  return normalized;
+}
+
+bool _matchesVersionConstraint(String currentVersion, String constraint) {
+  final currentParts = _parseVersion(currentVersion);
+  for (final rawPart in constraint.split(',')) {
+    final part = rawPart.trim();
+    if (part.isEmpty) {
+      continue;
+    }
+
+    final match = RegExp(
+      r'^(>=|<=|>|<|==|=)?\s*(\d+(?:\.\d+)*)$',
+    ).firstMatch(part);
+    if (match == null) {
+      return false;
+    }
+
+    final operator = match.group(1) ?? '=';
+    final expectedParts = _parseVersion(match.group(2)!);
+    final comparison = _compareVersions(currentParts, expectedParts);
+    switch (operator) {
+      case '>=':
+        if (comparison < 0) {
+          return false;
+        }
+      case '>':
+        if (comparison <= 0) {
+          return false;
+        }
+      case '<=':
+        if (comparison > 0) {
+          return false;
+        }
+      case '<':
+        if (comparison >= 0) {
+          return false;
+        }
+      case '=':
+      case '==':
+        if (comparison != 0) {
+          return false;
+        }
+    }
+  }
+  return true;
+}
+
+List<int> _parseVersion(String value) {
+  return value.split('.').map((part) => int.parse(part)).toList(growable: false);
+}
+
+int _compareVersions(List<int> left, List<int> right) {
+  final length = left.length > right.length ? left.length : right.length;
+  for (var index = 0; index < length; index += 1) {
+    final leftValue = index < left.length ? left[index] : 0;
+    final rightValue = index < right.length ? right[index] : 0;
+    if (leftValue < rightValue) {
+      return -1;
+    }
+    if (leftValue > rightValue) {
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/lib/core/announcement_service.dart
+++ b/lib/core/announcement_service.dart
@@ -86,6 +86,8 @@ class AnnouncementService {
     AnnouncementLocalState localState,
   ) {
     switch (announcement.behavior.redDot) {
+      case AnnouncementRepeatBehavior.none:
+        return false;
       case AnnouncementRepeatBehavior.forever:
         return true;
       case AnnouncementRepeatBehavior.once:
@@ -103,6 +105,8 @@ class AnnouncementService {
         return false;
       }
       switch (announcement.behavior.popup) {
+        case AnnouncementRepeatBehavior.none:
+          return false;
         case AnnouncementRepeatBehavior.once:
           return !localState.shownPopupIds.contains(announcement.id);
         case AnnouncementRepeatBehavior.forever:

--- a/lib/core/app_controller.dart
+++ b/lib/core/app_controller.dart
@@ -4,6 +4,8 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:geolocator/geolocator.dart';
 
 import 'android_home_integration.dart';
+import 'announcement_models.dart';
+import 'announcement_service.dart';
 import 'android_trip_monitor.dart';
 import 'app_analytics.dart';
 import 'app_build_info.dart';
@@ -28,7 +30,8 @@ class AppController extends ChangeNotifier {
     required this.appUpdateService,
     required this.appUpdateInstaller,
     required this.authService,
-  });
+    AnnouncementService? announcementService,
+  }) : announcementService = announcementService ?? AnnouncementService();
 
   static const defaultFavoriteGroupName = '我的最愛';
 
@@ -39,10 +42,14 @@ class AppController extends ChangeNotifier {
   final AppUpdateService appUpdateService;
   final AppUpdateInstaller appUpdateInstaller;
   final AuthService authService;
+  final AnnouncementService announcementService;
 
   AppSettings _settings = AppSettings.defaults();
   AuthSession? _authSession;
   AuthAccount? _authAccount;
+  AnnouncementLocalState _announcementLocalState =
+      AnnouncementLocalState.empty();
+  List<AppAnnouncement> _announcements = const [];
   List<SearchHistoryEntry> _history = const [];
   Map<String, List<FavoriteStop>> _favoriteGroups = const {};
   List<RouteUsageProfile> _routeUsageProfiles = const [];
@@ -55,15 +62,18 @@ class AppController extends ChangeNotifier {
   bool _checkingAppUpdate = false;
   bool _authBusy = false;
   bool _authAccountLoading = false;
+  bool _announcementsLoading = false;
   bool _startupAppUpdateChecked = false;
   bool _startupDatabaseUpdateChecked = false;
   AppUpdateCheckResult? _lastAppUpdateResult;
   Map<BusProvider, int> _pendingDatabaseUpdates = const {};
+  String? _announcementsError;
 
   AppSettings get settings => _settings;
   AuthSession? get authSession => _authSession;
   AuthAccount? get authAccount => _authAccount;
   bool get isAuthenticated => _authSession?.isAuthenticated ?? false;
+  List<AppAnnouncement> get announcements => List.unmodifiable(_announcements);
   List<SearchHistoryEntry> get history => List.unmodifiable(_history);
   Map<String, List<FavoriteStop>> get favoriteGroups =>
       Map.unmodifiable(_favoriteGroups);
@@ -119,10 +129,19 @@ class AppController extends ChangeNotifier {
   bool get checkingAppUpdate => _checkingAppUpdate;
   bool get authBusy => _authBusy;
   bool get authAccountLoading => _authAccountLoading;
+  bool get announcementsLoading => _announcementsLoading;
   AppUpdateCheckResult? get lastAppUpdateResult => _lastAppUpdateResult;
   Map<BusProvider, int> get pendingDatabaseUpdates =>
       Map.unmodifiable(_pendingDatabaseUpdates);
   bool get hasPendingDatabaseUpdates => _pendingDatabaseUpdates.isNotEmpty;
+  String? get announcementsError => _announcementsError;
+  bool get hasUnreadAnnouncements => _announcements.any(
+    (announcement) =>
+        announcementService.shouldShowRedDot(
+          announcement,
+          _announcementLocalState,
+        ),
+  );
 
   bool isDatabaseReady(BusProvider provider) {
     return _databaseReadyByProvider[provider] ?? false;
@@ -144,6 +163,7 @@ class AppController extends ChangeNotifier {
     await authService.initialize();
     _authSession = authService.session;
     _settings = await storage.loadSettings();
+    _announcementLocalState = await storage.loadAnnouncementLocalState();
     _history = await storage.loadHistory();
     _favoriteGroups = await storage.loadFavoriteGroups();
     _routeUsageProfiles = await storage.loadRouteUsageProfiles();
@@ -247,6 +267,95 @@ class AppController extends ChangeNotifier {
       _authBusy = false;
       notifyListeners();
     }
+  }
+
+  Future<void> ensureAnnouncementsLoaded() async {
+    if (_announcementsLoading || _announcements.isNotEmpty || _announcementsError != null) {
+      return;
+    }
+    await refreshAnnouncements(force: true);
+  }
+
+  Future<void> refreshAnnouncements({bool force = false}) async {
+    if (_announcementsLoading) {
+      return;
+    }
+    if (!force && _announcements.isNotEmpty) {
+      return;
+    }
+
+    _announcementsLoading = true;
+    if (force || _announcements.isEmpty) {
+      _announcementsError = null;
+    }
+    notifyListeners();
+    try {
+      _announcements = await announcementService.fetchAnnouncements(
+        buildInfo: buildInfo,
+      );
+      _announcementsError = null;
+    } catch (error) {
+      _announcementsError = '$error';
+    } finally {
+      _announcementsLoading = false;
+      notifyListeners();
+    }
+  }
+
+  AppAnnouncement? findAnnouncementById(String announcementId) {
+    final normalized = announcementId.trim();
+    for (final announcement in _announcements) {
+      if (announcement.id == normalized) {
+        return announcement;
+      }
+    }
+    return null;
+  }
+
+  AppAnnouncement? nextPendingAnnouncementPopup({
+    Set<String> sessionDeferredIds = const <String>{},
+  }) {
+    final pending = announcementService.pendingPopups(
+      _announcements,
+      _announcementLocalState,
+      sessionDeferredIds: sessionDeferredIds,
+    );
+    return pending.isEmpty ? null : pending.first;
+  }
+
+  Future<void> markAnnouncementListViewed() async {
+    final nextState = announcementService.markListViewed(
+      _announcementLocalState,
+      _announcements,
+    );
+    await _updateAnnouncementLocalState(nextState);
+  }
+
+  Future<void> markAnnouncementPopupShown(AppAnnouncement announcement) async {
+    final nextState = announcementService.markPopupShown(
+      _announcementLocalState,
+      announcement,
+    );
+    await _updateAnnouncementLocalState(nextState);
+  }
+
+  Future<void> dismissAnnouncementPopup(AppAnnouncement announcement) async {
+    final nextState = announcementService.dismissPopup(
+      _announcementLocalState,
+      announcement,
+    );
+    await _updateAnnouncementLocalState(nextState);
+  }
+
+  Future<void> _updateAnnouncementLocalState(
+    AnnouncementLocalState nextState,
+  ) async {
+    if (identical(nextState, _announcementLocalState)) {
+      return;
+    }
+    _announcementLocalState = nextState;
+    await storage.saveAnnouncementLocalState(nextState);
+    notifyListeners();
   }
 
   Future<void> refreshDatabaseState() async {

--- a/lib/core/app_link_handler.dart
+++ b/lib/core/app_link_handler.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'app_routes.dart';
+
+Future<bool> openAppLink(BuildContext context, String href) async {
+  final uri = Uri.tryParse(href.trim());
+  if (uri == null) {
+    return false;
+  }
+  return openAppUri(context, uri);
+}
+
+Future<bool> openAppUri(BuildContext context, Uri uri) async {
+  final internalLocation = _internalLocationForUri(uri);
+  if (internalLocation != null) {
+    await Navigator.of(context).pushNamed(internalLocation);
+    return true;
+  }
+
+  return launchUrl(uri, mode: LaunchMode.externalApplication);
+}
+
+String? _internalLocationForUri(Uri uri) {
+  Uri normalized = uri;
+  if (uri.hasScheme) {
+    final scheme = uri.scheme.trim().toLowerCase();
+    if (scheme != 'http' && scheme != 'https') {
+      return null;
+    }
+    if (!AppRoutes.isSupportedInternalHost(uri.host)) {
+      return null;
+    }
+    normalized = Uri(
+      path: uri.path.isEmpty ? AppRoutes.home : uri.path,
+      queryParameters: uri.queryParameters.isEmpty ? null : uri.queryParameters,
+      fragment: uri.fragment.isEmpty ? null : uri.fragment,
+    );
+  } else if (uri.path.isNotEmpty && !uri.path.startsWith('/')) {
+    normalized = Uri(
+      path: '/${uri.path}',
+      queryParameters: uri.queryParameters.isEmpty ? null : uri.queryParameters,
+      fragment: uri.fragment.isEmpty ? null : uri.fragment,
+    );
+  }
+
+  final intent = parseAppRoute(normalized.toString());
+  switch (intent.kind) {
+    case AppRouteKind.home:
+    case AppRouteKind.search:
+    case AppRouteKind.favorites:
+    case AppRouteKind.nearby:
+    case AppRouteKind.settings:
+    case AppRouteKind.account:
+    case AppRouteKind.databaseSettings:
+    case AppRouteKind.termsOfService:
+    case AppRouteKind.privacyPolicy:
+    case AppRouteKind.announcements:
+    case AppRouteKind.announcementDetail:
+    case AppRouteKind.routeDetail:
+      return intent.location;
+    case AppRouteKind.stopDetail:
+    case AppRouteKind.unknown:
+      return null;
+  }
+}

--- a/lib/core/app_routes.dart
+++ b/lib/core/app_routes.dart
@@ -1,0 +1,266 @@
+import 'models.dart';
+
+class AppRoutes {
+  AppRoutes._();
+
+  static const home = '/';
+  static const search = '/search';
+  static const favorites = '/favorites';
+  static const nearby = '/nearby';
+  static const settings = '/settings';
+  static const account = '/account';
+  static const databaseSettings = '/database-settings';
+  static const termsOfService = '/terms-of-service';
+  static const privacyPolicy = '/privacy-policy';
+  static const announcements = '/announcement';
+
+  static const _supportedInternalHosts = <String>{'busapp.avianjay.sbs'};
+  static const _legacyAliases = <String, String>{
+    'search': search,
+    'favorites': favorites,
+    'favorite_groups': favorites,
+    'nearby': nearby,
+    'settings': settings,
+    'account': account,
+    'database_settings': databaseSettings,
+    'terms-of-service': termsOfService,
+    'privacy-policy': privacyPolicy,
+    'announcement': announcements,
+    'announcements': announcements,
+  };
+
+  static bool isSupportedInternalHost(String host) {
+    return _supportedInternalHosts.contains(host.trim().toLowerCase());
+  }
+
+  static String normalize(String? rawLocation) {
+    final trimmed = (rawLocation ?? '').trim();
+    if (trimmed.isEmpty) {
+      return home;
+    }
+
+    var normalized = trimmed;
+    if (normalized.startsWith('/#')) {
+      normalized = normalized.substring(2);
+    }
+    if (normalized.startsWith('#')) {
+      normalized = normalized.substring(1);
+    }
+
+    if (!normalized.startsWith('/')) {
+      final alias = _legacyAliases[normalized];
+      if (alias != null) {
+        return alias;
+      }
+      normalized = '/$normalized';
+    }
+
+    final uri = Uri.tryParse(normalized);
+    if (uri == null) {
+      return home;
+    }
+
+    final alias = _legacyAliases[uri.path.replaceFirst(RegExp(r'^/+'), '')];
+    final path = alias ?? (uri.path.isEmpty ? home : uri.path);
+    return uri.replace(path: path).toString();
+  }
+
+  static String routeDetailPath({
+    required BusProvider provider,
+    required int routeKey,
+    int? pathId,
+    int? stopId,
+    int? destinationPathId,
+    int? destinationStopId,
+  }) {
+    final queryParameters = <String, String>{
+      if (pathId != null) 'pathId': '$pathId',
+      if (stopId != null) 'stopId': '$stopId',
+      if (destinationPathId != null)
+        'destinationPathId': '$destinationPathId',
+      if (destinationStopId != null)
+        'destinationStopId': '$destinationStopId',
+    };
+    return Uri(
+      pathSegments: ['route', provider.name, '$routeKey'],
+      queryParameters: queryParameters.isEmpty ? null : queryParameters,
+    ).toString();
+  }
+
+  static String announcementDetailPath(String announcementId) {
+    return Uri(pathSegments: ['announcement', announcementId]).toString();
+  }
+}
+
+enum AppRouteKind {
+  home,
+  search,
+  favorites,
+  nearby,
+  settings,
+  account,
+  databaseSettings,
+  termsOfService,
+  privacyPolicy,
+  announcements,
+  announcementDetail,
+  routeDetail,
+  stopDetail,
+  unknown,
+}
+
+class AppRouteIntent {
+  const AppRouteIntent({
+    required this.kind,
+    required this.location,
+    this.provider,
+    this.routeKey,
+    this.pathId,
+    this.stopId,
+    this.destinationPathId,
+    this.destinationStopId,
+    this.announcementId,
+    this.stopIdentifier,
+  });
+
+  final AppRouteKind kind;
+  final String location;
+  final BusProvider? provider;
+  final int? routeKey;
+  final int? pathId;
+  final int? stopId;
+  final int? destinationPathId;
+  final int? destinationStopId;
+  final String? announcementId;
+  final String? stopIdentifier;
+}
+
+AppRouteIntent parseAppRoute(String? rawLocation) {
+  final location = AppRoutes.normalize(rawLocation);
+  final uri = Uri.tryParse(location);
+  if (uri == null) {
+    return const AppRouteIntent(
+      kind: AppRouteKind.unknown,
+      location: AppRoutes.home,
+    );
+  }
+
+  if (uri.path == AppRoutes.home) {
+    return const AppRouteIntent(kind: AppRouteKind.home, location: AppRoutes.home);
+  }
+  if (uri.path == AppRoutes.search) {
+    return const AppRouteIntent(
+      kind: AppRouteKind.search,
+      location: AppRoutes.search,
+    );
+  }
+  if (uri.path == AppRoutes.favorites) {
+    return const AppRouteIntent(
+      kind: AppRouteKind.favorites,
+      location: AppRoutes.favorites,
+    );
+  }
+  if (uri.path == AppRoutes.nearby) {
+    return const AppRouteIntent(
+      kind: AppRouteKind.nearby,
+      location: AppRoutes.nearby,
+    );
+  }
+  if (uri.path == AppRoutes.settings) {
+    return const AppRouteIntent(
+      kind: AppRouteKind.settings,
+      location: AppRoutes.settings,
+    );
+  }
+  if (uri.path == AppRoutes.account) {
+    return const AppRouteIntent(
+      kind: AppRouteKind.account,
+      location: AppRoutes.account,
+    );
+  }
+  if (uri.path == AppRoutes.databaseSettings) {
+    return const AppRouteIntent(
+      kind: AppRouteKind.databaseSettings,
+      location: AppRoutes.databaseSettings,
+    );
+  }
+  if (uri.path == AppRoutes.termsOfService) {
+    return const AppRouteIntent(
+      kind: AppRouteKind.termsOfService,
+      location: AppRoutes.termsOfService,
+    );
+  }
+  if (uri.path == AppRoutes.privacyPolicy) {
+    return const AppRouteIntent(
+      kind: AppRouteKind.privacyPolicy,
+      location: AppRoutes.privacyPolicy,
+    );
+  }
+  if (uri.path == AppRoutes.announcements) {
+    return const AppRouteIntent(
+      kind: AppRouteKind.announcements,
+      location: AppRoutes.announcements,
+    );
+  }
+
+  final segments = uri.pathSegments;
+  if (segments.isEmpty) {
+    return const AppRouteIntent(kind: AppRouteKind.home, location: AppRoutes.home);
+  }
+
+  if (segments.first == 'announcement' && segments.length >= 2) {
+    return AppRouteIntent(
+      kind: AppRouteKind.announcementDetail,
+      location: location,
+      announcementId: Uri.decodeComponent(segments[1]),
+    );
+  }
+
+  if (segments.first == 'route' && segments.length >= 3) {
+    final provider = _providerFromName(segments[1]);
+    final routeKey = int.tryParse(segments[2]);
+    if (provider != null && routeKey != null) {
+      return AppRouteIntent(
+        kind: AppRouteKind.routeDetail,
+        location: location,
+        provider: provider,
+        routeKey: routeKey,
+        pathId: _tryParseInt(uri.queryParameters['pathId']),
+        stopId: _tryParseInt(uri.queryParameters['stopId']),
+        destinationPathId: _tryParseInt(
+          uri.queryParameters['destinationPathId'],
+        ),
+        destinationStopId: _tryParseInt(
+          uri.queryParameters['destinationStopId'],
+        ),
+      );
+    }
+  }
+
+  if (segments.first == 'stop' && segments.length >= 2) {
+    return AppRouteIntent(
+      kind: AppRouteKind.stopDetail,
+      location: location,
+      stopIdentifier: Uri.decodeComponent(segments[1]),
+    );
+  }
+
+  return AppRouteIntent(kind: AppRouteKind.unknown, location: location);
+}
+
+int? _tryParseInt(String? value) {
+  if (value == null) {
+    return null;
+  }
+  return int.tryParse(value.trim());
+}
+
+BusProvider? _providerFromName(String rawValue) {
+  final normalized = rawValue.trim().toLowerCase();
+  for (final provider in BusProvider.values) {
+    if (provider.name == normalized) {
+      return provider;
+    }
+  }
+  return null;
+}

--- a/lib/core/legal_document_service.dart
+++ b/lib/core/legal_document_service.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'api_config.dart';
+import 'api_user_agent.dart';
+
+class LegalDocumentService {
+  LegalDocumentService({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  Future<String> fetchTermsOfService() {
+    return _fetchMarkdownDocument('/api/v1/terms-of-service');
+  }
+
+  Future<String> fetchPrivacyPolicy() {
+    return _fetchMarkdownDocument('/api/v1/privacy-policy');
+  }
+
+  Future<String> _fetchMarkdownDocument(String path) async {
+    final uri = Uri.parse('${ApiConfig.baseUrl}$path');
+    final response = await _client.get(
+      uri,
+      headers: ApiUserAgent.applyTo(const {
+        'Accept': 'application/json',
+        'Accept-Encoding': 'gzip',
+      }),
+    );
+    if (response.statusCode != 200) {
+      throw Exception(_errorMessage(response, '文件載入失敗。'));
+    }
+
+    final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('Invalid legal document payload.');
+    }
+
+    final content = '${decoded['content'] ?? ''}'.trim();
+    if (content.isEmpty) {
+      throw const FormatException('Missing legal document content.');
+    }
+    return content;
+  }
+}
+
+String _errorMessage(http.Response response, String fallback) {
+  try {
+    final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+    if (decoded is Map && decoded['detail'] != null) {
+      final detail = '${decoded['detail']}'.trim();
+      if (detail.isNotEmpty) {
+        return detail;
+      }
+    }
+  } catch (_) {
+    // Ignore malformed error payloads and fall back to the generic message.
+  }
+  return fallback;
+}

--- a/lib/core/relative_time_formatter.dart
+++ b/lib/core/relative_time_formatter.dart
@@ -1,0 +1,20 @@
+String formatRelativeTimestamp(DateTime value) {
+  final elapsed = DateTime.now().difference(value.toLocal());
+  final seconds = elapsed.inSeconds < 0 ? 0 : elapsed.inSeconds;
+  if (seconds < 60) {
+    return '$seconds 秒前';
+  }
+
+  final minutes = elapsed.inMinutes;
+  if (minutes < 60) {
+    return '$minutes 分鐘前';
+  }
+
+  final hours = elapsed.inHours;
+  if (hours < 24) {
+    return '$hours 小時前';
+  }
+
+  final days = elapsed.inDays;
+  return '$days 天前';
+}

--- a/lib/core/storage_service.dart
+++ b/lib/core/storage_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'announcement_models.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'models.dart';
@@ -11,6 +12,7 @@ class StorageService {
   static const _historyKey = 'search_history';
   static const _favoritesKey = 'favorite_groups';
   static const _routeUsageProfilesKey = 'route_usage_profiles';
+  static const _announcementLocalStateKey = 'announcement_local_state';
 
   Future<void> migrateLegacyApiDataIfNeeded() async {
     final prefs = await SharedPreferences.getInstance();
@@ -148,6 +150,31 @@ class StorageService {
     await prefs.setString(
       _routeUsageProfilesKey,
       jsonEncode(profiles.map((entry) => entry.toJson()).toList()),
+    );
+  }
+
+  Future<AnnouncementLocalState> loadAnnouncementLocalState() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_announcementLocalStateKey);
+    if (raw == null || raw.isEmpty) {
+      return AnnouncementLocalState.empty();
+    }
+
+    try {
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      return AnnouncementLocalState.fromJson(decoded);
+    } catch (_) {
+      return AnnouncementLocalState.empty();
+    }
+  }
+
+  Future<void> saveAnnouncementLocalState(
+    AnnouncementLocalState state,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _announcementLocalStateKey,
+      jsonEncode(state.toJson()),
     );
   }
 }

--- a/lib/screens/announcement_detail_page.dart
+++ b/lib/screens/announcement_detail_page.dart
@@ -1,0 +1,121 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../app/bus_app.dart';
+import '../widgets/announcement_content.dart';
+
+class AnnouncementDetailPage extends StatefulWidget {
+  const AnnouncementDetailPage({required this.announcementId, super.key});
+
+  final String announcementId;
+
+  @override
+  State<AnnouncementDetailPage> createState() => _AnnouncementDetailPageState();
+}
+
+class _AnnouncementDetailPageState extends State<AnnouncementDetailPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(AppControllerScope.read(context).ensureAnnouncementsLoaded());
+    });
+  }
+
+  Future<void> _refresh() {
+    return AppControllerScope.read(context).refreshAnnouncements(force: true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = AppControllerScope.of(context);
+    final theme = Theme.of(context);
+
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        final announcement = controller.findAnnouncementById(widget.announcementId);
+        final loading = controller.announcementsLoading;
+        final error = controller.announcementsError;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(announcement?.title ?? '公告'),
+            actions: [
+              IconButton(
+                tooltip: '重新整理',
+                onPressed: loading ? null : _refresh,
+                icon: loading
+                    ? const SizedBox.square(
+                        dimension: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.refresh_rounded),
+              ),
+            ],
+          ),
+          body: announcement == null && loading
+              ? const Center(child: CircularProgressIndicator())
+              : RefreshIndicator(
+                  onRefresh: _refresh,
+                  child: ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                    children: [
+                      Center(
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 920),
+                          child: Card(
+                            child: Padding(
+                              padding: const EdgeInsets.all(20),
+                              child: announcement == null
+                                  ? Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          '找不到這則公告。',
+                                          style: theme.textTheme.titleMedium,
+                                        ),
+                                        if (error != null) ...[
+                                          const SizedBox(height: 8),
+                                          Text(error),
+                                        ],
+                                        const SizedBox(height: 12),
+                                        FilledButton.tonalIcon(
+                                          onPressed: _refresh,
+                                          icon: const Icon(Icons.refresh_rounded),
+                                          label: const Text('重新同步公告'),
+                                        ),
+                                      ],
+                                    )
+                                  : Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        if (error != null) ...[
+                                          Card(
+                                            color: theme.colorScheme.errorContainer,
+                                            child: Padding(
+                                              padding: const EdgeInsets.all(16),
+                                              child: Text(error),
+                                            ),
+                                          ),
+                                          const SizedBox(height: 16),
+                                        ],
+                                        AnnouncementContent(
+                                          announcement: announcement,
+                                        ),
+                                      ],
+                                    ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/announcements_page.dart
+++ b/lib/screens/announcements_page.dart
@@ -3,8 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import '../app/bus_app.dart';
-import '../core/announcement_models.dart';
+// import '../core/announcement_models.dart';
 import '../core/app_routes.dart';
+import '../core/relative_time_formatter.dart';
 
 class AnnouncementsPage extends StatefulWidget {
   const AnnouncementsPage({super.key});
@@ -83,22 +84,25 @@ class _AnnouncementsPageState extends State<AnnouncementsPage> {
                         Center(
                           child: ConstrainedBox(
                             constraints: const BoxConstraints(maxWidth: 920),
-                            child: Padding(
-                              padding: const EdgeInsets.only(bottom: 12),
-                              child: Card(
-                                color: theme.colorScheme.errorContainer,
-                                child: Padding(
-                                  padding: const EdgeInsets.all(18),
-                                  child: Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        '公告同步失敗',
-                                        style: theme.textTheme.titleMedium,
-                                      ),
-                                      const SizedBox(height: 8),
-                                      Text(error),
-                                    ],
+                            child: SizedBox(
+                              width: double.infinity,
+                              child: Padding(
+                                padding: const EdgeInsets.only(bottom: 12),
+                                child: Card(
+                                  color: theme.colorScheme.errorContainer,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(18),
+                                    child: Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          '公告同步失敗',
+                                          style: theme.textTheme.titleMedium,
+                                        ),
+                                        const SizedBox(height: 8),
+                                        Text(error),
+                                      ],
+                                    ),
                                   ),
                                 ),
                               ),
@@ -126,63 +130,66 @@ class _AnnouncementsPageState extends State<AnnouncementsPage> {
                           Center(
                             child: ConstrainedBox(
                               constraints: const BoxConstraints(maxWidth: 920),
-                              child: Card(
-                                child: InkWell(
-                                  borderRadius: BorderRadius.circular(24),
-                                  onTap: () {
-                                    Navigator.of(context).pushNamed(
-                                      AppRoutes.announcementDetailPath(
-                                        announcement.id,
-                                      ),
-                                    );
-                                  },
-                                  child: Padding(
-                                    padding: const EdgeInsets.all(18),
-                                    child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      children: [
-                                        Text(
-                                          announcement.title,
-                                          style: theme.textTheme.titleLarge,
+                              child: SizedBox(
+                                width: double.infinity,
+                                child: Card(
+                                  child: InkWell(
+                                    borderRadius: BorderRadius.circular(24),
+                                    onTap: () {
+                                      Navigator.of(context).pushNamed(
+                                        AppRoutes.announcementDetailPath(
+                                          announcement.id,
                                         ),
-                                        const SizedBox(height: 8),
-                                        Text(_excerpt(announcement.content)),
-                                        const SizedBox(height: 12),
-                                        Wrap(
-                                          spacing: 8,
-                                          runSpacing: 8,
-                                          children: [
-                                            Chip(
-                                              avatar: const Icon(
-                                                Icons.schedule_outlined,
-                                                size: 18,
-                                              ),
-                                              label: Text(
-                                                _formatTimestamp(
-                                                  announcement.createdAtDateTime,
-                                                ),
-                                              ),
-                                            ),
-                                            if (announcement.author case final author?)
+                                      );
+                                    },
+                                    child: Padding(
+                                      padding: const EdgeInsets.all(18),
+                                      child: Column(
+                                        crossAxisAlignment: CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            announcement.title,
+                                            style: theme.textTheme.titleLarge,
+                                          ),
+                                          const SizedBox(height: 8),
+                                          Text(_excerpt(announcement.content)),
+                                          const SizedBox(height: 12),
+                                          Wrap(
+                                            spacing: 8,
+                                            runSpacing: 8,
+                                            children: [
                                               Chip(
                                                 avatar: const Icon(
-                                                  Icons.person_outline_rounded,
+                                                  Icons.schedule_outlined,
                                                   size: 18,
                                                 ),
-                                                label: Text(author),
-                                              ),
-                                            if (announcement.behavior.popup ==
-                                                AnnouncementRepeatBehavior.forever)
-                                              const Chip(
-                                                avatar: Icon(
-                                                  Icons.notification_important_outlined,
-                                                  size: 18,
+                                                label: Text(
+                                                  formatRelativeTimestamp(
+                                                    announcement.createdAtDateTime,
+                                                  ),
                                                 ),
-                                                label: Text('持續彈出'),
                                               ),
-                                          ],
-                                        ),
-                                      ],
+                                              if (announcement.author case final author?)
+                                                Chip(
+                                                  avatar: const Icon(
+                                                    Icons.person_outline_rounded,
+                                                    size: 18,
+                                                  ),
+                                                  label: Text(author),
+                                                ),
+                                              // if (announcement.behavior.popup ==
+                                              //     AnnouncementRepeatBehavior.forever)
+                                              //   const Chip(
+                                              //     avatar: Icon(
+                                              //       Icons.notification_important_outlined,
+                                              //       size: 18,
+                                              //     ),
+                                              //     label: Text('持續彈出'),
+                                              //   ),
+                                            ],
+                                          ),
+                                        ],
+                                      ),
                                     ),
                                   ),
                                 ),
@@ -198,14 +205,4 @@ class _AnnouncementsPageState extends State<AnnouncementsPage> {
       },
     );
   }
-}
-
-String _formatTimestamp(DateTime value) {
-  final local = value.toLocal();
-  final year = local.year.toString().padLeft(4, '0');
-  final month = local.month.toString().padLeft(2, '0');
-  final day = local.day.toString().padLeft(2, '0');
-  final hour = local.hour.toString().padLeft(2, '0');
-  final minute = local.minute.toString().padLeft(2, '0');
-  return '$year/$month/$day $hour:$minute';
 }

--- a/lib/screens/announcements_page.dart
+++ b/lib/screens/announcements_page.dart
@@ -1,0 +1,211 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../app/bus_app.dart';
+import '../core/announcement_models.dart';
+import '../core/app_routes.dart';
+
+class AnnouncementsPage extends StatefulWidget {
+  const AnnouncementsPage({super.key});
+
+  @override
+  State<AnnouncementsPage> createState() => _AnnouncementsPageState();
+}
+
+class _AnnouncementsPageState extends State<AnnouncementsPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_loadAnnouncements());
+    });
+  }
+
+  Future<void> _loadAnnouncements({bool force = false}) async {
+    final controller = AppControllerScope.read(context);
+    if (force) {
+      await controller.refreshAnnouncements(force: true);
+    } else {
+      await controller.ensureAnnouncementsLoaded();
+    }
+    await controller.markAnnouncementListViewed();
+  }
+
+  String _excerpt(String markdown) {
+    final normalized = markdown
+        .replaceAll(RegExp(r'[#>*_`\[\]\(\)!-]'), ' ')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+    if (normalized.length <= 92) {
+      return normalized;
+    }
+    return '${normalized.substring(0, 92)}…';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = AppControllerScope.of(context);
+    final theme = Theme.of(context);
+
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        final announcements = controller.announcements;
+        final error = controller.announcementsError;
+        final loading = controller.announcementsLoading;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('公告'),
+            actions: [
+              IconButton(
+                tooltip: '重新整理',
+                onPressed: loading ? null : () => _loadAnnouncements(force: true),
+                icon: loading
+                    ? const SizedBox.square(
+                        dimension: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.refresh_rounded),
+              ),
+            ],
+          ),
+          body: loading && announcements.isEmpty
+              ? const Center(child: CircularProgressIndicator())
+              : RefreshIndicator(
+                  onRefresh: () => _loadAnnouncements(force: true),
+                  child: ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                    children: [
+                      if (error != null)
+                        Center(
+                          child: ConstrainedBox(
+                            constraints: const BoxConstraints(maxWidth: 920),
+                            child: Padding(
+                              padding: const EdgeInsets.only(bottom: 12),
+                              child: Card(
+                                color: theme.colorScheme.errorContainer,
+                                child: Padding(
+                                  padding: const EdgeInsets.all(18),
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        '公告同步失敗',
+                                        style: theme.textTheme.titleMedium,
+                                      ),
+                                      const SizedBox(height: 8),
+                                      Text(error),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      if (announcements.isEmpty)
+                        Center(
+                          child: Padding(
+                            padding: const EdgeInsets.all(24),
+                            child: Column(
+                              children: [
+                                const Icon(Icons.campaign_outlined, size: 40),
+                                const SizedBox(height: 12),
+                                Text(
+                                  '目前沒有公告。',
+                                  style: theme.textTheme.titleMedium,
+                                ),
+                              ],
+                            ),
+                          ),
+                        )
+                      else
+                        for (final announcement in announcements) ...[
+                          Center(
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(maxWidth: 920),
+                              child: Card(
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(24),
+                                  onTap: () {
+                                    Navigator.of(context).pushNamed(
+                                      AppRoutes.announcementDetailPath(
+                                        announcement.id,
+                                      ),
+                                    );
+                                  },
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(18),
+                                    child: Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          announcement.title,
+                                          style: theme.textTheme.titleLarge,
+                                        ),
+                                        const SizedBox(height: 8),
+                                        Text(_excerpt(announcement.content)),
+                                        const SizedBox(height: 12),
+                                        Wrap(
+                                          spacing: 8,
+                                          runSpacing: 8,
+                                          children: [
+                                            Chip(
+                                              avatar: const Icon(
+                                                Icons.schedule_outlined,
+                                                size: 18,
+                                              ),
+                                              label: Text(
+                                                _formatTimestamp(
+                                                  announcement.createdAtDateTime,
+                                                ),
+                                              ),
+                                            ),
+                                            if (announcement.author case final author?)
+                                              Chip(
+                                                avatar: const Icon(
+                                                  Icons.person_outline_rounded,
+                                                  size: 18,
+                                                ),
+                                                label: Text(author),
+                                              ),
+                                            if (announcement.behavior.popup ==
+                                                AnnouncementRepeatBehavior.forever)
+                                              const Chip(
+                                                avatar: Icon(
+                                                  Icons.notification_important_outlined,
+                                                  size: 18,
+                                                ),
+                                                label: Text('持續彈出'),
+                                              ),
+                                          ],
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                        ],
+                    ],
+                  ),
+                ),
+        );
+      },
+    );
+  }
+}
+
+String _formatTimestamp(DateTime value) {
+  final local = value.toLocal();
+  final year = local.year.toString().padLeft(4, '0');
+  final month = local.month.toString().padLeft(2, '0');
+  final day = local.day.toString().padLeft(2, '0');
+  final hour = local.hour.toString().padLeft(2, '0');
+  final minute = local.minute.toString().padLeft(2, '0');
+  return '$year/$month/$day $hour:$minute';
+}

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -7,8 +7,8 @@ import '../core/app_controller.dart';
 import '../core/models.dart';
 import '../widgets/eta_badge.dart';
 import 'favorite_groups_screen.dart';
-import 'route_detail_screen.dart';
 import '../widgets/background_image_wrapper.dart';
+import 'route_detail_navigation.dart';
 
 class FavoritesScreen extends StatefulWidget {
   const FavoritesScreen({this.initialGroupName, super.key});
@@ -708,22 +708,17 @@ class _FavoritesScreenState extends State<FavoritesScreen>
                 if (!context.mounted) {
                   return;
                 }
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    settings: const RouteSettings(name: 'route_detail'),
-                    builder: (_) => RouteDetailScreen(
-                      routeKey: item.reference.routeKey,
-                      provider: item.reference.provider,
-                      routeIdHint: item.reference.routeId ?? item.route.routeId,
-                      routeNameHint: item.route.routeName,
-                      initialPathId: item.reference.pathId,
-                      initialStopId: item.reference.stopId,
-                      initialDestinationPathId:
-                          item.reference.destinationPathId,
-                      initialDestinationStopId:
-                          item.reference.destinationStopId,
-                    ),
-                  ),
+                await openRouteDetailPage(
+                  context,
+                  routeKey: item.reference.routeKey,
+                  provider: item.reference.provider,
+                  routeIdHint: item.reference.routeId ?? item.route.routeId,
+                  routeNameHint: item.route.routeName,
+                  initialPathId: item.reference.pathId,
+                  initialStopId: item.reference.stopId,
+                  initialDestinationPathId: item.reference.destinationPathId,
+                  initialDestinationStopId:
+                      item.reference.destinationStopId,
                 );
               },
             ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 
 import '../app/bus_app.dart';
+import '../core/app_routes.dart';
 import '../core/app_controller.dart';
 import '../core/models.dart';
 import '../core/pwa_install_service.dart';
@@ -15,7 +16,7 @@ import 'adaptive_settings_presenter.dart';
 import 'database_settings_screen.dart';
 import 'favorites_screen.dart';
 import 'nearby_screen.dart';
-import 'route_detail_screen.dart';
+import 'route_detail_navigation.dart';
 import 'search_screen.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -209,6 +210,22 @@ class HomeScreen extends StatelessWidget {
                       ),
                     ),
             ),
+          IconButton(
+            tooltip: '公告',
+            onPressed: () {
+              Navigator.of(context).pushNamed(AppRoutes.announcements);
+            },
+            icon: controller.announcementsLoading &&
+                    controller.announcements.isEmpty
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Badge(
+                    isLabelVisible: controller.hasUnreadAnnouncements,
+                    child: const Icon(Icons.campaign_outlined),
+                  ),
+          ),
           IconButton(
             onPressed: () => openAdaptiveSettingsScreen(context),
             icon: const Icon(Icons.settings_outlined),
@@ -512,16 +529,12 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
     if (!mounted) {
       return;
     }
-    await Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        settings: const RouteSettings(name: 'route_detail'),
-        builder: (_) => RouteDetailScreen(
-          routeKey: suggestion.profile.routeKey,
-          provider: suggestion.profile.provider,
-          initialPathId: pathId,
-          initialStopId: stopId,
-        ),
-      ),
+    await openRouteDetailPage(
+      context,
+      routeKey: suggestion.profile.routeKey,
+      provider: suggestion.profile.provider,
+      initialPathId: pathId,
+      initialStopId: stopId,
     );
   }
 
@@ -537,18 +550,14 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
     if (!mounted) {
       return;
     }
-    await Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        settings: const RouteSettings(name: 'route_detail'),
-        builder: (_) => RouteDetailScreen(
-          routeKey: nearby.result.route.routeKey,
-          provider: routeProvider,
-          routeIdHint: nearby.result.route.routeId,
-          routeNameHint: nearby.result.route.routeName,
-          initialPathId: nearby.result.stop.pathId,
-          initialStopId: nearby.result.stop.stopId,
-        ),
-      ),
+    await openRouteDetailPage(
+      context,
+      routeKey: nearby.result.route.routeKey,
+      provider: routeProvider,
+      routeIdHint: nearby.result.route.routeId,
+      routeNameHint: nearby.result.route.routeName,
+      initialPathId: nearby.result.stop.pathId,
+      initialStopId: nearby.result.stop.stopId,
     );
   }
 
@@ -1058,18 +1067,14 @@ class _DesktopNearbyMapPanelState extends State<_DesktopNearbyMapPanel> {
     if (!mounted) {
       return;
     }
-    await Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        settings: const RouteSettings(name: 'route_detail'),
-        builder: (_) => RouteDetailScreen(
-          routeKey: selected.route.routeKey,
-          provider: routeProvider,
-          routeIdHint: selected.route.routeId,
-          routeNameHint: selected.route.routeName,
-          initialPathId: selected.stop.pathId,
-          initialStopId: selected.stop.stopId,
-        ),
-      ),
+    await openRouteDetailPage(
+      context,
+      routeKey: selected.route.routeKey,
+      provider: routeProvider,
+      routeIdHint: selected.route.routeId,
+      routeNameHint: selected.route.routeName,
+      initialPathId: selected.stop.pathId,
+      initialStopId: selected.stop.stopId,
     );
   }
 

--- a/lib/screens/legal_markdown_page.dart
+++ b/lib/screens/legal_markdown_page.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/markdown_content_view.dart';
+
+class LegalMarkdownPage extends StatefulWidget {
+  const LegalMarkdownPage({
+    required this.title,
+    required this.loadDocument,
+    super.key,
+  });
+
+  final String title;
+  final Future<String> Function() loadDocument;
+
+  @override
+  State<LegalMarkdownPage> createState() => _LegalMarkdownPageState();
+}
+
+class _LegalMarkdownPageState extends State<LegalMarkdownPage> {
+  String? _content;
+  String? _error;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDocument();
+  }
+
+  Future<void> _loadDocument() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final content = await widget.loadDocument();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _content = content;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = '$error';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+        actions: [
+          IconButton(
+            tooltip: '重新整理',
+            onPressed: _loading ? null : _loadDocument,
+            icon: _loading
+                ? const SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.refresh_rounded),
+          ),
+        ],
+      ),
+      body: _loading && _content == null
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: _loadDocument,
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: [
+                  if (_error case final error?)
+                    Center(
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 920),
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
+                          child: Card(
+                            color: theme.colorScheme.errorContainer,
+                            child: Padding(
+                              padding: const EdgeInsets.all(18),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    '文件更新失敗',
+                                    style: theme.textTheme.titleMedium,
+                                  ),
+                                  const SizedBox(height: 8),
+                                  Text(error),
+                                  const SizedBox(height: 12),
+                                  FilledButton.tonalIcon(
+                                    onPressed: _loadDocument,
+                                    icon: const Icon(Icons.refresh_rounded),
+                                    label: const Text('重試'),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  if (_content case final content?)
+                    MarkdownContentView(markdown: content)
+                  else if (!_loading)
+                    Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: FilledButton.tonalIcon(
+                          onPressed: _loadDocument,
+                          icon: const Icon(Icons.refresh_rounded),
+                          label: const Text('重新載入文件'),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+    );
+  }
+}

--- a/lib/screens/nearby_screen.dart
+++ b/lib/screens/nearby_screen.dart
@@ -4,8 +4,8 @@ import 'package:geolocator/geolocator.dart';
 import '../app/bus_app.dart';
 import '../core/models.dart';
 import 'adaptive_settings_presenter.dart';
-import 'route_detail_screen.dart';
 import '../widgets/background_image_wrapper.dart';
+import 'route_detail_navigation.dart';
 
 class NearbyScreen extends StatefulWidget {
   const NearbyScreen({super.key});
@@ -174,18 +174,14 @@ class _NearbyScreenState extends State<NearbyScreen> {
                         if (!context.mounted) {
                           return;
                         }
-                        await Navigator.of(context).push(
-                          MaterialPageRoute<void>(
-                            settings: const RouteSettings(name: 'route_detail'),
-                            builder: (_) => RouteDetailScreen(
-                              routeKey: item.route.routeKey,
-                              provider: routeProvider,
-                              routeIdHint: item.route.routeId,
-                              routeNameHint: item.route.routeName,
-                              initialPathId: item.stop.pathId,
-                              initialStopId: item.stop.stopId,
-                            ),
-                          ),
+                        await openRouteDetailPage(
+                          context,
+                          routeKey: item.route.routeKey,
+                          provider: routeProvider,
+                          routeIdHint: item.route.routeId,
+                          routeNameHint: item.route.routeName,
+                          initialPathId: item.stop.pathId,
+                          initialStopId: item.stop.stopId,
                         );
                       },
                     ),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -4,6 +4,7 @@ import 'package:geolocator/geolocator.dart';
 
 import '../app/bus_app.dart';
 import '../core/app_controller.dart';
+import '../core/app_routes.dart';
 import '../core/models.dart';
 
 class OnboardingScreen extends StatefulWidget {
@@ -238,9 +239,35 @@ class _IntroStep extends StatelessWidget {
 
   final Future<void> Function() onNext;
 
+  Widget _buildLegalLink(
+    BuildContext context, {
+    required String label,
+    required String routeName,
+  }) {
+    final theme = Theme.of(context);
+    return TextButton(
+      onPressed: () => Navigator.of(context).pushNamed(routeName),
+      style: TextButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 2),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        visualDensity: VisualDensity.compact,
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.primary,
+          decoration: TextDecoration.underline,
+          decorationColor: theme.colorScheme.primary,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -279,6 +306,48 @@ class _IntroStep extends StatelessWidget {
           subtitle: '配合定位權限快速找周邊站點。',
         ),
         const Spacer(),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: Center(
+            child: Wrap(
+              alignment: WrapAlignment.center,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                Text(
+                  '繼續即代表您同意我們的',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                _buildLegalLink(
+                  context,
+                  label: '服務條款',
+                  routeName: AppRoutes.termsOfService,
+                ),
+                Text(
+                  '及',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                _buildLegalLink(
+                  context,
+                  label: '隱私權政策',
+                  routeName: AppRoutes.privacyPolicy,
+                ),
+                Text(
+                  '。',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
         SizedBox(
           width: double.infinity,
           child: FilledButton(onPressed: onNext, child: const Text('開始設定')),

--- a/lib/screens/privacy_policy_page.dart
+++ b/lib/screens/privacy_policy_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import '../core/legal_document_service.dart';
+import 'legal_markdown_page.dart';
+
+class PrivacyPolicyPage extends StatelessWidget {
+  const PrivacyPolicyPage({super.key});
+
+  static final LegalDocumentService _service = LegalDocumentService();
+
+  @override
+  Widget build(BuildContext context) {
+    return LegalMarkdownPage(
+      title: '隱私權政策',
+      loadDocument: _service.fetchPrivacyPolicy,
+    );
+  }
+}

--- a/lib/screens/route_detail_navigation.dart
+++ b/lib/screens/route_detail_navigation.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+import '../core/app_routes.dart';
+import '../core/models.dart';
+import 'route_detail_screen.dart';
+
+Route<void> buildRouteDetailRoute({
+  required int routeKey,
+  required BusProvider provider,
+  String? routeIdHint,
+  String? routeNameHint,
+  int? initialPathId,
+  int? initialStopId,
+  int? initialDestinationPathId,
+  int? initialDestinationStopId,
+}) {
+  return MaterialPageRoute<void>(
+    settings: RouteSettings(
+      name: AppRoutes.routeDetailPath(
+        provider: provider,
+        routeKey: routeKey,
+        pathId: initialPathId,
+        stopId: initialStopId,
+        destinationPathId: initialDestinationPathId,
+        destinationStopId: initialDestinationStopId,
+      ),
+    ),
+    builder: (_) => RouteDetailScreen(
+      routeKey: routeKey,
+      provider: provider,
+      routeIdHint: routeIdHint,
+      routeNameHint: routeNameHint,
+      initialPathId: initialPathId,
+      initialStopId: initialStopId,
+      initialDestinationPathId: initialDestinationPathId,
+      initialDestinationStopId: initialDestinationStopId,
+    ),
+  );
+}
+
+Future<void> openRouteDetailPage(
+  BuildContext context, {
+  required int routeKey,
+  required BusProvider provider,
+  String? routeIdHint,
+  String? routeNameHint,
+  int? initialPathId,
+  int? initialStopId,
+  int? initialDestinationPathId,
+  int? initialDestinationStopId,
+}) {
+  return Navigator.of(context).push(
+    buildRouteDetailRoute(
+      routeKey: routeKey,
+      provider: provider,
+      routeIdHint: routeIdHint,
+      routeNameHint: routeNameHint,
+      initialPathId: initialPathId,
+      initialStopId: initialStopId,
+      initialDestinationPathId: initialDestinationPathId,
+      initialDestinationStopId: initialDestinationStopId,
+    ),
+  );
+}

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -8,8 +8,8 @@ import '../app/bus_app.dart';
 import '../core/app_controller.dart';
 import '../core/models.dart';
 import '../core/route_search_ranking.dart';
-import 'route_detail_screen.dart';
 import '../widgets/background_image_wrapper.dart';
+import 'route_detail_navigation.dart';
 
 class SearchScreen extends StatefulWidget {
   const SearchScreen({super.key});
@@ -222,17 +222,13 @@ class _SearchScreenState extends State<SearchScreen> {
     if (!mounted) {
       return;
     }
-    await Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        settings: const RouteSettings(name: 'route_detail'),
-        builder: (_) => RouteDetailScreen(
-          routeKey: routeKey,
-          provider: provider,
-          routeIdHint: routeIdHint,
-          routeNameHint: routeName,
-          initialPathId: initialPathId,
-        ),
-      ),
+    await openRouteDetailPage(
+      context,
+      routeKey: routeKey,
+      provider: provider,
+      routeIdHint: routeIdHint,
+      routeNameHint: routeName,
+      initialPathId: initialPathId,
     );
   }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../app/bus_app.dart';
 import '../core/android_trip_monitor.dart';
+import '../core/app_routes.dart';
 import '../core/app_controller.dart';
 import '../core/models.dart';
 import '../widgets/app_update_dialog.dart';
@@ -546,6 +547,29 @@ class SettingsScreen extends StatelessWidget {
                               label: const Text('清除路線選擇紀錄'),
                             ),
                           ],
+                        ),
+                        const SizedBox(height: 16),
+                        ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          leading: const Icon(Icons.gavel_outlined),
+                          title: const Text('服務條款'),
+                          trailing: const Icon(Icons.chevron_right),
+                          onTap: () {
+                            Navigator.of(context).pushNamed(
+                              AppRoutes.termsOfService,
+                            );
+                          },
+                        ),
+                        ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          leading: const Icon(Icons.privacy_tip_outlined),
+                          title: const Text('隱私權政策'),
+                          trailing: const Icon(Icons.chevron_right),
+                          onTap: () {
+                            Navigator.of(context).pushNamed(
+                              AppRoutes.privacyPolicy,
+                            );
+                          },
                         ),
                       ],
                     ),

--- a/lib/screens/terms_of_service_page.dart
+++ b/lib/screens/terms_of_service_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import '../core/legal_document_service.dart';
+import 'legal_markdown_page.dart';
+
+class TermsOfServicePage extends StatelessWidget {
+  const TermsOfServicePage({super.key});
+
+  static final LegalDocumentService _service = LegalDocumentService();
+
+  @override
+  Widget build(BuildContext context) {
+    return LegalMarkdownPage(
+      title: '服務條款',
+      loadDocument: _service.fetchTermsOfService,
+    );
+  }
+}

--- a/lib/widgets/announcement_content.dart
+++ b/lib/widgets/announcement_content.dart
@@ -3,6 +3,7 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 
 import '../core/announcement_models.dart';
 import '../core/app_link_handler.dart';
+import '../core/relative_time_formatter.dart';
 
 class AnnouncementContent extends StatelessWidget {
   const AnnouncementContent({
@@ -26,32 +27,31 @@ class AnnouncementContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final chips = <Widget>[
       Chip(
         avatar: const Icon(Icons.schedule_outlined, size: 18),
-        label: Text(_formatTimestamp(announcement.createdAtDateTime)),
+        label: Text(formatRelativeTimestamp(announcement.createdAtDateTime)),
       ),
       if (announcement.author case final author?)
         Chip(
           avatar: const Icon(Icons.person_outline_rounded, size: 18),
           label: Text(author),
         ),
-      if (announcement.expireAtDateTime case final expireAt?)
-        Chip(
-          avatar: const Icon(Icons.hourglass_bottom_rounded, size: 18),
-          label: Text('到 ${_formatTimestamp(expireAt)}'),
-        ),
-      if (announcement.behavior.redDot == AnnouncementRepeatBehavior.forever)
-        const Chip(
-          avatar: Icon(Icons.brightness_1_rounded, size: 14),
-          label: Text('紅點持續顯示'),
-        ),
-      if (announcement.behavior.popup == AnnouncementRepeatBehavior.forever)
-        const Chip(
-          avatar: Icon(Icons.notification_important_outlined, size: 18),
-          label: Text('持續彈出'),
-        ),
+      // if (announcement.expireAtDateTime case final expireAt?)
+      //   Chip(
+      //     avatar: const Icon(Icons.hourglass_bottom_rounded, size: 18),
+      //     label: Text('到 ${_formatTimestamp(expireAt)}'),
+      //   ),
+      // if (announcement.behavior.redDot == AnnouncementRepeatBehavior.forever)
+      //   const Chip(
+      //     avatar: Icon(Icons.brightness_1_rounded, size: 14),
+      //     label: Text('紅點持續顯示'),
+      //   ),
+      // if (announcement.behavior.popup == AnnouncementRepeatBehavior.forever)
+      //   const Chip(
+      //     avatar: Icon(Icons.notification_important_outlined, size: 18),
+      //     label: Text('持續彈出'),
+      //   ),
     ];
 
     return Column(
@@ -92,8 +92,8 @@ class AnnouncementContent extends StatelessWidget {
           ),
         ],
         if (announcement.actions.isNotEmpty) ...[
-          const SizedBox(height: 20),
-          Text('操作', style: theme.textTheme.titleMedium),
+          // const SizedBox(height: 20),
+          // Text('操作', style: theme.textTheme.titleMedium),
           const SizedBox(height: 10),
           Wrap(
             spacing: 12,
@@ -113,14 +113,4 @@ class AnnouncementContent extends StatelessWidget {
       ],
     );
   }
-}
-
-String _formatTimestamp(DateTime value) {
-  final local = value.toLocal();
-  final year = local.year.toString().padLeft(4, '0');
-  final month = local.month.toString().padLeft(2, '0');
-  final day = local.day.toString().padLeft(2, '0');
-  final hour = local.hour.toString().padLeft(2, '0');
-  final minute = local.minute.toString().padLeft(2, '0');
-  return '$year/$month/$day $hour:$minute';
 }

--- a/lib/widgets/announcement_content.dart
+++ b/lib/widgets/announcement_content.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+
+import '../core/announcement_models.dart';
+import '../core/app_link_handler.dart';
+
+class AnnouncementContent extends StatelessWidget {
+  const AnnouncementContent({
+    required this.announcement,
+    this.compact = false,
+    super.key,
+  });
+
+  final AppAnnouncement announcement;
+  final bool compact;
+
+  Future<void> _openLink(BuildContext context, String url) async {
+    final opened = await openAppLink(context, url);
+    if (!context.mounted || opened) {
+      return;
+    }
+    ScaffoldMessenger.maybeOf(
+      context,
+    )?.showSnackBar(const SnackBar(content: Text('無法開啟連結。')));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final chips = <Widget>[
+      Chip(
+        avatar: const Icon(Icons.schedule_outlined, size: 18),
+        label: Text(_formatTimestamp(announcement.createdAtDateTime)),
+      ),
+      if (announcement.author case final author?)
+        Chip(
+          avatar: const Icon(Icons.person_outline_rounded, size: 18),
+          label: Text(author),
+        ),
+      if (announcement.expireAtDateTime case final expireAt?)
+        Chip(
+          avatar: const Icon(Icons.hourglass_bottom_rounded, size: 18),
+          label: Text('到 ${_formatTimestamp(expireAt)}'),
+        ),
+      if (announcement.behavior.redDot == AnnouncementRepeatBehavior.forever)
+        const Chip(
+          avatar: Icon(Icons.brightness_1_rounded, size: 14),
+          label: Text('紅點持續顯示'),
+        ),
+      if (announcement.behavior.popup == AnnouncementRepeatBehavior.forever)
+        const Chip(
+          avatar: Icon(Icons.notification_important_outlined, size: 18),
+          label: Text('持續彈出'),
+        ),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(spacing: 8, runSpacing: 8, children: chips),
+        const SizedBox(height: 16),
+        MarkdownBody(
+          data: announcement.content,
+          onTapLink: (text, href, title) {
+            if (href != null) {
+              _openLink(context, href);
+            }
+          },
+        ),
+        if (announcement.embed case final embed?) ...[
+          const SizedBox(height: 20),
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.ondemand_video_outlined),
+              title: Text(embed.type.isEmpty ? '嵌入內容' : embed.type),
+              subtitle: Text(embed.url),
+              trailing: const Icon(Icons.open_in_new_rounded),
+              onTap: () => _openLink(context, embed.url),
+            ),
+          ),
+        ],
+        if (announcement.soundUrl case final soundUrl?) ...[
+          const SizedBox(height: 12),
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.volume_up_outlined),
+              title: const Text('提示音'),
+              subtitle: Text(soundUrl),
+              trailing: const Icon(Icons.open_in_new_rounded),
+              onTap: () => _openLink(context, soundUrl),
+            ),
+          ),
+        ],
+        if (announcement.actions.isNotEmpty) ...[
+          const SizedBox(height: 20),
+          Text('操作', style: theme.textTheme.titleMedium),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              for (final action in announcement.actions)
+                FilledButton.tonal(
+                  onPressed: action.url.isEmpty
+                      ? null
+                      : () => _openLink(context, action.url),
+                  child: Text(action.label),
+                ),
+            ],
+          ),
+        ],
+        if (!compact) const SizedBox(height: 24),
+      ],
+    );
+  }
+}
+
+String _formatTimestamp(DateTime value) {
+  final local = value.toLocal();
+  final year = local.year.toString().padLeft(4, '0');
+  final month = local.month.toString().padLeft(2, '0');
+  final day = local.day.toString().padLeft(2, '0');
+  final hour = local.hour.toString().padLeft(2, '0');
+  final minute = local.minute.toString().padLeft(2, '0');
+  return '$year/$month/$day $hour:$minute';
+}

--- a/lib/widgets/announcement_popup_dialog.dart
+++ b/lib/widgets/announcement_popup_dialog.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import '../core/announcement_models.dart';
+import 'announcement_content.dart';
+
+enum AnnouncementPopupResult { later, dismissForever, viewDetails }
+
+Future<AnnouncementPopupResult> showAnnouncementPopupDialog(
+  BuildContext context, {
+  required AppAnnouncement announcement,
+}) async {
+  final result = await showDialog<AnnouncementPopupResult>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(announcement.title),
+        content: SizedBox(
+          width: 560,
+          child: SingleChildScrollView(
+            child: AnnouncementContent(announcement: announcement, compact: true),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(
+              dialogContext,
+            ).pop(AnnouncementPopupResult.later),
+            child: const Text('稍後'),
+          ),
+          if (announcement.behavior.popup == AnnouncementRepeatBehavior.forever)
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(
+                AnnouncementPopupResult.dismissForever,
+              ),
+              child: const Text('不再顯示'),
+            ),
+          FilledButton(
+            onPressed: () => Navigator.of(
+              dialogContext,
+            ).pop(AnnouncementPopupResult.viewDetails),
+            child: const Text('查看公告'),
+          ),
+        ],
+      );
+    },
+  );
+  return result ?? AnnouncementPopupResult.later;
+}

--- a/lib/widgets/markdown_content_view.dart
+++ b/lib/widgets/markdown_content_view.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+
+import '../core/app_link_handler.dart';
+
+class MarkdownContentView extends StatelessWidget {
+  const MarkdownContentView({
+    required this.markdown,
+    this.maxWidth = 920,
+    this.padding = const EdgeInsets.all(20),
+    super.key,
+  });
+
+  final String markdown;
+  final double maxWidth;
+  final EdgeInsetsGeometry padding;
+
+  Future<void> _handleLink(BuildContext context, String? href) async {
+    if (href == null || href.trim().isEmpty) {
+      return;
+    }
+    final opened = await openAppLink(context, href);
+    if (!context.mounted || opened) {
+      return;
+    }
+    ScaffoldMessenger.maybeOf(
+      context,
+    )?.showSnackBar(const SnackBar(content: Text('無法開啟連結。')));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: maxWidth),
+        child: Padding(
+          padding: padding,
+          child: MarkdownBody(
+            data: markdown,
+            onTapLink: (text, href, title) => _handleLink(context, href),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/web/404.html
+++ b/web/404.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>YABus</title>
+  <script>
+    (function () {
+      var path = window.location.pathname || '/';
+      var search = window.location.search || '';
+      var hash = window.location.hash || '';
+      if (!path.startsWith('/')) {
+        path = '/' + path;
+      }
+      var target = '/#' + path + search + hash;
+      window.location.replace(target);
+    })();
+  </script>
+</head>
+<body>
+  <p>正在返回 YABus…</p>
+</body>
+</html>


### PR DESCRIPTION
- Implemented AppRoutes for navigation including announcements, terms of service, and privacy policy.
- Created LegalDocumentService to fetch legal documents from the API.
- Added AnnouncementDetailPage and AnnouncementsPage for displaying announcements.
- Introduced AnnouncementContent widget for rendering announcement details.
- Developed a popup dialog for announcements with options to view details or dismiss.
- Updated HomeScreen and SettingsScreen to include links to legal documents.
- Refactored route navigation to use a dedicated route detail navigation file.
- Added markdown content view for displaying legal documents and announcements.
- Implemented error handling and loading states for fetching documents and announcements.
- Created a custom 404 page for better user experience on invalid routes.