### PR TITLE
Add Trip Mode and shared motion tokens

### DIFF
--- a/lib/core/app_motion.dart
+++ b/lib/core/app_motion.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/animation.dart';
+
+class AppMotion {
+  AppMotion._();
+
+  static const microInteraction = Duration(milliseconds: 160);
+  static const quick = Duration(milliseconds: 180);
+  static const standard = Duration(milliseconds: 220);
+  static const settle = Duration(milliseconds: 250);
+  static const progress = Duration(milliseconds: 260);
+  static const emphasis = Duration(milliseconds: 280);
+  static const scroll = Duration(milliseconds: 360);
+
+  static const Curve enter = Curves.easeOutCubic;
+  static const Curve exit = Curves.easeInCubic;
+}

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../app/bus_app.dart';
 import '../core/app_controller.dart';
+import '../core/app_motion.dart';
 import '../core/app_route_observer.dart';
 import '../core/bus_repository.dart';
 import '../core/models.dart';
@@ -227,9 +228,9 @@ class _FavoritesScreenState extends State<FavoritesScreen>
 
   Widget _buildBottomProgressIndicator() {
     return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 260),
-      switchInCurve: Curves.easeOutCubic,
-      switchOutCurve: Curves.easeInCubic,
+      duration: AppMotion.progress,
+      switchInCurve: AppMotion.enter,
+      switchOutCurve: AppMotion.exit,
       transitionBuilder: (child, animation) {
         return SizeTransition(
           sizeFactor: animation,

--- a/lib/screens/main_transit_shell.dart
+++ b/lib/screens/main_transit_shell.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import '../app/bus_app.dart';
+import '../core/app_motion.dart';
 import '../core/desktop_discord_presence_service.dart';
 import '../widgets/background_image_wrapper.dart';
 import '../widgets/transit_drawer.dart';
@@ -33,7 +34,6 @@ class _MainTransitShellState extends State<MainTransitShell> {
     TransitMode.tra,
     TransitMode.youbike,
   ];
-  static const _switchDuration = Duration(milliseconds: 220);
   static const _hiddenOffset = Offset(0.035, 0);
 
   @override
@@ -130,12 +130,12 @@ class _MainTransitShellState extends State<MainTransitShell> {
         child: TickerMode(
           enabled: isActive,
           child: AnimatedSlide(
-            duration: _switchDuration,
-            curve: Curves.easeOutCubic,
+            duration: AppMotion.standard,
+            curve: AppMotion.enter,
             offset: isActive ? Offset.zero : _hiddenOffset,
             child: AnimatedOpacity(
-              duration: _switchDuration,
-              curve: Curves.easeOutCubic,
+              duration: AppMotion.standard,
+              curve: AppMotion.enter,
               opacity: isActive ? 1 : 0,
               child: BackgroundImageWrapper(pageKey: pageKey, child: child),
             ),

--- a/lib/screens/metro_dashboard_screen.dart
+++ b/lib/screens/metro_dashboard_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../core/app_motion.dart';
 import '../core/transit_repository.dart';
 import '../widgets/eta_badge.dart';
 import '../widgets/transit_drawer.dart';
@@ -448,7 +449,9 @@ class _MetroScreenState extends State<MetroScreen> {
                         ),
                         const SizedBox(height: 16),
                         AnimatedSwitcher(
-                          duration: const Duration(milliseconds: 220),
+                          duration: AppMotion.standard,
+                          switchInCurve: AppMotion.enter,
+                          switchOutCurve: AppMotion.exit,
                           child: switch (_panel) {
                             _MetroPanel.live => _buildLivePanel(theme),
                             _MetroPanel.map => _buildMapPanel(theme),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -4,6 +4,7 @@ import 'package:geolocator/geolocator.dart';
 
 import '../app/bus_app.dart';
 import '../core/app_controller.dart';
+import '../core/app_motion.dart';
 import '../core/app_routes.dart';
 import '../core/models.dart';
 
@@ -37,8 +38,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   Future<void> _goToStep(int index) async {
     await _pageController.animateToPage(
       index,
-      duration: const Duration(milliseconds: 280),
-      curve: Curves.easeOutCubic,
+      duration: AppMotion.emphasis,
+      curve: AppMotion.enter,
     );
   }
 
@@ -150,7 +151,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     }
 
     if (mounted && _stepIndex == 1) {
-      await Future<void>.delayed(const Duration(milliseconds: 250));
+      await Future<void>.delayed(AppMotion.settle);
       await _nextStep();
     }
   }
@@ -175,7 +176,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                         right: index == _effectiveStepCount - 1 ? 0 : 8,
                       ),
                       child: AnimatedContainer(
-                        duration: const Duration(milliseconds: 220),
+                        duration: AppMotion.standard,
+                        curve: AppMotion.enter,
                         height: 6,
                         decoration: BoxDecoration(
                           color: active

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -14,6 +14,7 @@ import '../core/android_home_integration.dart';
 import '../core/android_trip_monitor.dart';
 import '../core/app_controller.dart';
 import '../core/app_launch_service.dart';
+import '../core/app_motion.dart';
 import '../core/app_route_observer.dart';
 import '../core/app_routes.dart';
 import '../core/bus_repository.dart';
@@ -85,6 +86,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
   bool _backgroundTripMonitorReady = false;
   bool _backgroundTripMonitorPromptInProgress = false;
   bool _backgroundTripMonitorPaused = false;
+  bool _tripModeStartInProgress = false;
   bool _backgroundDataRefreshInFlight = false;
   bool _awaitingBackgroundLocationPermission = false;
   bool _destinationPromptShown = false;
@@ -729,8 +731,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       if (targetIndex != -1 && _tabController!.index != targetIndex) {
         _tabController!.animateTo(
           targetIndex,
-          duration: const Duration(milliseconds: 220),
-          curve: Curves.easeOutCubic,
+          duration: AppMotion.standard,
+          curve: AppMotion.enter,
         );
         for (var attempt = 0; attempt < 12; attempt++) {
           await WidgetsBinding.instance.endOfFrame;
@@ -804,8 +806,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       if (targetIndex != -1 && _tabController!.index != targetIndex) {
         _tabController!.animateTo(
           targetIndex,
-          duration: const Duration(milliseconds: 220),
-          curve: Curves.easeOutCubic,
+          duration: AppMotion.standard,
+          curve: AppMotion.enter,
         );
         for (var attempt = 0; attempt < 12; attempt++) {
           await WidgetsBinding.instance.endOfFrame;
@@ -939,9 +941,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
   Widget _buildBottomProgressIndicator() {
     return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 260),
-      switchInCurve: Curves.easeOutCubic,
-      switchOutCurve: Curves.easeInCubic,
+      duration: AppMotion.progress,
+      switchInCurve: AppMotion.enter,
+      switchOutCurve: AppMotion.exit,
       transitionBuilder: (child, animation) {
         return SizeTransition(
           sizeFactor: animation,
@@ -1004,7 +1006,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     int pathId,
     int stopId, {
     double alignment = 0.5,
-    Duration duration = const Duration(milliseconds: 360),
+    Duration duration = AppMotion.scroll,
   }) async {
     var hasPrimedLazyList = false;
     for (var attempt = 0; attempt < 12; attempt++) {
@@ -1032,7 +1034,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       await Scrollable.ensureVisible(
         targetContext,
         duration: duration,
-        curve: Curves.easeOutCubic,
+        curve: AppMotion.enter,
         alignment: alignment,
       );
       return true;
@@ -1168,8 +1170,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     }
     tabController.animateTo(
       targetIndex,
-      duration: const Duration(milliseconds: 220),
-      curve: Curves.easeOutCubic,
+      duration: AppMotion.standard,
+      curve: AppMotion.enter,
     );
   }
 
@@ -1951,7 +1953,10 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     ).showSnackBar(SnackBar(content: Text('已將 ${stop.stopName} 設為上車站。')));
   }
 
-  Future<void> _setDestinationStop(StopInfo stop) async {
+  Future<void> _setDestinationStop(
+    StopInfo stop, {
+    bool showFeedback = true,
+  }) async {
     final boardingStop = _resolvedBoardingStop();
     setState(() {
       _pendingAutoDestinationSelection = false;
@@ -1968,9 +1973,86 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (!mounted) {
       return;
     }
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text('已將 ${stop.stopName} 設為下車提醒。')));
+    if (showFeedback) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('已將 ${stop.stopName} 設為下車提醒。')));
+    }
+  }
+
+  Future<void> _startTripMode() async {
+    if (_tripModeStartInProgress || _currentPathStops.isEmpty) {
+      return;
+    }
+
+    setState(() {
+      _tripModeStartInProgress = true;
+    });
+    try {
+      final controller = AppControllerScope.read(context);
+      final boardingStop = _resolvedBoardingStop();
+
+      if (_destinationStopId == null) {
+        final destinationStop = await _pickTripMonitorStop(
+          title: '選擇下車站',
+          selectedStopId: _destinationStopId,
+          selectedIcon: Icons.flag_rounded,
+          blockedStopId: boardingStop?.stopId,
+          blockedReason: '這個站已設為上車站',
+        );
+        if (!mounted || destinationStop == null) {
+          return;
+        }
+        await _setDestinationStop(destinationStop, showFeedback: false);
+      } else if (_boardingStopId == null && boardingStop != null) {
+        setState(() {
+          _boardingStopId = boardingStop.stopId;
+          _boardingStopName = boardingStop.stopName;
+        });
+      }
+
+      if (!controller.settings.enableRouteBackgroundMonitor) {
+        await controller.updateEnableRouteBackgroundMonitor(
+          true,
+          markPromptSeen: true,
+        );
+      }
+      if (!mounted) {
+        return;
+      }
+
+      if (_backgroundTripMonitorPaused) {
+        await _setBackgroundTripMonitorPaused(
+          false,
+          reason: 'trip_mode',
+          showFeedback: false,
+        );
+      } else {
+        await _configureBackgroundTripMonitorIfNeeded(
+          forcePermissionCheck: true,
+        );
+      }
+
+      if (!mounted) {
+        return;
+      }
+      final destinationName = _destinationStopName?.trim();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            destinationName == null || destinationName.isEmpty
+                ? '乘車模式已啟動。'
+                : '乘車模式已啟動，下車提醒：$destinationName。',
+          ),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _tripModeStartInProgress = false;
+        });
+      }
+    }
   }
 
   Future<void> _clearBoardingStop() async {
@@ -3578,7 +3660,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
                 children: [
                   Expanded(
                     child: Text(
-                      '背景乘車提醒',
+                      '乘車模式',
                       style: theme.textTheme.titleLarge?.copyWith(
                         fontWeight: FontWeight.w700,
                       ),
@@ -3595,7 +3677,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
             Padding(
               padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
               child: Text(
-                '把背景追蹤與下車提醒控制集中在這裡。',
+                '乘車模式會持續追蹤這趟車，並在接近下車站時提醒你。',
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
@@ -3609,7 +3691,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
                     : Icons.pause_circle_outline_rounded,
               ),
               title: Text(
-                _backgroundTripMonitorPaused ? '恢復背景乘車提醒' : '暫時停止背景乘車提醒',
+                _backgroundTripMonitorPaused ? '恢復乘車模式' : '暫停乘車模式',
               ),
               subtitle: Text(
                 _backgroundTripMonitorPaused
@@ -4239,6 +4321,37 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     );
   }
 
+  Widget _buildTripModeButton({
+    required bool active,
+    required bool paused,
+    required bool canOpenSettings,
+  }) {
+    final label = active
+        ? '乘車中'
+        : paused
+        ? '恢復乘車'
+        : '我正在搭車';
+    final icon = active
+        ? Icons.near_me_rounded
+        : paused
+        ? Icons.play_arrow_rounded
+        : Icons.directions_bus_filled_rounded;
+    return FilledButton.icon(
+      onPressed: _tripModeStartInProgress
+          ? null
+          : active && canOpenSettings
+          ? () => _scaffoldKey.currentState?.openEndDrawer()
+          : () => unawaited(_startTripMode()),
+      icon: _tripModeStartInProgress
+          ? const SizedBox.square(
+              dimension: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Icon(icon),
+      label: Text(label),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final controller = AppControllerScope.of(context);
@@ -4257,6 +4370,13 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         : _nearestStopByPath[currentPathId];
     final canOpenBackgroundTripMonitorDrawer =
         settings.enableRouteBackgroundMonitor && _currentPathStops.isNotEmpty;
+    final tripModeAvailable = (_isAndroid || _isIOS) &&
+        detail != null &&
+        _currentPathStops.isNotEmpty;
+    final tripModeConfigured =
+        settings.enableRouteBackgroundMonitor && _destinationStopId != null;
+    final tripModeActive = tripModeConfigured && !_backgroundTripMonitorPaused;
+    final tripModePaused = tripModeConfigured && _backgroundTripMonitorPaused;
     final isWideLayout =
         MediaQuery.sizeOf(context).width >= _wideLayoutBreakpoint;
     final canShowInlineMap =
@@ -4325,7 +4445,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
             if (canOpenBackgroundTripMonitorDrawer)
               IconButton(
                 onPressed: () => _scaffoldKey.currentState?.openEndDrawer(),
-                tooltip: '背景乘車提醒',
+                tooltip: '乘車模式',
                 icon: Icon(
                   _backgroundTripMonitorPaused
                       ? Icons.notifications_paused_outlined
@@ -4381,18 +4501,50 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
               _buildBottomProgressIndicator(),
               Padding(
                 padding: EdgeInsets.fromLTRB(16, 8, 16, bottomInset + 10),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    _statusMessage ??
-                        (_remainingSeconds > 0
-                            ? '$_remainingSeconds 秒後更新'
-                            : '正在更新'),
-                    style: theme.textTheme.labelLarge?.copyWith(
-                      color: theme.colorScheme.onSurface,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    final statusLabel = Text(
+                      _statusMessage ??
+                          (_remainingSeconds > 0
+                              ? '$_remainingSeconds 秒後更新'
+                              : '正在更新'),
+                      style: theme.textTheme.labelLarge?.copyWith(
+                        color: theme.colorScheme.onSurface,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    );
+                    if (!tripModeAvailable) {
+                      return Align(
+                        alignment: Alignment.centerLeft,
+                        child: statusLabel,
+                      );
+                    }
+
+                    final tripModeButton = _buildTripModeButton(
+                      active: tripModeActive,
+                      paused: tripModePaused,
+                      canOpenSettings: canOpenBackgroundTripMonitorDrawer,
+                    );
+                    if (constraints.maxWidth < 430) {
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          statusLabel,
+                          const SizedBox(height: 8),
+                          tripModeButton,
+                        ],
+                      );
+                    }
+
+                    return Row(
+                      children: [
+                        Expanded(child: statusLabel),
+                        const SizedBox(width: 12),
+                        tripModeButton,
+                      ],
+                    );
+                  },
                 ),
               ),
             ],

--- a/lib/screens/thsr_dashboard_screen.dart
+++ b/lib/screens/thsr_dashboard_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../core/app_motion.dart';
 import '../core/transit_repository.dart';
 import '../widgets/transit_drawer.dart';
 import '../widgets/transit_station_map.dart';
@@ -256,7 +257,9 @@ class _ThsrScreenState extends State<ThsrScreen> {
                         ),
                         const SizedBox(height: 16),
                         AnimatedSwitcher(
-                          duration: const Duration(milliseconds: 220),
+                          duration: AppMotion.standard,
+                          switchInCurve: AppMotion.enter,
+                          switchOutCurve: AppMotion.exit,
                           child: switch (_panel) {
                             _ThsrPanel.timetable => _buildTimetablePanel(theme),
                             _ThsrPanel.seats => _buildSeatPanel(theme),

--- a/lib/screens/tra_screen.dart
+++ b/lib/screens/tra_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../core/app_motion.dart';
 import '../core/transit_repository.dart';
 import '../widgets/transit_drawer.dart';
 import '../widgets/transit_station_map.dart';
@@ -261,7 +262,9 @@ class _TraScreenState extends State<TraScreen> {
                         ),
                         const SizedBox(height: 16),
                         AnimatedSwitcher(
-                          duration: const Duration(milliseconds: 220),
+                          duration: AppMotion.standard,
+                          switchInCurve: AppMotion.enter,
+                          switchOutCurve: AppMotion.exit,
                           child: _panel == _TraPanel.query
                               ? _buildQueryPanel(theme)
                               : _buildMapPanel(theme),

--- a/lib/widgets/route_bus_map_sheet.dart
+++ b/lib/widgets/route_bus_map_sheet.dart
@@ -10,6 +10,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart' as gmaps;
 import 'package:latlong2/latlong.dart';
 
 import '../app/bus_app.dart';
+import '../core/app_motion.dart';
 import '../core/models.dart';
 import 'eta_badge.dart';
 import 'platform_map_provider.dart';
@@ -1950,7 +1951,8 @@ class _BusMarker extends StatelessWidget {
         : Colors.white;
     return AnimatedScale(
       scale: selected ? 1.08 : 1,
-      duration: const Duration(milliseconds: 180),
+      duration: AppMotion.quick,
+      curve: AppMotion.enter,
       child: Container(
         decoration: BoxDecoration(
           color: color,
@@ -1992,7 +1994,8 @@ class _StopMarker extends StatelessWidget {
   Widget build(BuildContext context) {
     return AnimatedScale(
       scale: selected ? 1.08 : 1,
-      duration: const Duration(milliseconds: 180),
+      duration: AppMotion.quick,
+      curve: AppMotion.enter,
       child: DecoratedBox(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(999),

--- a/lib/widgets/transit_station_map.dart
+++ b/lib/widgets/transit_station_map.dart
@@ -4,6 +4,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart' as gmaps;
 import 'package:latlong2/latlong.dart';
 
 import '../app/bus_app.dart';
+import '../core/app_motion.dart';
 import 'platform_map_provider.dart';
 
 class TransitMapPoint {
@@ -332,7 +333,8 @@ class _TransitPointMarker extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         AnimatedContainer(
-          duration: const Duration(milliseconds: 160),
+          duration: AppMotion.microInteraction,
+          curve: AppMotion.enter,
           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
           decoration: BoxDecoration(
             color: theme.colorScheme.surface.withValues(


### PR DESCRIPTION
## Summary
- add AppMotion as shared UI duration/curve tokens
- apply motion tokens to route detail, favorites, transit mode switches, onboarding, rail panels, and map marker micro-interactions
- add a Route Detail Trip Mode action that reuses the existing background monitor, destination reminder, and Live Activity pipeline

## Verification
- git diff --check
- GitHub Actions Build should validate flutter analyze/test/build after this PR opens

Note: local dart/flutter commands are not available on this Windows PATH.