### PR TITLE
Centralize UI motion tokens

### DIFF
--- a/lib/core/app_motion.dart
+++ b/lib/core/app_motion.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/animation.dart';
+
+class AppMotion {
+  AppMotion._();
+
+  static const microInteraction = Duration(milliseconds: 160);
+  static const quick = Duration(milliseconds: 180);
+  static const standard = Duration(milliseconds: 220);
+  static const settle = Duration(milliseconds: 250);
+  static const progress = Duration(milliseconds: 260);
+  static const emphasis = Duration(milliseconds: 280);
+  static const scroll = Duration(milliseconds: 360);
+
+  static const Curve enter = Curves.easeOutCubic;
+  static const Curve exit = Curves.easeInCubic;
+}

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../app/bus_app.dart';
 import '../core/app_controller.dart';
+import '../core/app_motion.dart';
 import '../core/app_route_observer.dart';
 import '../core/bus_repository.dart';
 import '../core/models.dart';
@@ -227,9 +228,9 @@ class _FavoritesScreenState extends State<FavoritesScreen>
 
   Widget _buildBottomProgressIndicator() {
     return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 260),
-      switchInCurve: Curves.easeOutCubic,
-      switchOutCurve: Curves.easeInCubic,
+      duration: AppMotion.progress,
+      switchInCurve: AppMotion.enter,
+      switchOutCurve: AppMotion.exit,
       transitionBuilder: (child, animation) {
         return SizeTransition(
           sizeFactor: animation,

--- a/lib/screens/main_transit_shell.dart
+++ b/lib/screens/main_transit_shell.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import '../app/bus_app.dart';
+import '../core/app_motion.dart';
 import '../core/desktop_discord_presence_service.dart';
 import '../widgets/background_image_wrapper.dart';
 import '../widgets/transit_drawer.dart';
@@ -33,7 +34,6 @@ class _MainTransitShellState extends State<MainTransitShell> {
     TransitMode.tra,
     TransitMode.youbike,
   ];
-  static const _switchDuration = Duration(milliseconds: 220);
   static const _hiddenOffset = Offset(0.035, 0);
 
   @override
@@ -130,12 +130,12 @@ class _MainTransitShellState extends State<MainTransitShell> {
         child: TickerMode(
           enabled: isActive,
           child: AnimatedSlide(
-            duration: _switchDuration,
-            curve: Curves.easeOutCubic,
+            duration: AppMotion.standard,
+            curve: AppMotion.enter,
             offset: isActive ? Offset.zero : _hiddenOffset,
             child: AnimatedOpacity(
-              duration: _switchDuration,
-              curve: Curves.easeOutCubic,
+              duration: AppMotion.standard,
+              curve: AppMotion.enter,
               opacity: isActive ? 1 : 0,
               child: BackgroundImageWrapper(pageKey: pageKey, child: child),
             ),

--- a/lib/screens/metro_dashboard_screen.dart
+++ b/lib/screens/metro_dashboard_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../core/app_motion.dart';
 import '../core/transit_repository.dart';
 import '../widgets/eta_badge.dart';
 import '../widgets/transit_drawer.dart';
@@ -448,7 +449,9 @@ class _MetroScreenState extends State<MetroScreen> {
                         ),
                         const SizedBox(height: 16),
                         AnimatedSwitcher(
-                          duration: const Duration(milliseconds: 220),
+                          duration: AppMotion.standard,
+                          switchInCurve: AppMotion.enter,
+                          switchOutCurve: AppMotion.exit,
                           child: switch (_panel) {
                             _MetroPanel.live => _buildLivePanel(theme),
                             _MetroPanel.map => _buildMapPanel(theme),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -4,6 +4,7 @@ import 'package:geolocator/geolocator.dart';
 
 import '../app/bus_app.dart';
 import '../core/app_controller.dart';
+import '../core/app_motion.dart';
 import '../core/app_routes.dart';
 import '../core/models.dart';
 
@@ -37,8 +38,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   Future<void> _goToStep(int index) async {
     await _pageController.animateToPage(
       index,
-      duration: const Duration(milliseconds: 280),
-      curve: Curves.easeOutCubic,
+      duration: AppMotion.emphasis,
+      curve: AppMotion.enter,
     );
   }
 
@@ -150,7 +151,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     }
 
     if (mounted && _stepIndex == 1) {
-      await Future<void>.delayed(const Duration(milliseconds: 250));
+      await Future<void>.delayed(AppMotion.settle);
       await _nextStep();
     }
   }
@@ -175,7 +176,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                         right: index == _effectiveStepCount - 1 ? 0 : 8,
                       ),
                       child: AnimatedContainer(
-                        duration: const Duration(milliseconds: 220),
+                        duration: AppMotion.standard,
+                        curve: AppMotion.enter,
                         height: 6,
                         decoration: BoxDecoration(
                           color: active

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -14,6 +14,7 @@ import '../core/android_home_integration.dart';
 import '../core/android_trip_monitor.dart';
 import '../core/app_controller.dart';
 import '../core/app_launch_service.dart';
+import '../core/app_motion.dart';
 import '../core/app_route_observer.dart';
 import '../core/app_routes.dart';
 import '../core/bus_repository.dart';
@@ -729,8 +730,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       if (targetIndex != -1 && _tabController!.index != targetIndex) {
         _tabController!.animateTo(
           targetIndex,
-          duration: const Duration(milliseconds: 220),
-          curve: Curves.easeOutCubic,
+          duration: AppMotion.standard,
+          curve: AppMotion.enter,
         );
         for (var attempt = 0; attempt < 12; attempt++) {
           await WidgetsBinding.instance.endOfFrame;
@@ -804,8 +805,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       if (targetIndex != -1 && _tabController!.index != targetIndex) {
         _tabController!.animateTo(
           targetIndex,
-          duration: const Duration(milliseconds: 220),
-          curve: Curves.easeOutCubic,
+          duration: AppMotion.standard,
+          curve: AppMotion.enter,
         );
         for (var attempt = 0; attempt < 12; attempt++) {
           await WidgetsBinding.instance.endOfFrame;
@@ -939,9 +940,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
   Widget _buildBottomProgressIndicator() {
     return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 260),
-      switchInCurve: Curves.easeOutCubic,
-      switchOutCurve: Curves.easeInCubic,
+      duration: AppMotion.progress,
+      switchInCurve: AppMotion.enter,
+      switchOutCurve: AppMotion.exit,
       transitionBuilder: (child, animation) {
         return SizeTransition(
           sizeFactor: animation,
@@ -1004,7 +1005,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     int pathId,
     int stopId, {
     double alignment = 0.5,
-    Duration duration = const Duration(milliseconds: 360),
+    Duration duration = AppMotion.scroll,
   }) async {
     var hasPrimedLazyList = false;
     for (var attempt = 0; attempt < 12; attempt++) {
@@ -1032,7 +1033,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       await Scrollable.ensureVisible(
         targetContext,
         duration: duration,
-        curve: Curves.easeOutCubic,
+        curve: AppMotion.enter,
         alignment: alignment,
       );
       return true;
@@ -1168,8 +1169,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     }
     tabController.animateTo(
       targetIndex,
-      duration: const Duration(milliseconds: 220),
-      curve: Curves.easeOutCubic,
+      duration: AppMotion.standard,
+      curve: AppMotion.enter,
     );
   }
 

--- a/lib/screens/thsr_dashboard_screen.dart
+++ b/lib/screens/thsr_dashboard_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../core/app_motion.dart';
 import '../core/transit_repository.dart';
 import '../widgets/transit_drawer.dart';
 import '../widgets/transit_station_map.dart';
@@ -256,7 +257,9 @@ class _ThsrScreenState extends State<ThsrScreen> {
                         ),
                         const SizedBox(height: 16),
                         AnimatedSwitcher(
-                          duration: const Duration(milliseconds: 220),
+                          duration: AppMotion.standard,
+                          switchInCurve: AppMotion.enter,
+                          switchOutCurve: AppMotion.exit,
                           child: switch (_panel) {
                             _ThsrPanel.timetable => _buildTimetablePanel(theme),
                             _ThsrPanel.seats => _buildSeatPanel(theme),

--- a/lib/screens/tra_screen.dart
+++ b/lib/screens/tra_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../core/app_motion.dart';
 import '../core/transit_repository.dart';
 import '../widgets/transit_drawer.dart';
 import '../widgets/transit_station_map.dart';
@@ -261,7 +262,9 @@ class _TraScreenState extends State<TraScreen> {
                         ),
                         const SizedBox(height: 16),
                         AnimatedSwitcher(
-                          duration: const Duration(milliseconds: 220),
+                          duration: AppMotion.standard,
+                          switchInCurve: AppMotion.enter,
+                          switchOutCurve: AppMotion.exit,
                           child: _panel == _TraPanel.query
                               ? _buildQueryPanel(theme)
                               : _buildMapPanel(theme),

--- a/lib/widgets/route_bus_map_sheet.dart
+++ b/lib/widgets/route_bus_map_sheet.dart
@@ -10,6 +10,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart' as gmaps;
 import 'package:latlong2/latlong.dart';
 
 import '../app/bus_app.dart';
+import '../core/app_motion.dart';
 import '../core/models.dart';
 import 'eta_badge.dart';
 import 'platform_map_provider.dart';
@@ -1950,7 +1951,8 @@ class _BusMarker extends StatelessWidget {
         : Colors.white;
     return AnimatedScale(
       scale: selected ? 1.08 : 1,
-      duration: const Duration(milliseconds: 180),
+      duration: AppMotion.quick,
+      curve: AppMotion.enter,
       child: Container(
         decoration: BoxDecoration(
           color: color,
@@ -1992,7 +1994,8 @@ class _StopMarker extends StatelessWidget {
   Widget build(BuildContext context) {
     return AnimatedScale(
       scale: selected ? 1.08 : 1,
-      duration: const Duration(milliseconds: 180),
+      duration: AppMotion.quick,
+      curve: AppMotion.enter,
       child: DecoratedBox(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(999),

--- a/lib/widgets/transit_station_map.dart
+++ b/lib/widgets/transit_station_map.dart
@@ -4,6 +4,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart' as gmaps;
 import 'package:latlong2/latlong.dart';
 
 import '../app/bus_app.dart';
+import '../core/app_motion.dart';
 import 'platform_map_provider.dart';
 
 class TransitMapPoint {
@@ -332,7 +333,8 @@ class _TransitPointMarker extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         AnimatedContainer(
-          duration: const Duration(milliseconds: 160),
+          duration: AppMotion.microInteraction,
+          curve: AppMotion.enter,
           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
           decoration: BoxDecoration(
             color: theme.colorScheme.surface.withValues(


### PR DESCRIPTION
## Summary
- add AppMotion as shared UI motion duration and curve tokens
- replace existing hard-coded animation durations/curves in route detail, favorites, onboarding, transit switching, rail panel switching, and map marker micro-interactions
- leave non-UI timers such as search debounce and map simulation tick unchanged

## Verification
- git diff --check
- GitHub Actions Build should validate flutter analyze/test/build after this PR opens

Note: local dart/flutter commands are not available on this Windows PATH.