### PR TITLE
feat: add playful status states and haptics

### DIFF
--- a/android/app/src/main/kotlin/tw/avianjay/taiwanbus/flutter/RouteTripMonitorService.kt
+++ b/android/app/src/main/kotlin/tw/avianjay/taiwanbus/flutter/RouteTripMonitorService.kt
@@ -1247,15 +1247,21 @@ class RouteTripMonitorService : Service() {
         userBusLiveStop: LiveStopState? = null,
     ): String? {
         val normalizedCurrent = normalizeVehicleId(currentTrackedBusId)
-        if (normalizedCurrent != null) {
+        val currentStops = listOf(userBusLiveStop, nearestLiveStop, boardingLiveStop, destinationLiveStop)
+        if (
+            normalizedCurrent != null &&
+                currentStops.any { stopState ->
+                    isVehicleSeenAtStop(stopState, normalizedCurrent)
+                }
+        ) {
             return normalizedCurrent
         }
 
-        listOf(userBusLiveStop, nearestLiveStop, boardingLiveStop, destinationLiveStop).forEach { stopState ->
+        currentStops.forEach { stopState ->
             firstKnownVehicleId(stopState)?.let { return it }
         }
 
-        return normalizedCurrent
+        return null
     }
 
     private fun firstKnownVehicleId(stopState: LiveStopState?): String? {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -43,6 +43,11 @@ post_install do |installer|
     flutter_additional_ios_build_settings(target)
     target.build_configurations.each do |config|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
+      definitions = config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] || ['$(inherited)']
+      definitions = [definitions].flatten
+      definitions << 'PERMISSION_PHOTOS=1'
+      definitions << 'PERMISSION_NOTIFICATIONS=1'
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = definitions.uniq
     end
   end
 end

--- a/ios/YABus/AppDelegate.swift
+++ b/ios/YABus/AppDelegate.swift
@@ -31,11 +31,6 @@ import UIKit
     return super.application(app, open: url, options: options)
   }
 
-  override func applicationWillTerminate(_ application: UIApplication) {
-    LiveActivityBridge.shared.endAllActivitiesFromHost()
-    super.applicationWillTerminate(application)
-  }
-
   private func configureBridges(messenger: FlutterBinaryMessenger) {
     AppLaunchBridge.shared.configure(messenger: messenger)
     WidgetDataBridge.shared.configure(messenger: messenger)

--- a/ios/YABus/BusArrivalAttributes.swift
+++ b/ios/YABus/BusArrivalAttributes.swift
@@ -11,6 +11,7 @@ struct BusArrivalAttributes: ActivityAttributes {
   struct ContentState: Codable, Hashable {
     let displayStopId: Int
     let displayStopName: String
+    let alertStopName: String?
     let previousStopName: String?
     let nextStopName: String?
     let lineStopNames: [String]

--- a/ios/YABus/GeneratedPluginRegistrant.m
+++ b/ios/YABus/GeneratedPluginRegistrant.m
@@ -30,6 +30,12 @@
 @import package_info_plus;
 #endif
 
+#if __has_include(<permission_handler_apple/PermissionHandlerPlugin.h>)
+#import <permission_handler_apple/PermissionHandlerPlugin.h>
+#else
+@import permission_handler_apple;
+#endif
+
 #if __has_include(<shared_preferences_foundation/SharedPreferencesPlugin.h>)
 #import <shared_preferences_foundation/SharedPreferencesPlugin.h>
 #else
@@ -61,6 +67,7 @@
   [FGMGoogleMapsPlugin registerWithRegistrar:[registry registrarForPlugin:@"FGMGoogleMapsPlugin"]];
   [FLTGoogleSignInPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTGoogleSignInPlugin"]];
   [FPPPackageInfoPlusPlugin registerWithRegistrar:[registry registrarForPlugin:@"FPPPackageInfoPlusPlugin"]];
+  [PermissionHandlerPlugin registerWithRegistrar:[registry registrarForPlugin:@"PermissionHandlerPlugin"]];
   [SharedPreferencesPlugin registerWithRegistrar:[registry registrarForPlugin:@"SharedPreferencesPlugin"]];
   [SqflitePlugin registerWithRegistrar:[registry registrarForPlugin:@"SqflitePlugin"]];
   [URLLauncherPlugin registerWithRegistrar:[registry registrarForPlugin:@"URLLauncherPlugin"]];

--- a/ios/YABus/Info.plist
+++ b/ios/YABus/Info.plist
@@ -46,14 +46,18 @@
 		<true/>
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
+		<key>NSCameraUsageDescription</key>
+		<string>YABus can use the camera when you choose to take a new background photo.</string>
 		<key>NSPhotoLibraryUsageDescription</key>
-		<string>沒有相簿存取權限要怎麼選擇背景圖片呢 o(*￣▽￣*)ブ</string>
+		<string>YABus lets you choose a photo from your library for custom backgrounds.</string>
+		<key>NSUserNotificationsUsageDescription</key>
+		<string>YABus sends bus arrival and trip monitoring alerts when you enable them.</string>
 		<key>NSLocationWhenInUseUsageDescription</key>
-		<string>我需要定位權限才可以找附近站牌。</string>
+		<string>YABus uses your location to find nearby stops and suggest local transit data.</string>
 		<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-		<string>我需要持續取得定位，才能在背景更新乘車提醒與靈動島。</string>
+		<string>YABus uses background location to keep trip monitoring alerts accurate after you leave the app.</string>
 		<key>NSLocationAlwaysUsageDescription</key>
-		<string>我需要持續取得定位，才能在背景更新乘車提醒與靈動島。</string>
+		<string>YABus uses background location to keep trip monitoring alerts accurate after you leave the app.</string>
 		<key>UIApplicationSceneManifest</key>
 		<dict>
 			<key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/YABus/Info.plist
+++ b/ios/YABus/Info.plist
@@ -47,17 +47,17 @@
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
 		<key>NSCameraUsageDescription</key>
-		<string>YABus can use the camera when you choose to take a new background photo.</string>
+		<string>沒有相機權限要怎麼拍新的背景圖片呢 o(*￣▽￣*)ブ</string>
 		<key>NSPhotoLibraryUsageDescription</key>
-		<string>YABus lets you choose a photo from your library for custom backgrounds.</string>
+		<string>沒有相簿存取權限要怎麼選擇背景圖片呢 o(*￣▽￣*)ブ</string>
 		<key>NSUserNotificationsUsageDescription</key>
-		<string>YABus sends bus arrival and trip monitoring alerts when you enable them.</string>
+		<string>沒有通知權限要怎麼提醒你公車到了呢 o(*￣▽￣*)ブ</string>
 		<key>NSLocationWhenInUseUsageDescription</key>
-		<string>YABus uses your location to find nearby stops and suggest local transit data.</string>
+		<string>我需要定位權限才可以找附近站牌。</string>
 		<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-		<string>YABus uses background location to keep trip monitoring alerts accurate after you leave the app.</string>
+		<string>我需要持續取得定位，才能在背景更新乘車提醒與靈動島。</string>
 		<key>NSLocationAlwaysUsageDescription</key>
-		<string>YABus uses background location to keep trip monitoring alerts accurate after you leave the app.</string>
+		<string>我需要持續取得定位，才能在背景更新乘車提醒與靈動島。</string>
 		<key>UIApplicationSceneManifest</key>
 		<dict>
 			<key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/YABus/LiveActivityBridge.swift
+++ b/ios/YABus/LiveActivityBridge.swift
@@ -86,7 +86,6 @@ final class LiveActivityBridge {
     let lineHighlightedStopIndex = args["lineHighlightedStopIndex"] as? Int
     let modeLabel = args["modeLabel"] as? String
     let statusText = args["statusText"] as? String
-    let alertKind = args["alertKind"] as? String
 
     let etaSeconds = args["etaSeconds"] as? Int
     let etaMessage = args["etaMessage"] as? String
@@ -144,7 +143,7 @@ final class LiveActivityBridge {
 
   private func handleUpdate(call: FlutterMethodCall, result: @escaping FlutterResult) {
     guard #available(iOS 16.2, *) else {
-      result(nil)
+      result(false)
       return
     }
 
@@ -191,13 +190,16 @@ final class LiveActivityBridge {
 
     Task {
       guard let activityId = currentActivityId else {
-        await MainActor.run { result(nil) }
+        await MainActor.run { result(false) }
         return
       }
 
       let activities = Activity<BusArrivalAttributes>.activities
       guard let activity = activities.first(where: { $0.id == activityId }) else {
-        await MainActor.run { result(nil) }
+        // The activity was dismissed or replaced; let Dart know so it can
+        // restart instead of assuming the update succeeded.
+        currentActivityId = nil
+        await MainActor.run { result(false) }
         return
       }
 
@@ -213,7 +215,7 @@ final class LiveActivityBridge {
       } else {
         await activity.update(content)
       }
-      await MainActor.run { result(nil) }
+      await MainActor.run { result(true) }
     }
   }
 

--- a/ios/YABus/LiveActivityBridge.swift
+++ b/ios/YABus/LiveActivityBridge.swift
@@ -78,6 +78,7 @@ final class LiveActivityBridge {
     let pathId = args["pathId"] as? Int ?? 0
     let displayStopId = args["displayStopId"] as? Int ?? 0
     let displayStopName = args["displayStopName"] as? String ?? ""
+    let alertStopName = args["alertStopName"] as? String
     let previousStopName = args["previousStopName"] as? String
     let nextStopName = args["nextStopName"] as? String
     let lineStopNames = args["lineStopNames"] as? [String] ?? []
@@ -106,6 +107,7 @@ final class LiveActivityBridge {
     let state = BusArrivalAttributes.ContentState(
       displayStopId: displayStopId,
       displayStopName: displayStopName,
+      alertStopName: alertStopName,
       previousStopName: previousStopName,
       nextStopName: nextStopName,
       lineStopNames: lineStopNames,
@@ -153,6 +155,7 @@ final class LiveActivityBridge {
 
     let displayStopId = args["displayStopId"] as? Int ?? 0
     let displayStopName = args["displayStopName"] as? String ?? ""
+    let alertStopName = args["alertStopName"] as? String
     let previousStopName = args["previousStopName"] as? String
     let nextStopName = args["nextStopName"] as? String
     let lineStopNames = args["lineStopNames"] as? [String] ?? []
@@ -170,6 +173,7 @@ final class LiveActivityBridge {
     let state = BusArrivalAttributes.ContentState(
       displayStopId: displayStopId,
       displayStopName: displayStopName,
+      alertStopName: alertStopName,
       previousStopName: previousStopName,
       nextStopName: nextStopName,
       lineStopNames: lineStopNames,
@@ -247,6 +251,7 @@ final class LiveActivityBridge {
     let finalState = BusArrivalAttributes.ContentState(
       displayStopId: 0,
       displayStopName: "",
+      alertStopName: nil,
       previousStopName: nil,
       nextStopName: nil,
       lineStopNames: [],
@@ -288,11 +293,12 @@ final class LiveActivityBridge {
     kind: String?,
     state: BusArrivalAttributes.ContentState
   ) -> AlertConfiguration? {
+    let stopName = state.alertStopName ?? state.displayStopName
     switch kind {
     case "boarding_imminent":
       return AlertConfiguration(
         title: "快到站了",
-        body: "\(state.displayStopName) 即將到站",
+        body: "\(stopName) 即將到站",
         sound: .default
       )
     case "boarded_no_destination":
@@ -304,13 +310,13 @@ final class LiveActivityBridge {
     case "destination_imminent":
       return AlertConfiguration(
         title: "準備下車",
-        body: "再幾站就到 \(state.displayStopName)",
+        body: "再幾站就到 \(stopName)",
         sound: .default
       )
     case "destination_arriving":
       return AlertConfiguration(
         title: "快到站了",
-        body: "\(state.displayStopName) 快到了",
+        body: "\(stopName) 快到了",
         sound: .default
       )
     default:

--- a/ios/YABus/SceneDelegate.swift
+++ b/ios/YABus/SceneDelegate.swift
@@ -30,11 +30,6 @@ class SceneDelegate: FlutterSceneDelegate {
     configureBridgesIfNeeded()
   }
 
-  override func sceneDidDisconnect(_ scene: UIScene) {
-    LiveActivityBridge.shared.endAllActivitiesFromHost()
-    super.sceneDidDisconnect(scene)
-  }
-
   private func configureBridgesIfNeeded() {
     guard
       let flutterViewController = resolveFlutterViewController(

--- a/ios/YABusTests/YABusTests.swift
+++ b/ios/YABusTests/YABusTests.swift
@@ -31,6 +31,7 @@ class YABusTests: XCTestCase {
     let state = BusArrivalAttributes.ContentState(
       displayStopId: 100,
       displayStopName: "臺北車站",
+      alertStopName: "臺北車站",
       previousStopName: "善導寺",
       nextStopName: "西門町",
       lineStopNames: ["善導寺", "臺北車站", "西門町"],
@@ -54,6 +55,7 @@ class YABusTests: XCTestCase {
 
     XCTAssertEqual(decoded.displayStopId, 100)
     XCTAssertEqual(decoded.displayStopName, "臺北車站")
+    XCTAssertEqual(decoded.alertStopName, "臺北車站")
     XCTAssertEqual(decoded.previousStopName, "善導寺")
     XCTAssertEqual(decoded.nextStopName, "西門町")
     XCTAssertEqual(decoded.lineStopNames, ["善導寺", "臺北車站", "西門町"])
@@ -73,6 +75,7 @@ class YABusTests: XCTestCase {
     let state = BusArrivalAttributes.ContentState(
       displayStopId: 101,
       displayStopName: "西門町",
+      alertStopName: nil,
       previousStopName: "臺北車站",
       nextStopName: "龍山寺",
       lineStopNames: ["臺北車站", "西門町", "龍山寺"],
@@ -94,6 +97,7 @@ class YABusTests: XCTestCase {
 
     XCTAssertEqual(decoded.displayStopId, 101)
     XCTAssertEqual(decoded.displayStopName, "西門町")
+    XCTAssertNil(decoded.alertStopName)
     XCTAssertEqual(decoded.previousStopName, "臺北車站")
     XCTAssertEqual(decoded.nextStopName, "龍山寺")
     XCTAssertEqual(decoded.lineStopNames, ["臺北車站", "西門町", "龍山寺"])
@@ -111,6 +115,7 @@ class YABusTests: XCTestCase {
     let state1 = BusArrivalAttributes.ContentState(
       displayStopId: 102,
       displayStopName: "龍山寺",
+      alertStopName: "龍山寺",
       previousStopName: "西門町",
       nextStopName: "江子翠",
       lineStopNames: ["西門町", "龍山寺", "江子翠"],
@@ -129,6 +134,7 @@ class YABusTests: XCTestCase {
     let state2 = BusArrivalAttributes.ContentState(
       displayStopId: 102,
       displayStopName: "龍山寺",
+      alertStopName: "龍山寺",
       previousStopName: "西門町",
       nextStopName: "江子翠",
       lineStopNames: ["西門町", "龍山寺", "江子翠"],
@@ -153,6 +159,7 @@ class YABusTests: XCTestCase {
     let state = BusArrivalAttributes.ContentState(
       displayStopId: 102,
       displayStopName: "龍山寺",
+      alertStopName: nil,
       previousStopName: "西門町",
       nextStopName: "江子翠",
       lineStopNames: ["西門町", "龍山寺", "江子翠"],
@@ -180,6 +187,7 @@ class YABusTests: XCTestCase {
     let state = BusArrivalAttributes.ContentState(
       displayStopId: 101,
       displayStopName: "西門町",
+      alertStopName: nil,
       previousStopName: "臺北車站",
       nextStopName: "龍山寺",
       lineStopNames: ["臺北車站", "西門町", "龍山寺"],
@@ -203,6 +211,7 @@ class YABusTests: XCTestCase {
     let state = BusArrivalAttributes.ContentState(
       displayStopId: 103,
       displayStopName: "板橋公車站",
+      alertStopName: nil,
       previousStopName: "江子翠",
       nextStopName: "新埔",
       lineStopNames: ["江子翠", "板橋公車站", "新埔"],

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -20,7 +20,7 @@ struct BusArrivalLiveActivity: Widget {
         DynamicIslandExpandedRegion(.bottom) {
           expandedBottom(context: context)
             .padding(.horizontal, 10)
-            .padding(.bottom, 4)
+            .padding(.bottom, 8)
         }
       } compactLeading: {
         compactLeadingView(context: context)
@@ -151,10 +151,13 @@ struct BusArrivalLiveActivity: Widget {
 
       HStack {
         if let statusText = trimmedText(context.state.statusText) {
-          Text(statusText)
-            .font(.system(size: 11, weight: .medium))
-            .foregroundStyle(.secondary)
+          Text(dynamicIslandStatusText(statusText))
+            .font(.system(size: 10.5, weight: .semibold))
+            .foregroundStyle(.primary.opacity(0.78))
             .lineLimit(1)
+            .minimumScaleFactor(0.72)
+            .allowsTightening(true)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         Spacer(minLength: 6)
         Text(context.state.updatedAt, style: .time)
@@ -378,7 +381,11 @@ struct BusArrivalLiveActivity: Widget {
       .minimumScaleFactor(0.7)
       .lineSpacing(-1)
       .multilineTextAlignment(.center)
-      .frame(maxWidth: .infinity, minHeight: 28, alignment: .top)
+      .frame(
+        maxWidth: .infinity,
+        minHeight: surface == .dynamicIsland ? 23 : 28,
+        alignment: .top
+      )
   }
 
   private func stopLineData(
@@ -462,6 +469,51 @@ struct BusArrivalLiveActivity: Widget {
     }
 
     return String(candidate.prefix(4)) + "…"
+  }
+
+  private func dynamicIslandStatusText(_ statusText: String) -> String {
+    let parts = statusText
+      .components(separatedBy: " · ")
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+
+    guard !parts.isEmpty else {
+      return statusText
+    }
+
+    var selected: [String] = []
+    if let destination = parts.first(where: { $0.hasPrefix("目的地 ") }) {
+      selected.append(destination)
+    } else if let boarding = parts.first(where: { $0.hasPrefix("上車站 ") }) {
+      selected.append(boarding)
+    } else if let nearest = parts.first(where: { $0.hasPrefix("最近站牌 ") }) {
+      selected.append(nearest)
+    } else {
+      selected.append(parts[0])
+    }
+
+    if let eta = parts.first(where: isCompactEtaStatusPart), !selected.contains(eta) {
+      selected.append(eta)
+    } else if let busSummary = parts.first(where: { $0.hasPrefix("公車") }), !selected.contains(busSummary) {
+      selected.append(busSummary)
+    }
+
+    return selected.joined(separator: " · ")
+  }
+
+  private func isCompactEtaStatusPart(_ value: String) -> Bool {
+    if value.hasPrefix("目的地 ") ||
+      value.hasPrefix("上車站 ") ||
+      value.hasPrefix("最近站牌 ") ||
+      value.hasPrefix("公車") {
+      return false
+    }
+
+    return value.contains("秒") ||
+      value.contains("分") ||
+      value.contains("進站") ||
+      value.contains("發車") ||
+      value.contains("末班")
   }
 
   private func trimmedText(_ value: String?) -> String? {
@@ -658,70 +710,83 @@ private struct LockScreenActivityView: View {
   @Environment(\.colorScheme) private var colorScheme
 
   var body: some View {
-    HStack(spacing: 16) {
-      VStack(alignment: .leading, spacing: 6) {
-        HStack(spacing: 8) {
-          lsRouteBadge(context.attributes.routeName)
-          Text(context.attributes.pathName)
-            .font(.system(size: 13, weight: .medium))
-            .foregroundStyle(lsSecondaryTextColor)
-            .lineLimit(1)
-        }
-
-        if let modeLabel = lsTrimmed(context.state.modeLabel) {
-          lsModePill(modeLabel)
-        }
-
-        HStack(spacing: 5) {
-          Image(systemName: "mappin.circle.fill")
-            .font(.system(size: 14))
-            .foregroundStyle(lsHighlightTextColor)
-          Text(lsDisplayStopName(context.state))
-            .font(.system(size: 16, weight: .semibold))
-            .foregroundStyle(lsPrimaryTextColor)
-            .lineLimit(1)
-        }
-
-        if let statusText = lsTrimmed(context.state.statusText) {
-          Text(statusText)
-            .font(.system(size: 12, weight: .medium))
-            .foregroundStyle(lsSecondaryTextColor)
-            .lineLimit(2)
-        }
-
-        lsStopLineView(context.state)
-          .padding(.top, 4)
-      }
-
-      Spacer(minLength: 8)
-
-      VStack(alignment: .trailing, spacing: 4) {
-        lsCountdownText(
-          context.state,
-          font: .system(size: 32, weight: .bold, design: .rounded)
-        )
-        .foregroundStyle(lsEtaColor(context.state))
-        .lineLimit(1)
-        .minimumScaleFactor(0.5)
-        .monospacedDigit()
-
-        if let vehicleId = lsTrimmed(context.state.vehicleId) {
-          HStack(spacing: 3) {
-            Image(systemName: "bus")
-              .font(.system(size: 10))
-            Text(vehicleId)
-              .font(.system(size: 11, weight: .medium, design: .monospaced))
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 8) {
+          HStack(spacing: 8) {
+            lsRouteBadge(context.attributes.routeName)
+            Text(context.attributes.pathName)
+              .font(.system(size: 13, weight: .medium))
+              .foregroundStyle(lsSecondaryTextColor)
+              .lineLimit(1)
+              .minimumScaleFactor(0.8)
           }
-          .foregroundStyle(lsSecondaryTextColor)
-        }
 
-        Text(context.state.updatedAt, style: .time)
-          .font(.system(size: 11, weight: .medium, design: .monospaced))
-          .foregroundStyle(lsTimestampTextColor)
+          if let modeLabel = lsTrimmed(context.state.modeLabel) {
+            lsModePill(modeLabel)
+          }
+
+          HStack(spacing: 5) {
+            Image(systemName: "mappin.circle.fill")
+              .font(.system(size: 14))
+              .foregroundStyle(lsHighlightTextColor)
+            Text(lsDisplayStopName(context.state))
+              .font(.system(size: 16, weight: .semibold))
+              .foregroundStyle(lsPrimaryTextColor)
+              .lineLimit(1)
+              .minimumScaleFactor(0.82)
+          }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+
+        VStack(alignment: .trailing, spacing: 5) {
+          lsCountdownText(
+            context.state,
+            font: .system(size: 30, weight: .bold, design: .rounded)
+          )
+          .foregroundStyle(lsEtaColor(context.state))
+          .lineLimit(1)
+          .minimumScaleFactor(0.48)
+          .monospacedDigit()
+          .padding(.horizontal, 12)
+          .padding(.vertical, 5)
+          .frame(minWidth: 108, alignment: .trailing)
+          .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+              .fill(lsEtaColor(context.state).opacity(colorScheme == .dark ? 0.18 : 0.16))
+          )
+
+          if let vehicleId = lsTrimmed(context.state.vehicleId) {
+            HStack(spacing: 3) {
+              Image(systemName: "bus")
+                .font(.system(size: 10))
+              Text(vehicleId)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .lineLimit(1)
+            }
+            .foregroundStyle(lsSecondaryTextColor)
+          }
+
+          Text(context.state.updatedAt, style: .time)
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .foregroundStyle(lsTimestampTextColor)
+        }
       }
+
+      if let statusText = lsTrimmed(context.state.statusText) {
+        Text(statusText)
+          .font(.system(size: 12, weight: .medium))
+          .foregroundStyle(lsSecondaryTextColor)
+          .lineLimit(2)
+          .minimumScaleFactor(0.82)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
+      lsStopLineView(context.state)
+        .padding(.top, 2)
     }
     .padding(.horizontal, 20)
-    .padding(.vertical, 14)
+    .padding(.vertical, 16)
     .widgetURL(
       BusArrivalDeepLink.route(
         provider: context.attributes.provider,

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -215,27 +215,24 @@ struct BusArrivalLiveActivity: Widget {
       VStack(spacing: 6) {
         HStack(spacing: 0) {
           ForEach(stopLine.stopNames.indices, id: \.self) { index in
-            routeStopColumnMarker(
+            stopMarker(
               isCurrent: index == stopLine.currentStopIndex,
               isHighlighted: index == stopLine.highlightedStopIndex,
-              previousConnectorVisible: index > 0,
-              nextConnectorVisible: index < stopLine.stopNames.count - 1,
-              previousConnectorIntensity: stopConnectorOpacity(
-                currentStopIndex: stopLine.currentStopIndex,
-                connectorIndex: index - 1
-              ),
-              nextConnectorIntensity: stopConnectorOpacity(
-                currentStopIndex: stopLine.currentStopIndex,
-                connectorIndex: index
-              ),
-              etaLabel: index == stopLine.currentStopIndex
-                ? routeBarEtaLabel(state)
-                : nil,
-              state: state,
               surface: surface,
               colorScheme: colorScheme
             )
-            .frame(maxWidth: .infinity)
+            .frame(width: 18)
+
+            if index < stopLine.stopNames.count - 1 {
+              stopConnector(
+                intensity: stopConnectorOpacity(
+                  currentStopIndex: stopLine.currentStopIndex,
+                  connectorIndex: index
+                ),
+                surface: surface,
+                colorScheme: colorScheme
+              )
+            }
           }
         }
 
@@ -257,24 +254,8 @@ struct BusArrivalLiveActivity: Widget {
       let currentStopName = displayStopName(state)
 
       if previousStopName == nil && nextStopName == nil {
-        VStack(spacing: 6) {
-          HStack(spacing: 0) {
-            Spacer(minLength: 0)
-            routeStopColumnMarker(
-              isCurrent: true,
-              isHighlighted: true,
-              previousConnectorVisible: false,
-              nextConnectorVisible: false,
-              previousConnectorIntensity: 0,
-              nextConnectorIntensity: 0,
-              etaLabel: routeBarEtaLabel(state),
-              state: state,
-              surface: surface,
-              colorScheme: colorScheme
-            )
-            .frame(maxWidth: .infinity)
-            Spacer(minLength: 0)
-          }
+        HStack {
+          Spacer(minLength: 0)
           stopLineLabel(
             currentStopName,
             isCurrent: true,
@@ -282,52 +263,22 @@ struct BusArrivalLiveActivity: Widget {
             surface: surface,
             colorScheme: colorScheme
           )
+          Spacer(minLength: 0)
         }
       } else {
         VStack(spacing: 6) {
           HStack(spacing: 0) {
-            routeStopColumnMarker(
-              isCurrent: false,
-              isHighlighted: false,
-              previousConnectorVisible: false,
-              nextConnectorVisible: true,
-              previousConnectorIntensity: 0,
-              nextConnectorIntensity: 0.4,
-              etaLabel: nil,
-              state: state,
-              surface: surface,
-              colorScheme: colorScheme
-            )
-            .frame(maxWidth: .infinity)
-            routeStopColumnMarker(
-              isCurrent: true,
-              isHighlighted: true,
-              previousConnectorVisible: true,
-              nextConnectorVisible: true,
-              previousConnectorIntensity: 0.4,
-              nextConnectorIntensity: 0.22,
-              etaLabel: routeBarEtaLabel(state),
-              state: state,
-              surface: surface,
-              colorScheme: colorScheme
-            )
-            .frame(maxWidth: .infinity)
-            routeStopColumnMarker(
-              isCurrent: false,
-              isHighlighted: false,
-              previousConnectorVisible: true,
-              nextConnectorVisible: false,
-              previousConnectorIntensity: 0.22,
-              nextConnectorIntensity: 0,
-              etaLabel: nil,
-              state: state,
-              surface: surface,
-              colorScheme: colorScheme
-            )
-            .frame(maxWidth: .infinity)
+            stopMarker(isCurrent: false, isHighlighted: false, surface: surface, colorScheme: colorScheme)
+              .frame(width: 18)
+            stopConnector(intensity: 0.4, surface: surface, colorScheme: colorScheme)
+            stopMarker(isCurrent: true, isHighlighted: true, surface: surface, colorScheme: colorScheme)
+              .frame(width: 18)
+            stopConnector(intensity: 0.22, surface: surface, colorScheme: colorScheme)
+            stopMarker(isCurrent: false, isHighlighted: false, surface: surface, colorScheme: colorScheme)
+              .frame(width: 18)
           }
 
-          HStack(alignment: .top, spacing: 8) {
+          HStack(alignment: .center, spacing: 8) {
             stopLineLabel(
               previousStopName ?? "起點",
               isCurrent: false,
@@ -398,73 +349,6 @@ struct BusArrivalLiveActivity: Widget {
       .frame(maxWidth: .infinity)
       .frame(height: 2)
       .padding(.horizontal, 4)
-  }
-
-  @ViewBuilder
-  private func routeStopColumnMarker(
-    isCurrent: Bool,
-    isHighlighted: Bool,
-    previousConnectorVisible: Bool,
-    nextConnectorVisible: Bool,
-    previousConnectorIntensity: Double,
-    nextConnectorIntensity: Double,
-    etaLabel: String?,
-    state: BusArrivalAttributes.ContentState,
-    surface: ActivitySurface,
-    colorScheme: ColorScheme = .dark
-  ) -> some View {
-    VStack(spacing: 1) {
-      ZStack {
-        HStack(spacing: 0) {
-          stopHalfConnector(
-            visible: previousConnectorVisible,
-            intensity: previousConnectorIntensity,
-            surface: surface,
-            colorScheme: colorScheme
-          )
-          stopHalfConnector(
-            visible: nextConnectorVisible,
-            intensity: nextConnectorIntensity,
-            surface: surface,
-            colorScheme: colorScheme
-          )
-        }
-
-        stopMarker(
-          isCurrent: isCurrent,
-          isHighlighted: isHighlighted,
-          surface: surface,
-          colorScheme: colorScheme
-        )
-      }
-      .frame(height: 20)
-
-      if let etaLabel {
-        Text(etaLabel)
-          .font(.system(size: 10, weight: .bold, design: .rounded))
-          .foregroundStyle(etaColor(state))
-          .lineLimit(1)
-          .minimumScaleFactor(0.6)
-          .monospacedDigit()
-      }
-    }
-  }
-
-  @ViewBuilder
-  private func stopHalfConnector(
-    visible: Bool,
-    intensity: Double,
-    surface: ActivitySurface,
-    colorScheme: ColorScheme = .dark
-  ) -> some View {
-    Rectangle()
-      .fill(
-        visible
-          ? stopConnectorColor(surface: surface, intensity: intensity, colorScheme: colorScheme)
-          : Color.clear
-      )
-      .frame(maxWidth: .infinity)
-      .frame(height: 2)
   }
 
   @ViewBuilder
@@ -743,25 +627,6 @@ struct BusArrivalLiveActivity: Widget {
     }
 
     return nil
-  }
-
-  /// Short ETA text shown under the current stop dot in the route bar.
-  private func routeBarEtaLabel(
-    _ state: BusArrivalAttributes.ContentState
-  ) -> String? {
-    if let msg = trimmedText(state.etaMessage) {
-      return msg.count > 4 ? String(msg.prefix(4)) : msg
-    }
-    guard let sec = state.etaSeconds else {
-      return nil
-    }
-    if sec <= 0 {
-      return "進站"
-    }
-    if sec < 60 {
-      return "\(sec)秒"
-    }
-    return "\(sec / 60)分"
   }
 
   private func etaColor(_ state: BusArrivalAttributes.ContentState) -> Color {

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -37,18 +37,36 @@ struct BusArrivalLiveActivity: Widget {
   private func compactLeadingView(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    Text(compactRouteName(context.attributes.routeName))
-      .font(.system(size: 12, weight: .heavy, design: .rounded))
-      .foregroundStyle(.white)
-      .lineLimit(1)
-      .minimumScaleFactor(0.55)
-      .padding(.horizontal, 7)
-      .padding(.vertical, 2)
-      .background(
-        Capsule(style: .continuous)
-          .fill(etaColor(context.state).opacity(0.9))
-      )
-      .frame(maxWidth: 56, alignment: .leading)
+    HStack(spacing: 4) {
+      Circle()
+        .fill(Color.white.opacity(0.92))
+        .frame(width: 4.5, height: 4.5)
+      Text(compactRouteName(context.attributes.routeName))
+        .font(.system(size: 12, weight: .heavy, design: .rounded))
+        .foregroundStyle(.white)
+        .lineLimit(1)
+        .minimumScaleFactor(0.55)
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 3)
+    .background(
+      Capsule(style: .continuous)
+        .fill(
+          LinearGradient(
+            colors: [
+              etaColor(context.state),
+              etaColor(context.state).opacity(0.78),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+          )
+        )
+    )
+    .overlay(
+      Capsule(style: .continuous)
+        .stroke(Color.white.opacity(0.16), lineWidth: 0.6)
+    )
+    .frame(maxWidth: 58, alignment: .leading)
   }
 
   @ViewBuilder
@@ -64,7 +82,17 @@ struct BusArrivalLiveActivity: Widget {
     .lineLimit(1)
     .minimumScaleFactor(0.45)
     .monospacedDigit()
-    .frame(width: 58, alignment: .trailing)
+    .padding(.horizontal, 8)
+    .padding(.vertical, 3)
+    .background(
+      Capsule(style: .continuous)
+        .fill(etaColor(context.state).opacity(0.14))
+    )
+    .overlay(
+      Capsule(style: .continuous)
+        .stroke(etaColor(context.state).opacity(0.28), lineWidth: 0.6)
+    )
+    .frame(minWidth: 58, alignment: .trailing)
   }
 
   @ViewBuilder
@@ -73,7 +101,9 @@ struct BusArrivalLiveActivity: Widget {
   ) -> some View {
     ZStack {
       Circle()
-        .fill(etaColor(context.state).opacity(0.25))
+        .fill(etaColor(context.state).opacity(0.18))
+      Circle()
+        .stroke(etaColor(context.state).opacity(0.4), lineWidth: 1.2)
       countdownText(
         context.state,
         style: .minimal,
@@ -89,19 +119,21 @@ struct BusArrivalLiveActivity: Widget {
   private func expandedLeading(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    VStack(alignment: .leading, spacing: 4) {
-      HStack(spacing: 6) {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .top, spacing: 8) {
         routeBadge(context.attributes.routeName, surface: .dynamicIsland)
-        Text(context.attributes.pathName)
-          .font(.system(size: 12, weight: .medium))
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
-          .minimumScaleFactor(0.8)
-          .truncationMode(.tail)
-      }
+        VStack(alignment: .leading, spacing: 4) {
+          Text(context.attributes.pathName)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+            .truncationMode(.tail)
 
-      if let modeLabel = trimmedText(context.state.modeLabel) {
-        modePill(modeLabel, surface: .dynamicIsland)
+          if let modeLabel = trimmedText(context.state.modeLabel) {
+            modePill(modeLabel, surface: .dynamicIsland)
+          }
+        }
       }
 
       HStack(spacing: 5) {
@@ -112,6 +144,12 @@ struct BusArrivalLiveActivity: Widget {
           .font(.system(size: 14, weight: .semibold))
           .lineLimit(1)
       }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 7)
+      .background(
+        RoundedRectangle(cornerRadius: 11, style: .continuous)
+          .fill(Color.white.opacity(0.08))
+      )
     }
   }
 
@@ -119,16 +157,32 @@ struct BusArrivalLiveActivity: Widget {
   private func expandedTrailing(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    VStack(alignment: .trailing, spacing: 2) {
-      countdownText(
-        context.state,
-        style: .expanded,
-        font: .system(size: 24, weight: .bold, design: .rounded)
+    VStack(alignment: .trailing, spacing: 6) {
+      VStack(alignment: .trailing, spacing: 2) {
+        Text("到站")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(etaColor(context.state).opacity(0.9))
+
+        countdownText(
+          context.state,
+          style: .expanded,
+          font: .system(size: 24, weight: .bold, design: .rounded)
+        )
+        .foregroundStyle(etaColor(context.state))
+        .lineLimit(1)
+        .minimumScaleFactor(0.6)
+        .monospacedDigit()
+      }
+      .padding(.horizontal, 10)
+      .padding(.vertical, 8)
+      .background(
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .fill(etaColor(context.state).opacity(0.14))
       )
-      .foregroundStyle(etaColor(context.state))
-      .lineLimit(1)
-      .minimumScaleFactor(0.6)
-      .monospacedDigit()
+      .overlay(
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .stroke(etaColor(context.state).opacity(0.28), lineWidth: 0.7)
+      )
 
       if let vehicleId = trimmedText(context.state.vehicleId) {
         HStack(spacing: 3) {
@@ -139,6 +193,12 @@ struct BusArrivalLiveActivity: Widget {
             .lineLimit(1)
         }
         .foregroundStyle(.secondary)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+          Capsule(style: .continuous)
+            .fill(Color.white.opacity(0.08))
+        )
       }
     }
   }
@@ -147,8 +207,14 @@ struct BusArrivalLiveActivity: Widget {
   private func expandedBottom(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    VStack(spacing: 5) {
+    VStack(spacing: 8) {
       stopLineView(context.state, surface: .dynamicIsland)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 8)
+        .background(
+          RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(Color.white.opacity(0.08))
+        )
 
       HStack {
         if let statusText = trimmedText(context.state.statusText) {
@@ -160,12 +226,22 @@ struct BusArrivalLiveActivity: Widget {
             .truncationMode(.tail)
         }
         Spacer(minLength: 6)
-        Text(context.state.updatedAt, style: .time)
-          .font(.system(size: 11, weight: .medium, design: .monospaced))
-          .foregroundStyle(Color(white: 0.5))
-          .lineLimit(1)
-          .fixedSize(horizontal: true, vertical: false)
-          .layoutPriority(1)
+        HStack(spacing: 4) {
+          Image(systemName: "clock")
+            .font(.system(size: 9, weight: .semibold))
+          Text(context.state.updatedAt, style: .time)
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+        }
+        .foregroundStyle(Color(white: 0.5))
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+          Capsule(style: .continuous)
+            .fill(Color.white.opacity(0.06))
+        )
+        .layoutPriority(1)
       }
       .padding(.horizontal, 2)
     }
@@ -183,10 +259,10 @@ struct BusArrivalLiveActivity: Widget {
       .foregroundStyle(routeBadgeTextColor(surface: surface))
       .lineLimit(1)
       .minimumScaleFactor(0.7)
-      .padding(.horizontal, 8)
-      .padding(.vertical, 3)
+      .padding(.horizontal, 9)
+      .padding(.vertical, 4)
       .background(
-        RoundedRectangle(cornerRadius: 6, style: .continuous)
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
           .fill(
             LinearGradient(
               colors: [Color(red: 0.0, green: 0.7, blue: 0.8), Color(red: 0.0, green: 0.55, blue: 0.75)],
@@ -194,6 +270,10 @@ struct BusArrivalLiveActivity: Widget {
               endPoint: .bottomTrailing
             )
           )
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+          .stroke(Color.white.opacity(0.16), lineWidth: 0.7)
       )
   }
 
@@ -207,6 +287,10 @@ struct BusArrivalLiveActivity: Widget {
       .background(
         Capsule(style: .continuous)
           .fill(modePillBackgroundColor(surface: surface, colorScheme: colorScheme))
+      )
+      .overlay(
+        Capsule(style: .continuous)
+          .stroke((surface == .dynamicIsland ? Color.white : lockScreenPrimaryTextColor(colorScheme: colorScheme)).opacity(0.1), lineWidth: 0.6)
       )
   }
 
@@ -701,72 +785,134 @@ private struct LockScreenActivityView: View {
   @Environment(\.colorScheme) private var colorScheme
 
   var body: some View {
-    HStack(spacing: 16) {
-      VStack(alignment: .leading, spacing: 6) {
-        HStack(spacing: 8) {
-          lsRouteBadge(context.attributes.routeName)
-          Text(context.attributes.pathName)
-            .font(.system(size: 13, weight: .medium))
-            .foregroundStyle(lsSecondaryTextColor)
+    ZStack {
+      RoundedRectangle(cornerRadius: 24, style: .continuous)
+        .fill(lsCardFillColor)
+      RoundedRectangle(cornerRadius: 24, style: .continuous)
+        .stroke(lsCardStrokeColor, lineWidth: 1)
+
+      HStack(spacing: 16) {
+        VStack(alignment: .leading, spacing: 10) {
+          HStack(alignment: .top, spacing: 10) {
+            lsRouteBadge(context.attributes.routeName)
+
+            VStack(alignment: .leading, spacing: 6) {
+              Text(context.attributes.pathName)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(lsSecondaryTextColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .truncationMode(.tail)
+
+              if let modeLabel = lsTrimmed(context.state.modeLabel) {
+                lsModePill(modeLabel)
+              }
+            }
+          }
+
+          HStack(spacing: 6) {
+            Image(systemName: "mappin.circle.fill")
+              .font(.system(size: 14))
+              .foregroundStyle(lsHighlightTextColor)
+            Text(lsDisplayStopName(context.state))
+              .font(.system(size: 16, weight: .semibold))
+              .foregroundStyle(lsPrimaryTextColor)
+              .lineLimit(1)
+          }
+          .padding(.horizontal, 10)
+          .padding(.vertical, 8)
+          .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+              .fill(lsSectionFillColor)
+          )
+
+          if let statusText = lsTrimmed(context.state.statusText) {
+            Text(statusText)
+              .font(.system(size: 12, weight: .medium))
+              .foregroundStyle(lsSecondaryTextColor)
+              .lineLimit(2)
+              .minimumScaleFactor(0.9)
+              .padding(.horizontal, 10)
+              .padding(.vertical, 8)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                  .fill(lsSectionFillColor)
+              )
+          }
+
+          lsStopLineView(context.state)
+            .padding(.horizontal, 10)
+            .padding(.top, 10)
+            .padding(.bottom, 8)
+            .background(
+              RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(lsSectionFillColor)
+            )
+        }
+
+        VStack(alignment: .trailing, spacing: 8) {
+          VStack(alignment: .trailing, spacing: 4) {
+            Text("到站")
+              .font(.system(size: 11, weight: .semibold))
+              .foregroundStyle(lsEtaColor(context.state).opacity(0.9))
+
+            lsCountdownText(
+              context.state,
+              font: .system(size: 32, weight: .bold, design: .rounded)
+            )
+            .foregroundStyle(lsEtaColor(context.state))
             .lineLimit(1)
-            .minimumScaleFactor(0.8)
-            .truncationMode(.tail)
-        }
+            .minimumScaleFactor(0.5)
+            .monospacedDigit()
+          }
+          .padding(.horizontal, 12)
+          .padding(.vertical, 10)
+          .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+              .fill(lsEtaPanelFillColor)
+          )
+          .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+              .stroke(lsEtaPanelStrokeColor, lineWidth: 1)
+          )
 
-        if let modeLabel = lsTrimmed(context.state.modeLabel) {
-          lsModePill(modeLabel)
-        }
-
-        HStack(spacing: 5) {
-          Image(systemName: "mappin.circle.fill")
-            .font(.system(size: 14))
-            .foregroundStyle(lsHighlightTextColor)
-          Text(lsDisplayStopName(context.state))
-            .font(.system(size: 16, weight: .semibold))
-            .foregroundStyle(lsPrimaryTextColor)
-            .lineLimit(1)
-        }
-
-        if let statusText = lsTrimmed(context.state.statusText) {
-          Text(statusText)
-            .font(.system(size: 12, weight: .medium))
+          if let vehicleId = lsTrimmed(context.state.vehicleId) {
+            HStack(spacing: 4) {
+              Image(systemName: "bus.fill")
+                .font(.system(size: 10))
+              Text(vehicleId)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+            }
             .foregroundStyle(lsSecondaryTextColor)
-            .lineLimit(2)
-        }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(
+              Capsule(style: .continuous)
+                .fill(lsSectionFillColor)
+            )
+          }
 
-        lsStopLineView(context.state)
-          .padding(.top, 4)
-      }
-
-      Spacer(minLength: 8)
-
-      VStack(alignment: .trailing, spacing: 4) {
-        lsCountdownText(
-          context.state,
-          font: .system(size: 32, weight: .bold, design: .rounded)
-        )
-        .foregroundStyle(lsEtaColor(context.state))
-        .lineLimit(1)
-        .minimumScaleFactor(0.5)
-        .monospacedDigit()
-
-        if let vehicleId = lsTrimmed(context.state.vehicleId) {
-          HStack(spacing: 3) {
-            Image(systemName: "bus")
-              .font(.system(size: 10))
-            Text(vehicleId)
+          HStack(spacing: 4) {
+            Image(systemName: "clock")
+              .font(.system(size: 9, weight: .semibold))
+            Text(context.state.updatedAt, style: .time)
               .font(.system(size: 11, weight: .medium, design: .monospaced))
           }
-          .foregroundStyle(lsSecondaryTextColor)
-        }
-
-        Text(context.state.updatedAt, style: .time)
-          .font(.system(size: 11, weight: .medium, design: .monospaced))
           .foregroundStyle(lsTimestampTextColor)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 5)
+          .background(
+            Capsule(style: .continuous)
+              .fill(lsSectionFillColor)
+          )
+        }
       }
+      .padding(.horizontal, 16)
+      .padding(.vertical, 16)
     }
-    .padding(.horizontal, 20)
-    .padding(.vertical, 14)
+    .padding(.horizontal, 6)
+    .padding(.vertical, 4)
     .widgetURL(
       BusArrivalDeepLink.route(
         provider: context.attributes.provider,
@@ -823,6 +969,32 @@ private struct LockScreenActivityView: View {
       : Color(red: 0.16, green: 0.22, blue: 0.31).opacity(0.1)
   }
 
+  private var lsCardFillColor: Color {
+    colorScheme == .dark
+      ? Color(red: 0.12, green: 0.16, blue: 0.24).opacity(0.96)
+      : Color.white.opacity(0.94)
+  }
+
+  private var lsCardStrokeColor: Color {
+    colorScheme == .dark
+      ? Color.white.opacity(0.08)
+      : Color(red: 0.16, green: 0.22, blue: 0.31).opacity(0.08)
+  }
+
+  private var lsSectionFillColor: Color {
+    colorScheme == .dark
+      ? Color.white.opacity(0.08)
+      : Color(red: 0.16, green: 0.22, blue: 0.31).opacity(0.06)
+  }
+
+  private var lsEtaPanelFillColor: Color {
+    lsEtaColor(context.state).opacity(colorScheme == .dark ? 0.16 : 0.12)
+  }
+
+  private var lsEtaPanelStrokeColor: Color {
+    lsEtaColor(context.state).opacity(colorScheme == .dark ? 0.34 : 0.22)
+  }
+
   // MARK: Helpers
 
   private func lsTrimmed(_ value: String?) -> String? {
@@ -853,10 +1025,10 @@ private struct LockScreenActivityView: View {
       .foregroundStyle(Color.white)
       .lineLimit(1)
       .minimumScaleFactor(0.7)
-      .padding(.horizontal, 8)
-      .padding(.vertical, 3)
+      .padding(.horizontal, 9)
+      .padding(.vertical, 4)
       .background(
-        RoundedRectangle(cornerRadius: 6, style: .continuous)
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
           .fill(
             LinearGradient(
               colors: [Color(red: 0.0, green: 0.7, blue: 0.8), Color(red: 0.0, green: 0.55, blue: 0.75)],
@@ -864,6 +1036,10 @@ private struct LockScreenActivityView: View {
               endPoint: .bottomTrailing
             )
           )
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+          .stroke(Color.white.opacity(0.16), lineWidth: 0.7)
       )
   }
 
@@ -877,6 +1053,10 @@ private struct LockScreenActivityView: View {
       .background(
         Capsule(style: .continuous)
           .fill(lsModePillBackgroundColor)
+      )
+      .overlay(
+        Capsule(style: .continuous)
+          .stroke(lsPrimaryTextColor.opacity(0.08), lineWidth: 0.6)
       )
   }
 

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -11,16 +11,15 @@ struct BusArrivalLiveActivity: Widget {
       DynamicIsland {
         DynamicIslandExpandedRegion(.leading) {
           expandedLeading(context: context)
-            .dynamicIsland(verticalPlacement: .belowIfTooWide)
-            .padding(.leading, 8)
+            .padding(.leading, 10)
         }
         DynamicIslandExpandedRegion(.trailing) {
           expandedTrailing(context: context)
-            .padding(.trailing, 8)
+            .padding(.trailing, 10)
         }
         DynamicIslandExpandedRegion(.bottom) {
           expandedBottom(context: context)
-            .padding(.horizontal, 8)
+            .padding(.horizontal, 10)
             .padding(.bottom, 4)
         }
       } compactLeading: {
@@ -38,29 +37,19 @@ struct BusArrivalLiveActivity: Widget {
   private func compactLeadingView(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    // Keep this as narrow as possible: the compact leading sits right next to
-    // the status-bar clock, so any extra width visually crowds the time.
     Text(compactRouteName(context.attributes.routeName))
       .font(.system(size: 12, weight: .heavy, design: .rounded))
       .foregroundStyle(.white)
       .lineLimit(1)
-      .minimumScaleFactor(0.6)
+      .minimumScaleFactor(0.55)
       .padding(.horizontal, 6)
       .padding(.vertical, 2)
       .background(
         Capsule(style: .continuous)
-          .fill(
-            LinearGradient(
-              colors: [
-                etaColor(context.state),
-                etaColor(context.state).opacity(0.78),
-              ],
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing
-            )
-          )
+          .fill(etaColor(context.state).opacity(0.9))
       )
-      .frame(maxWidth: 40, alignment: .center)
+      .frame(width: 42, alignment: .leading)
+      .clipped()
   }
 
   @ViewBuilder
@@ -76,13 +65,7 @@ struct BusArrivalLiveActivity: Widget {
     .lineLimit(1)
     .minimumScaleFactor(0.45)
     .monospacedDigit()
-    .padding(.horizontal, 6)
-    .padding(.vertical, 2)
-    .background(
-      Capsule(style: .continuous)
-        .fill(etaColor(context.state).opacity(0.14))
-    )
-    .frame(maxWidth: 52, alignment: .trailing)
+    .frame(width: 58, alignment: .trailing)
   }
 
   @ViewBuilder
@@ -91,9 +74,7 @@ struct BusArrivalLiveActivity: Widget {
   ) -> some View {
     ZStack {
       Circle()
-        .fill(etaColor(context.state).opacity(0.18))
-      Circle()
-        .stroke(etaColor(context.state).opacity(0.4), lineWidth: 1.2)
+        .fill(etaColor(context.state).opacity(0.25))
       countdownText(
         context.state,
         style: .minimal,
@@ -109,22 +90,26 @@ struct BusArrivalLiveActivity: Widget {
   private func expandedLeading(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    HStack(alignment: .center, spacing: 8) {
-      routeBadge(context.attributes.routeName, surface: .dynamicIsland)
-      VStack(alignment: .leading, spacing: 2) {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 6) {
+        routeBadge(context.attributes.routeName, surface: .dynamicIsland)
         Text(context.attributes.pathName)
-          .font(.system(size: 12, weight: .semibold))
+          .font(.system(size: 12, weight: .medium))
           .foregroundStyle(.secondary)
           .lineLimit(1)
-          .minimumScaleFactor(0.8)
-          .truncationMode(.tail)
+      }
 
-        if let modeLabel = trimmedText(context.state.modeLabel) {
-          Text(modeLabel)
-            .font(.system(size: 10, weight: .medium))
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-        }
+      if let modeLabel = trimmedText(context.state.modeLabel) {
+        modePill(modeLabel, surface: .dynamicIsland)
+      }
+
+      HStack(spacing: 5) {
+        Image(systemName: "mappin.circle.fill")
+          .font(.system(size: 13))
+          .foregroundStyle(.cyan)
+        Text(displayStopName(context.state))
+          .font(.system(size: 14, weight: .semibold))
+          .lineLimit(1)
       }
     }
   }
@@ -133,15 +118,11 @@ struct BusArrivalLiveActivity: Widget {
   private func expandedTrailing(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    VStack(alignment: .trailing, spacing: 1) {
-      Text("到站")
-        .font(.system(size: 9, weight: .semibold))
-        .foregroundStyle(etaColor(context.state).opacity(0.9))
-
+    VStack(alignment: .trailing, spacing: 2) {
       countdownText(
         context.state,
         style: .expanded,
-        font: .system(size: 22, weight: .bold, design: .rounded)
+        font: .system(size: 24, weight: .bold, design: .rounded)
       )
       .foregroundStyle(etaColor(context.state))
       .lineLimit(1)
@@ -151,214 +132,40 @@ struct BusArrivalLiveActivity: Widget {
       if let vehicleId = trimmedText(context.state.vehicleId) {
         HStack(spacing: 3) {
           Image(systemName: "bus")
-            .font(.system(size: 9))
+            .font(.system(size: 10))
           Text(vehicleId)
-            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
             .lineLimit(1)
         }
         .foregroundStyle(.secondary)
       }
     }
-    .fixedSize(horizontal: true, vertical: false)
   }
 
   @ViewBuilder
   private func expandedBottom(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    VStack(spacing: 6) {
-      busRouteBar(context.state, surface: .dynamicIsland)
+    VStack(spacing: 5) {
+      stopLineView(context.state, surface: .dynamicIsland)
 
-      if let statusText = trimmedText(context.state.statusText) {
-        HStack(spacing: 6) {
+      HStack {
+        if let statusText = trimmedText(context.state.statusText) {
           Text(statusText)
             .font(.system(size: 11, weight: .medium))
             .foregroundStyle(.secondary)
             .lineLimit(1)
-            .minimumScaleFactor(0.85)
-            .truncationMode(.tail)
-          Spacer(minLength: 6)
-          HStack(spacing: 3) {
-            Image(systemName: "arrow.clockwise")
-              .font(.system(size: 8, weight: .semibold))
-            Text(context.state.updatedAt, style: .relative)
-              .font(.system(size: 10, weight: .medium, design: .monospaced))
-              .lineLimit(1)
-              .fixedSize(horizontal: true, vertical: false)
-          }
+        }
+        Spacer(minLength: 6)
+        Text(context.state.updatedAt, style: .time)
+          .font(.system(size: 11, weight: .medium, design: .monospaced))
           .foregroundStyle(Color(white: 0.5))
+          .lineLimit(1)
+          .fixedSize(horizontal: true, vertical: false)
           .layoutPriority(1)
-        }
-        .padding(.horizontal, 2)
       }
+      .padding(.horizontal, 2)
     }
-  }
-
-  // MARK: - Route bar (colored dots + time)
-
-  /// A compact horizontal route strip: colored dots connected by lines, with
-  /// the stop name under each dot and the ETA shown under the highlighted /
-  /// current dot. Used in the expanded Dynamic Island bottom region.
-  @ViewBuilder
-  private func busRouteBar(
-    _ state: BusArrivalAttributes.ContentState,
-    surface: ActivitySurface,
-    colorScheme: ColorScheme = .dark
-  ) -> some View {
-    let line = busRouteBarData(state)
-    let etaLabel = routeBarEtaLabel(state)
-
-    HStack(alignment: .top, spacing: 0) {
-      ForEach(line.indices, id: \.self) { index in
-        VStack(spacing: 3) {
-          ZStack {
-            HStack(spacing: 0) {
-              routeBarConnector(
-                visible: index > 0,
-                active: index <= line.currentIndex,
-                surface: surface,
-                colorScheme: colorScheme
-              )
-              routeBarConnector(
-                visible: index < line.stops.count - 1,
-                active: index < line.currentIndex,
-                surface: surface,
-                colorScheme: colorScheme
-              )
-            }
-            routeBarDot(
-              isCurrent: index == line.currentIndex,
-              isHighlighted: index == line.highlightedIndex,
-              state: state
-            )
-          }
-          .frame(height: 18)
-
-          Text(compactStopLineLabel(line.stops[index]))
-            .font(.system(size: 9.5, weight: index == line.currentIndex ? .semibold : .medium))
-            .foregroundStyle(
-              stopLineLabelColor(
-                isCurrent: index == line.currentIndex,
-                isHighlighted: index == line.highlightedIndex,
-                surface: surface,
-                colorScheme: colorScheme
-              )
-            )
-            .lineLimit(1)
-            .minimumScaleFactor(0.6)
-
-          if index == line.currentIndex, let etaLabel {
-            Text(etaLabel)
-              .font(.system(size: 10, weight: .bold, design: .rounded))
-              .foregroundStyle(etaColor(state))
-              .lineLimit(1)
-              .minimumScaleFactor(0.6)
-              .monospacedDigit()
-          }
-        }
-        .frame(maxWidth: .infinity)
-      }
-    }
-  }
-
-  private struct RouteBarLine {
-    let stops: [String]
-    let currentIndex: Int
-    let highlightedIndex: Int?
-    var indices: Range<Int> { stops.indices }
-  }
-
-  private func busRouteBarData(
-    _ state: BusArrivalAttributes.ContentState
-  ) -> RouteBarLine {
-    if let data = stopLineData(state) {
-      return RouteBarLine(
-        stops: data.stopNames,
-        currentIndex: data.currentStopIndex,
-        highlightedIndex: data.highlightedStopIndex
-      )
-    }
-
-    let previous = trimmedText(state.previousStopName)
-    let next = trimmedText(state.nextStopName)
-    let current = displayStopName(state)
-
-    if previous == nil && next == nil {
-      return RouteBarLine(stops: [current], currentIndex: 0, highlightedIndex: 0)
-    }
-
-    return RouteBarLine(
-      stops: [previous ?? "起點", current, next ?? "終點"],
-      currentIndex: 1,
-      highlightedIndex: 1
-    )
-  }
-
-  private func routeBarEtaLabel(
-    _ state: BusArrivalAttributes.ContentState
-  ) -> String? {
-    if let msg = trimmedText(state.etaMessage) {
-      return msg.count > 4 ? String(msg.prefix(4)) : msg
-    }
-    guard let sec = state.etaSeconds else {
-      return nil
-    }
-    if sec <= 0 {
-      return "進站"
-    }
-    if sec < 60 {
-      return "\(sec)秒"
-    }
-    return "\(sec / 60)分"
-  }
-
-  @ViewBuilder
-  private func routeBarDot(
-    isCurrent: Bool,
-    isHighlighted: Bool,
-    state: BusArrivalAttributes.ContentState
-  ) -> some View {
-    if isCurrent {
-      ZStack {
-        Circle()
-          .fill(etaColor(state).opacity(0.28))
-          .frame(width: 20, height: 20)
-        Circle()
-          .fill(etaColor(state))
-          .frame(width: 15, height: 15)
-        Image(systemName: "bus.fill")
-          .font(.system(size: 8, weight: .bold))
-          .foregroundStyle(.white)
-      }
-    } else if isHighlighted {
-      Circle()
-        .strokeBorder(Color(red: 0.0, green: 0.74, blue: 0.83), lineWidth: 2)
-        .background(Circle().fill(Color(red: 0.0, green: 0.74, blue: 0.83).opacity(0.18)))
-        .frame(width: 12, height: 12)
-    } else {
-      Circle()
-        .fill(Color.secondary.opacity(0.5))
-        .frame(width: 8, height: 8)
-    }
-  }
-
-  @ViewBuilder
-  private func routeBarConnector(
-    visible: Bool,
-    active: Bool,
-    surface: ActivitySurface,
-    colorScheme: ColorScheme = .dark
-  ) -> some View {
-    Rectangle()
-      .fill(
-        !visible
-          ? Color.clear
-          : (active
-            ? Color(red: 0.0, green: 0.74, blue: 0.83).opacity(0.8)
-            : Color.secondary.opacity(0.3))
-      )
-      .frame(maxWidth: .infinity)
-      .frame(height: 2.5)
   }
 
   // lockScreenView 已移至 LockScreenActivityView struct（見下方）
@@ -371,12 +178,10 @@ struct BusArrivalLiveActivity: Widget {
     Text(name)
       .font(.system(size: 14, weight: .heavy, design: .rounded))
       .foregroundStyle(routeBadgeTextColor(surface: surface))
-      .lineLimit(1)
-      .minimumScaleFactor(0.7)
-      .padding(.horizontal, 9)
-      .padding(.vertical, 4)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 3)
       .background(
-        RoundedRectangle(cornerRadius: 8, style: .continuous)
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
           .fill(
             LinearGradient(
               colors: [Color(red: 0.0, green: 0.7, blue: 0.8), Color(red: 0.0, green: 0.55, blue: 0.75)],
@@ -384,10 +189,6 @@ struct BusArrivalLiveActivity: Widget {
               endPoint: .bottomTrailing
             )
           )
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: 8, style: .continuous)
-          .stroke(Color.white.opacity(0.16), lineWidth: 0.7)
       )
   }
 
@@ -402,10 +203,6 @@ struct BusArrivalLiveActivity: Widget {
         Capsule(style: .continuous)
           .fill(modePillBackgroundColor(surface: surface, colorScheme: colorScheme))
       )
-      .overlay(
-        Capsule(style: .continuous)
-          .stroke((surface == .dynamicIsland ? Color.white : lockScreenPrimaryTextColor(colorScheme: colorScheme)).opacity(0.1), lineWidth: 0.6)
-      )
   }
 
   @ViewBuilder
@@ -415,53 +212,52 @@ struct BusArrivalLiveActivity: Widget {
     colorScheme: ColorScheme = .dark
   ) -> some View {
     if let stopLine = stopLineData(state) {
-      // Markers and labels share the same equal-width columns so each dot
-      // lines up exactly above its stop name.
-      VStack(spacing: 5) {
+      VStack(spacing: 6) {
         HStack(spacing: 0) {
           ForEach(stopLine.stopNames.indices, id: \.self) { index in
-            ZStack {
-              HStack(spacing: 0) {
-                stopConnectorSegment(
-                  visible: index > 0,
-                  intensity: stopConnectorOpacity(
-                    currentStopIndex: stopLine.currentStopIndex,
-                    connectorIndex: index - 1
-                  ),
-                  surface: surface,
-                  colorScheme: colorScheme
-                )
-                stopConnectorSegment(
-                  visible: index < stopLine.stopNames.count - 1,
-                  intensity: stopConnectorOpacity(
-                    currentStopIndex: stopLine.currentStopIndex,
-                    connectorIndex: index
-                  ),
-                  surface: surface,
-                  colorScheme: colorScheme
-                )
-              }
-              stopMarker(
-                isCurrent: index == stopLine.currentStopIndex,
-                isHighlighted: index == stopLine.highlightedStopIndex,
-                surface: surface,
-                colorScheme: colorScheme
-              )
-            }
-            .frame(maxWidth: .infinity)
-          }
-        }
-        .frame(height: 20)
-
-        HStack(alignment: .top, spacing: 0) {
-          ForEach(stopLine.stopNames.indices, id: \.self) { index in
-            stopLineLabel(
-              stopLine.stopNames[index],
+            stopMarker(
               isCurrent: index == stopLine.currentStopIndex,
               isHighlighted: index == stopLine.highlightedStopIndex,
               surface: surface,
               colorScheme: colorScheme
             )
+            .frame(width: 18)
+
+            if index < stopLine.stopNames.count - 1 {
+              stopConnector(
+                intensity: stopConnectorOpacity(
+                  currentStopIndex: stopLine.currentStopIndex,
+                  connectorIndex: index
+                ),
+                surface: surface,
+                colorScheme: colorScheme
+              )
+            }
+          }
+        }
+
+        HStack(alignment: .top, spacing: 6) {
+          ForEach(stopLine.stopNames.indices, id: \.self) { index in
+            VStack(spacing: 1) {
+              stopLineLabel(
+                stopLine.stopNames[index],
+                isCurrent: index == stopLine.currentStopIndex,
+                isHighlighted: index == stopLine.highlightedStopIndex,
+                surface: surface,
+                colorScheme: colorScheme
+              )
+
+              if index == stopLine.currentStopIndex,
+                let etaLabel = routeBarEtaLabel(state) {
+                Text(etaLabel)
+                  .font(.system(size: 10, weight: .bold, design: .rounded))
+                  .foregroundStyle(etaColor(state))
+                  .lineLimit(1)
+                  .minimumScaleFactor(0.6)
+                  .monospacedDigit()
+              }
+            }
+            .frame(maxWidth: .infinity, alignment: .top)
           }
         }
       }
@@ -483,37 +279,19 @@ struct BusArrivalLiveActivity: Widget {
           Spacer(minLength: 0)
         }
       } else {
-        VStack(spacing: 5) {
+        VStack(spacing: 6) {
           HStack(spacing: 0) {
-            ForEach(0..<3, id: \.self) { index in
-              ZStack {
-                HStack(spacing: 0) {
-                  stopConnectorSegment(
-                    visible: index > 0,
-                    intensity: index == 1 ? 0.4 : 0.22,
-                    surface: surface,
-                    colorScheme: colorScheme
-                  )
-                  stopConnectorSegment(
-                    visible: index < 2,
-                    intensity: index == 0 ? 0.4 : 0.22,
-                    surface: surface,
-                    colorScheme: colorScheme
-                  )
-                }
-                stopMarker(
-                  isCurrent: index == 1,
-                  isHighlighted: index == 1,
-                  surface: surface,
-                  colorScheme: colorScheme
-                )
-              }
-              .frame(maxWidth: .infinity)
-            }
+            stopMarker(isCurrent: false, isHighlighted: false, surface: surface, colorScheme: colorScheme)
+              .frame(width: 18)
+            stopConnector(intensity: 0.4, surface: surface, colorScheme: colorScheme)
+            stopMarker(isCurrent: true, isHighlighted: true, surface: surface, colorScheme: colorScheme)
+              .frame(width: 18)
+            stopConnector(intensity: 0.22, surface: surface, colorScheme: colorScheme)
+            stopMarker(isCurrent: false, isHighlighted: false, surface: surface, colorScheme: colorScheme)
+              .frame(width: 18)
           }
-          .frame(height: 20)
 
-          HStack(alignment: .top, spacing: 0) {
+          HStack(alignment: .top, spacing: 8) {
             stopLineLabel(
               previousStopName ?? "起點",
               isCurrent: false,
@@ -521,13 +299,24 @@ struct BusArrivalLiveActivity: Widget {
               surface: surface,
               colorScheme: colorScheme
             )
-            stopLineLabel(
-              currentStopName,
-              isCurrent: true,
-              isHighlighted: true,
-              surface: surface,
-              colorScheme: colorScheme
-            )
+            VStack(spacing: 1) {
+              stopLineLabel(
+                currentStopName,
+                isCurrent: true,
+                isHighlighted: true,
+                surface: surface,
+                colorScheme: colorScheme
+              )
+              if let etaLabel = routeBarEtaLabel(state) {
+                Text(etaLabel)
+                  .font(.system(size: 10, weight: .bold, design: .rounded))
+                  .foregroundStyle(etaColor(state))
+                  .lineLimit(1)
+                  .minimumScaleFactor(0.6)
+                  .monospacedDigit()
+              }
+            }
+            .frame(maxWidth: .infinity, alignment: .top)
             stopLineLabel(
               nextStopName ?? "終點",
               isCurrent: false,
@@ -578,20 +367,12 @@ struct BusArrivalLiveActivity: Widget {
   }
 
   @ViewBuilder
-  private func stopConnectorSegment(
-    visible: Bool,
-    intensity: Double,
-    surface: ActivitySurface,
-    colorScheme: ColorScheme = .dark
-  ) -> some View {
-    Rectangle()
-      .fill(
-        visible
-          ? stopConnectorColor(surface: surface, intensity: intensity, colorScheme: colorScheme)
-          : Color.clear
-      )
+  private func stopConnector(intensity: Double, surface: ActivitySurface, colorScheme: ColorScheme = .dark) -> some View {
+    Capsule(style: .continuous)
+      .fill(stopConnectorColor(surface: surface, intensity: intensity, colorScheme: colorScheme))
       .frame(maxWidth: .infinity)
       .frame(height: 2)
+      .padding(.horizontal, 4)
   }
 
   @ViewBuilder
@@ -605,7 +386,7 @@ struct BusArrivalLiveActivity: Widget {
     Text(compactStopLineLabel(text))
       .font(
         .system(
-          size: isCurrent ? 11 : 10,
+          size: isCurrent ? 10.5 : 9.5,
           weight: isCurrent || isHighlighted ? .semibold : .medium
         )
       )
@@ -617,10 +398,11 @@ struct BusArrivalLiveActivity: Widget {
           colorScheme: colorScheme
         )
       )
-      .lineLimit(1)
-      .minimumScaleFactor(0.6)
+      .lineLimit(2)
+      .minimumScaleFactor(0.7)
+      .lineSpacing(-1)
       .multilineTextAlignment(.center)
-      .frame(maxWidth: .infinity, alignment: .center)
+      .frame(maxWidth: .infinity, minHeight: 28, alignment: .top)
   }
 
   private func stopLineData(
@@ -719,19 +501,18 @@ struct BusArrivalLiveActivity: Widget {
   }
 
   private func compactRouteName(_ text: String) -> String {
-    // Keep the compact-leading label short so the Dynamic Island stays narrow
-    // and does not visually crowd the status-bar clock.
     let trimmed = trimmedText(text) ?? text
-    if trimmed.count <= 3 {
+    if trimmed.count <= 4 {
       return trimmed
     }
-    return String(trimmed.prefix(3))
+    return String(trimmed.prefix(4))
   }
 
   private func routeBadgeTextColor(surface: ActivitySurface) -> Color {
-    // The badge always sits on the cyan gradient, so white keeps proper
-    // contrast on every surface (`.primary` could resolve to near-black).
-    .white
+    if surface == .dynamicIsland {
+      return .primary
+    }
+    return .white
   }
 
   private func modePillTextColor(surface: ActivitySurface, colorScheme: ColorScheme) -> Color {
@@ -872,6 +653,25 @@ struct BusArrivalLiveActivity: Widget {
     return nil
   }
 
+  /// Short ETA text shown under the current stop dot in the route bar.
+  private func routeBarEtaLabel(
+    _ state: BusArrivalAttributes.ContentState
+  ) -> String? {
+    if let msg = trimmedText(state.etaMessage) {
+      return msg.count > 4 ? String(msg.prefix(4)) : msg
+    }
+    guard let sec = state.etaSeconds else {
+      return nil
+    }
+    if sec <= 0 {
+      return "進站"
+    }
+    if sec < 60 {
+      return "\(sec)秒"
+    }
+    return "\(sec / 60)分"
+  }
+
   private func etaColor(_ state: BusArrivalAttributes.ContentState) -> Color {
     if trimmedText(state.etaMessage) != nil {
       return Color(red: 0.0, green: 0.7, blue: 0.65)
@@ -901,12 +701,6 @@ private struct LockScreenActivityView: View {
   @Environment(\.colorScheme) private var colorScheme
 
   var body: some View {
-    // Keep this layout simple and content-sized. Do NOT add a custom card
-    // background (ZStack shape or a full-size `.background`) here: the system
-    // manages the Live Activity container and applies `.activityBackgroundTint`.
-    // Drawing our own full-bleed card fought the system sizing and made the
-    // view balloon into a blank rectangle on unlock and during the
-    // lock-screen → Dynamic Island hand-off.
     HStack(spacing: 16) {
       VStack(alignment: .leading, spacing: 6) {
         HStack(spacing: 8) {
@@ -915,8 +709,6 @@ private struct LockScreenActivityView: View {
             .font(.system(size: 13, weight: .medium))
             .foregroundStyle(lsSecondaryTextColor)
             .lineLimit(1)
-            .minimumScaleFactor(0.8)
-            .truncationMode(.tail)
         }
 
         if let modeLabel = lsTrimmed(context.state.modeLabel) {
@@ -947,10 +739,6 @@ private struct LockScreenActivityView: View {
       Spacer(minLength: 8)
 
       VStack(alignment: .trailing, spacing: 4) {
-        Text("到站")
-          .font(.system(size: 10, weight: .semibold))
-          .foregroundStyle(lsEtaColor(context.state).opacity(0.9))
-
         lsCountdownText(
           context.state,
           font: .system(size: 32, weight: .bold, design: .rounded)
@@ -970,14 +758,9 @@ private struct LockScreenActivityView: View {
           .foregroundStyle(lsSecondaryTextColor)
         }
 
-        HStack(spacing: 3) {
-          Image(systemName: "arrow.clockwise")
-            .font(.system(size: 8, weight: .semibold))
-          Text(context.state.updatedAt, style: .relative)
-            .font(.system(size: 11, weight: .medium, design: .monospaced))
-            .lineLimit(1)
-        }
-        .foregroundStyle(lsTimestampTextColor)
+        Text(context.state.updatedAt, style: .time)
+          .font(.system(size: 11, weight: .medium, design: .monospaced))
+          .foregroundStyle(lsTimestampTextColor)
       }
     }
     .padding(.horizontal, 20)
@@ -1038,32 +821,6 @@ private struct LockScreenActivityView: View {
       : Color(red: 0.16, green: 0.22, blue: 0.31).opacity(0.1)
   }
 
-  private var lsCardFillColor: Color {
-    colorScheme == .dark
-      ? Color(red: 0.12, green: 0.16, blue: 0.24).opacity(0.96)
-      : Color.white.opacity(0.94)
-  }
-
-  private var lsCardStrokeColor: Color {
-    colorScheme == .dark
-      ? Color.white.opacity(0.08)
-      : Color(red: 0.16, green: 0.22, blue: 0.31).opacity(0.08)
-  }
-
-  private var lsSectionFillColor: Color {
-    colorScheme == .dark
-      ? Color.white.opacity(0.08)
-      : Color(red: 0.16, green: 0.22, blue: 0.31).opacity(0.06)
-  }
-
-  private var lsEtaPanelFillColor: Color {
-    lsEtaColor(context.state).opacity(colorScheme == .dark ? 0.16 : 0.12)
-  }
-
-  private var lsEtaPanelStrokeColor: Color {
-    lsEtaColor(context.state).opacity(colorScheme == .dark ? 0.34 : 0.22)
-  }
-
   // MARK: Helpers
 
   private func lsTrimmed(_ value: String?) -> String? {
@@ -1092,12 +849,10 @@ private struct LockScreenActivityView: View {
     Text(name)
       .font(.system(size: 14, weight: .heavy, design: .rounded))
       .foregroundStyle(Color.white)
-      .lineLimit(1)
-      .minimumScaleFactor(0.7)
-      .padding(.horizontal, 9)
-      .padding(.vertical, 4)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 3)
       .background(
-        RoundedRectangle(cornerRadius: 8, style: .continuous)
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
           .fill(
             LinearGradient(
               colors: [Color(red: 0.0, green: 0.7, blue: 0.8), Color(red: 0.0, green: 0.55, blue: 0.75)],
@@ -1105,10 +860,6 @@ private struct LockScreenActivityView: View {
               endPoint: .bottomTrailing
             )
           )
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: 8, style: .continuous)
-          .stroke(Color.white.opacity(0.16), lineWidth: 0.7)
       )
   }
 
@@ -1122,10 +873,6 @@ private struct LockScreenActivityView: View {
       .background(
         Capsule(style: .continuous)
           .fill(lsModePillBackgroundColor)
-      )
-      .overlay(
-        Capsule(style: .continuous)
-          .stroke(lsPrimaryTextColor.opacity(0.08), lineWidth: 0.6)
       )
   }
 
@@ -1161,30 +908,17 @@ private struct LockScreenActivityView: View {
       let currentIdx = (state.lineCurrentStopIndex.map { $0 >= 0 && $0 < count ? $0 : 0 }) ?? 0
       let highlightIdx = state.lineHighlightedStopIndex.flatMap { $0 >= 0 && $0 < count ? $0 : nil }
 
-      // Markers and labels share the same equal-width columns so each dot
-      // lines up exactly above its stop name.
-      VStack(spacing: 5) {
+      VStack(spacing: 6) {
         HStack(spacing: 0) {
           ForEach(state.lineStopNames.indices, id: \.self) { index in
-            ZStack {
-              HStack(spacing: 0) {
-                lsStopConnectorSegment(
-                  visible: index > 0,
-                  intensity: index - 1 < currentIdx ? 0.46 : 0.18
-                )
-                lsStopConnectorSegment(
-                  visible: index < count - 1,
-                  intensity: index < currentIdx ? 0.46 : 0.18
-                )
-              }
-              lsStopMarker(isCurrent: index == currentIdx, isHighlighted: index == highlightIdx)
+            lsStopMarker(isCurrent: index == currentIdx, isHighlighted: index == highlightIdx)
+              .frame(width: 18)
+            if index < count - 1 {
+              lsStopConnector(intensity: index < currentIdx ? 0.46 : 0.18)
             }
-            .frame(maxWidth: .infinity)
           }
         }
-        .frame(height: 20)
-
-        HStack(alignment: .top, spacing: 0) {
+        HStack(alignment: .top, spacing: 6) {
           ForEach(state.lineStopNames.indices, id: \.self) { index in
             lsStopLabel(
               state.lineStopNames[index],
@@ -1206,28 +940,15 @@ private struct LockScreenActivityView: View {
           Spacer(minLength: 0)
         }
       } else {
-        VStack(spacing: 5) {
+        VStack(spacing: 6) {
           HStack(spacing: 0) {
-            ForEach(0..<3, id: \.self) { index in
-              ZStack {
-                HStack(spacing: 0) {
-                  lsStopConnectorSegment(
-                    visible: index > 0,
-                    intensity: index == 1 ? 0.4 : 0.22
-                  )
-                  lsStopConnectorSegment(
-                    visible: index < 2,
-                    intensity: index == 0 ? 0.4 : 0.22
-                  )
-                }
-                lsStopMarker(isCurrent: index == 1, isHighlighted: index == 1)
-              }
-              .frame(maxWidth: .infinity)
-            }
+            lsStopMarker(isCurrent: false, isHighlighted: false).frame(width: 18)
+            lsStopConnector(intensity: 0.4)
+            lsStopMarker(isCurrent: true, isHighlighted: true).frame(width: 18)
+            lsStopConnector(intensity: 0.22)
+            lsStopMarker(isCurrent: false, isHighlighted: false).frame(width: 18)
           }
-          .frame(height: 20)
-
-          HStack(alignment: .top, spacing: 0) {
+          HStack(alignment: .center, spacing: 8) {
             lsStopLabel(prev ?? "起點", isCurrent: false, isHighlighted: false)
             lsStopLabel(current, isCurrent: true, isHighlighted: true)
             lsStopLabel(next ?? "終點", isCurrent: false, isHighlighted: false)
@@ -1266,11 +987,12 @@ private struct LockScreenActivityView: View {
   }
 
   @ViewBuilder
-  private func lsStopConnectorSegment(visible: Bool, intensity: Double) -> some View {
-    Rectangle()
-      .fill(visible ? lsSecondaryTextColor.opacity(max(intensity, 0.12)) : Color.clear)
+  private func lsStopConnector(intensity: Double) -> some View {
+    Capsule(style: .continuous)
+      .fill(lsSecondaryTextColor.opacity(max(intensity, 0.12)))
       .frame(maxWidth: .infinity)
       .frame(height: 2)
+      .padding(.horizontal, 4)
   }
 
   @ViewBuilder
@@ -1279,14 +1001,15 @@ private struct LockScreenActivityView: View {
     let color: Color = isCurrent ? lsPrimaryTextColor : (isHighlighted ? lsHighlightTextColor : lsSecondaryTextColor)
     Text(label)
       .font(.system(
-        size: isCurrent ? 11 : 10,
+        size: isCurrent ? 10.5 : 9.5,
         weight: isCurrent || isHighlighted ? .semibold : .medium
       ))
       .foregroundStyle(color)
-      .lineLimit(1)
-      .minimumScaleFactor(0.6)
+      .lineLimit(2)
+      .minimumScaleFactor(0.7)
+      .lineSpacing(-1)
       .multilineTextAlignment(.center)
-      .frame(maxWidth: .infinity, alignment: .center)
+      .frame(maxWidth: .infinity, minHeight: 28, alignment: .top)
   }
 
   private func lsCompactStopLabel(_ text: String) -> String {

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -109,37 +109,23 @@ struct BusArrivalLiveActivity: Widget {
   private func expandedLeading(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    VStack(alignment: .leading, spacing: 8) {
-      HStack(alignment: .top, spacing: 8) {
-        routeBadge(context.attributes.routeName, surface: .dynamicIsland)
-        VStack(alignment: .leading, spacing: 4) {
-          Text(context.attributes.pathName)
-            .font(.system(size: 12, weight: .semibold))
+    HStack(alignment: .center, spacing: 8) {
+      routeBadge(context.attributes.routeName, surface: .dynamicIsland)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(context.attributes.pathName)
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .minimumScaleFactor(0.8)
+          .truncationMode(.tail)
+
+        if let modeLabel = trimmedText(context.state.modeLabel) {
+          Text(modeLabel)
+            .font(.system(size: 10, weight: .medium))
             .foregroundStyle(.secondary)
             .lineLimit(1)
-            .minimumScaleFactor(0.8)
-            .truncationMode(.tail)
-
-          if let modeLabel = trimmedText(context.state.modeLabel) {
-            modePill(modeLabel, surface: .dynamicIsland)
-          }
         }
       }
-
-      HStack(spacing: 5) {
-        Image(systemName: "mappin.circle.fill")
-          .font(.system(size: 13))
-          .foregroundStyle(.cyan)
-        Text(displayStopName(context.state))
-          .font(.system(size: 14, weight: .semibold))
-          .lineLimit(1)
-      }
-      .padding(.horizontal, 8)
-      .padding(.vertical, 7)
-      .background(
-        RoundedRectangle(cornerRadius: 11, style: .continuous)
-          .fill(Color.white.opacity(0.08))
-      )
     }
   }
 
@@ -147,94 +133,232 @@ struct BusArrivalLiveActivity: Widget {
   private func expandedTrailing(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    VStack(alignment: .trailing, spacing: 6) {
-      VStack(alignment: .trailing, spacing: 2) {
-        Text("到站")
-          .font(.system(size: 10, weight: .semibold))
-          .foregroundStyle(etaColor(context.state).opacity(0.9))
+    VStack(alignment: .trailing, spacing: 1) {
+      Text("到站")
+        .font(.system(size: 9, weight: .semibold))
+        .foregroundStyle(etaColor(context.state).opacity(0.9))
 
-        countdownText(
-          context.state,
-          style: .expanded,
-          font: .system(size: 24, weight: .bold, design: .rounded)
-        )
-        .foregroundStyle(etaColor(context.state))
-        .lineLimit(1)
-        .minimumScaleFactor(0.6)
-        .monospacedDigit()
-      }
-      .padding(.horizontal, 10)
-      .padding(.vertical, 8)
-      .background(
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-          .fill(etaColor(context.state).opacity(0.14))
+      countdownText(
+        context.state,
+        style: .expanded,
+        font: .system(size: 22, weight: .bold, design: .rounded)
       )
-      .overlay(
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-          .stroke(etaColor(context.state).opacity(0.28), lineWidth: 0.7)
-      )
+      .foregroundStyle(etaColor(context.state))
+      .lineLimit(1)
+      .minimumScaleFactor(0.6)
+      .monospacedDigit()
 
       if let vehicleId = trimmedText(context.state.vehicleId) {
         HStack(spacing: 3) {
           Image(systemName: "bus")
-            .font(.system(size: 10))
+            .font(.system(size: 9))
           Text(vehicleId)
-            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .font(.system(size: 10, weight: .medium, design: .monospaced))
             .lineLimit(1)
         }
         .foregroundStyle(.secondary)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(
-          Capsule(style: .continuous)
-            .fill(Color.white.opacity(0.08))
-        )
       }
     }
+    .fixedSize(horizontal: true, vertical: false)
   }
 
   @ViewBuilder
   private func expandedBottom(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    VStack(spacing: 8) {
-      stopLineView(context.state, surface: .dynamicIsland)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 8)
-        .background(
-          RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .fill(Color.white.opacity(0.08))
-        )
+    VStack(spacing: 6) {
+      busRouteBar(context.state, surface: .dynamicIsland)
 
-      HStack {
-        if let statusText = trimmedText(context.state.statusText) {
+      if let statusText = trimmedText(context.state.statusText) {
+        HStack(spacing: 6) {
           Text(statusText)
             .font(.system(size: 11, weight: .medium))
             .foregroundStyle(.secondary)
             .lineLimit(1)
             .minimumScaleFactor(0.85)
             .truncationMode(.tail)
+          Spacer(minLength: 6)
+          HStack(spacing: 3) {
+            Image(systemName: "arrow.clockwise")
+              .font(.system(size: 8, weight: .semibold))
+            Text(context.state.updatedAt, style: .relative)
+              .font(.system(size: 10, weight: .medium, design: .monospaced))
+              .lineLimit(1)
+              .fixedSize(horizontal: true, vertical: false)
+          }
+          .foregroundStyle(Color(white: 0.5))
+          .layoutPriority(1)
         }
-        Spacer(minLength: 6)
-        HStack(spacing: 3) {
-          Image(systemName: "arrow.clockwise")
-            .font(.system(size: 9, weight: .semibold))
-          Text(context.state.updatedAt, style: .relative)
-            .font(.system(size: 11, weight: .medium, design: .monospaced))
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
-        }
-        .foregroundStyle(Color(white: 0.5))
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(
-          Capsule(style: .continuous)
-            .fill(Color.white.opacity(0.06))
-        )
-        .layoutPriority(1)
+        .padding(.horizontal, 2)
       }
-      .padding(.horizontal, 2)
     }
+  }
+
+  // MARK: - Route bar (colored dots + time)
+
+  /// A compact horizontal route strip: colored dots connected by lines, with
+  /// the stop name under each dot and the ETA shown under the highlighted /
+  /// current dot. Used in the expanded Dynamic Island bottom region.
+  @ViewBuilder
+  private func busRouteBar(
+    _ state: BusArrivalAttributes.ContentState,
+    surface: ActivitySurface,
+    colorScheme: ColorScheme = .dark
+  ) -> some View {
+    let line = busRouteBarData(state)
+    let etaLabel = routeBarEtaLabel(state)
+
+    HStack(alignment: .top, spacing: 0) {
+      ForEach(line.indices, id: \.self) { index in
+        VStack(spacing: 3) {
+          ZStack {
+            HStack(spacing: 0) {
+              routeBarConnector(
+                visible: index > 0,
+                active: index <= line.currentIndex,
+                surface: surface,
+                colorScheme: colorScheme
+              )
+              routeBarConnector(
+                visible: index < line.stops.count - 1,
+                active: index < line.currentIndex,
+                surface: surface,
+                colorScheme: colorScheme
+              )
+            }
+            routeBarDot(
+              isCurrent: index == line.currentIndex,
+              isHighlighted: index == line.highlightedIndex,
+              state: state
+            )
+          }
+          .frame(height: 18)
+
+          Text(compactStopLineLabel(line.stops[index]))
+            .font(.system(size: 9.5, weight: index == line.currentIndex ? .semibold : .medium))
+            .foregroundStyle(
+              stopLineLabelColor(
+                isCurrent: index == line.currentIndex,
+                isHighlighted: index == line.highlightedIndex,
+                surface: surface,
+                colorScheme: colorScheme
+              )
+            )
+            .lineLimit(1)
+            .minimumScaleFactor(0.6)
+
+          if index == line.currentIndex, let etaLabel {
+            Text(etaLabel)
+              .font(.system(size: 10, weight: .bold, design: .rounded))
+              .foregroundStyle(etaColor(state))
+              .lineLimit(1)
+              .minimumScaleFactor(0.6)
+              .monospacedDigit()
+          }
+        }
+        .frame(maxWidth: .infinity)
+      }
+    }
+  }
+
+  private struct RouteBarLine {
+    let stops: [String]
+    let currentIndex: Int
+    let highlightedIndex: Int?
+    var indices: Range<Int> { stops.indices }
+  }
+
+  private func busRouteBarData(
+    _ state: BusArrivalAttributes.ContentState
+  ) -> RouteBarLine {
+    if let data = stopLineData(state) {
+      return RouteBarLine(
+        stops: data.stopNames,
+        currentIndex: data.currentStopIndex,
+        highlightedIndex: data.highlightedStopIndex
+      )
+    }
+
+    let previous = trimmedText(state.previousStopName)
+    let next = trimmedText(state.nextStopName)
+    let current = displayStopName(state)
+
+    if previous == nil && next == nil {
+      return RouteBarLine(stops: [current], currentIndex: 0, highlightedIndex: 0)
+    }
+
+    return RouteBarLine(
+      stops: [previous ?? "起點", current, next ?? "終點"],
+      currentIndex: 1,
+      highlightedIndex: 1
+    )
+  }
+
+  private func routeBarEtaLabel(
+    _ state: BusArrivalAttributes.ContentState
+  ) -> String? {
+    if let msg = trimmedText(state.etaMessage) {
+      return msg.count > 4 ? String(msg.prefix(4)) : msg
+    }
+    guard let sec = state.etaSeconds else {
+      return nil
+    }
+    if sec <= 0 {
+      return "進站"
+    }
+    if sec < 60 {
+      return "\(sec)秒"
+    }
+    return "\(sec / 60)分"
+  }
+
+  @ViewBuilder
+  private func routeBarDot(
+    isCurrent: Bool,
+    isHighlighted: Bool,
+    state: BusArrivalAttributes.ContentState
+  ) -> some View {
+    if isCurrent {
+      ZStack {
+        Circle()
+          .fill(etaColor(state).opacity(0.28))
+          .frame(width: 20, height: 20)
+        Circle()
+          .fill(etaColor(state))
+          .frame(width: 15, height: 15)
+        Image(systemName: "bus.fill")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundStyle(.white)
+      }
+    } else if isHighlighted {
+      Circle()
+        .strokeBorder(Color(red: 0.0, green: 0.74, blue: 0.83), lineWidth: 2)
+        .background(Circle().fill(Color(red: 0.0, green: 0.74, blue: 0.83).opacity(0.18)))
+        .frame(width: 12, height: 12)
+    } else {
+      Circle()
+        .fill(Color.secondary.opacity(0.5))
+        .frame(width: 8, height: 8)
+    }
+  }
+
+  @ViewBuilder
+  private func routeBarConnector(
+    visible: Bool,
+    active: Bool,
+    surface: ActivitySurface,
+    colorScheme: ColorScheme = .dark
+  ) -> some View {
+    Rectangle()
+      .fill(
+        !visible
+          ? Color.clear
+          : (active
+            ? Color(red: 0.0, green: 0.74, blue: 0.83).opacity(0.8)
+            : Color.secondary.opacity(0.3))
+      )
+      .frame(maxWidth: .infinity)
+      .frame(height: 2.5)
   }
 
   // lockScreenView 已移至 LockScreenActivityView struct（見下方）

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -792,68 +792,65 @@ private struct LockScreenActivityView: View {
       RoundedRectangle(cornerRadius: 24, style: .continuous)
         .stroke(lsCardStrokeColor, lineWidth: 1)
 
-      VStack(alignment: .leading, spacing: 10) {
-        HStack(alignment: .top) {
+      VStack(alignment: .leading, spacing: 8) {
+        HStack(alignment: .top, spacing: 8) {
+          if let vehicleId = lsTrimmed(context.state.vehicleId) {
+            HStack(spacing: 4) {
+              Image(systemName: "bus.fill")
+                .font(.system(size: 10))
+              Text(vehicleId)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+            }
+            .foregroundStyle(lsSecondaryTextColor)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(
+              Capsule(style: .continuous)
+                .fill(lsSectionFillColor)
+            )
+          }
+
           Spacer(minLength: 0)
 
-          VStack(alignment: .trailing, spacing: 8) {
-            VStack(alignment: .trailing, spacing: 4) {
-              Text("到站")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(lsEtaColor(context.state).opacity(0.9))
-
-              lsCountdownText(
-                context.state,
-                font: .system(size: 32, weight: .bold, design: .rounded)
-              )
-              .foregroundStyle(lsEtaColor(context.state))
+          HStack(spacing: 4) {
+            Image(systemName: "clock")
+              .font(.system(size: 9, weight: .semibold))
+            Text(context.state.updatedAt, style: .time)
+              .font(.system(size: 11, weight: .medium, design: .monospaced))
               .lineLimit(1)
-              .minimumScaleFactor(0.5)
-              .monospacedDigit()
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .background(
-              RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(lsEtaPanelFillColor)
-            )
-            .overlay(
-              RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(lsEtaPanelStrokeColor, lineWidth: 1)
-            )
-
-            HStack(spacing: 6) {
-              if let vehicleId = lsTrimmed(context.state.vehicleId) {
-                HStack(spacing: 4) {
-                  Image(systemName: "bus.fill")
-                    .font(.system(size: 10))
-                  Text(vehicleId)
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                }
-                .foregroundStyle(lsSecondaryTextColor)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 5)
-                .background(
-                  Capsule(style: .continuous)
-                    .fill(lsSectionFillColor)
-                )
-              }
-
-              HStack(spacing: 4) {
-                Image(systemName: "clock")
-                  .font(.system(size: 9, weight: .semibold))
-                Text(context.state.updatedAt, style: .time)
-                  .font(.system(size: 11, weight: .medium, design: .monospaced))
-              }
-              .foregroundStyle(lsTimestampTextColor)
-              .padding(.horizontal, 8)
-              .padding(.vertical, 5)
-              .background(
-                Capsule(style: .continuous)
-                  .fill(lsSectionFillColor)
-              )
-            }
           }
+          .foregroundStyle(lsTimestampTextColor)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 5)
+          .background(
+            Capsule(style: .continuous)
+              .fill(lsSectionFillColor)
+          )
+
+          VStack(alignment: .trailing, spacing: 2) {
+            Text("到站")
+              .font(.system(size: 10, weight: .semibold))
+              .foregroundStyle(lsEtaColor(context.state).opacity(0.9))
+
+            lsCountdownText(
+              context.state,
+              font: .system(size: 30, weight: .bold, design: .rounded)
+            )
+            .foregroundStyle(lsEtaColor(context.state))
+            .lineLimit(1)
+            .minimumScaleFactor(0.5)
+            .monospacedDigit()
+          }
+          .padding(.horizontal, 10)
+          .padding(.vertical, 8)
+          .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+              .fill(lsEtaPanelFillColor)
+          )
+          .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+              .stroke(lsEtaPanelStrokeColor, lineWidth: 1)
+          )
         }
 
         HStack(alignment: .top, spacing: 10) {
@@ -874,20 +871,31 @@ private struct LockScreenActivityView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.vertical, 9)
         .background(
           RoundedRectangle(cornerRadius: 16, style: .continuous)
             .fill(lsSectionFillColor)
         )
 
-        HStack(spacing: 6) {
-          Image(systemName: "mappin.circle.fill")
-            .font(.system(size: 14))
-            .foregroundStyle(lsHighlightTextColor)
-          Text(lsDisplayStopName(context.state))
-            .font(.system(size: 16, weight: .semibold))
-            .foregroundStyle(lsPrimaryTextColor)
-            .lineLimit(1)
+        VStack(alignment: .leading, spacing: 5) {
+          HStack(spacing: 6) {
+            Image(systemName: "mappin.circle.fill")
+              .font(.system(size: 14))
+              .foregroundStyle(lsHighlightTextColor)
+            Text(lsDisplayStopName(context.state))
+              .font(.system(size: 16, weight: .semibold))
+              .foregroundStyle(lsPrimaryTextColor)
+              .lineLimit(1)
+          }
+
+          if let statusText = lsTrimmed(context.state.statusText) {
+            Text(statusText)
+              .font(.system(size: 12, weight: .medium))
+              .foregroundStyle(lsSecondaryTextColor)
+              .lineLimit(1)
+              .minimumScaleFactor(0.88)
+              .truncationMode(.tail)
+          }
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
@@ -896,32 +904,17 @@ private struct LockScreenActivityView: View {
             .fill(lsSectionFillColor)
         )
 
-        if let statusText = lsTrimmed(context.state.statusText) {
-          Text(statusText)
-            .font(.system(size: 12, weight: .medium))
-            .foregroundStyle(lsSecondaryTextColor)
-            .lineLimit(2)
-            .minimumScaleFactor(0.9)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-              RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(lsSectionFillColor)
-            )
-        }
-
         lsStopLineView(context.state)
           .padding(.horizontal, 10)
-          .padding(.top, 10)
-          .padding(.bottom, 8)
+          .padding(.top, 8)
+          .padding(.bottom, 7)
           .background(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
               .fill(lsSectionFillColor)
           )
       }
-      .padding(.horizontal, 16)
-      .padding(.vertical, 16)
+      .padding(.horizontal, 14)
+      .padding(.vertical, 14)
     }
     .padding(.horizontal, 6)
     .padding(.vertical, 4)

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -38,36 +38,29 @@ struct BusArrivalLiveActivity: Widget {
   private func compactLeadingView(
     context: ActivityViewContext<BusArrivalAttributes>
   ) -> some View {
-    HStack(spacing: 4) {
-      Circle()
-        .fill(Color.white.opacity(0.92))
-        .frame(width: 4.5, height: 4.5)
-      Text(compactRouteName(context.attributes.routeName))
-        .font(.system(size: 12, weight: .heavy, design: .rounded))
-        .foregroundStyle(.white)
-        .lineLimit(1)
-        .minimumScaleFactor(0.55)
-    }
-    .padding(.horizontal, 8)
-    .padding(.vertical, 3)
-    .background(
-      Capsule(style: .continuous)
-        .fill(
-          LinearGradient(
-            colors: [
-              etaColor(context.state),
-              etaColor(context.state).opacity(0.78),
-            ],
-            startPoint: .topLeading,
-            endPoint: .bottomTrailing
+    // Keep this as narrow as possible: the compact leading sits right next to
+    // the status-bar clock, so any extra width visually crowds the time.
+    Text(compactRouteName(context.attributes.routeName))
+      .font(.system(size: 12, weight: .heavy, design: .rounded))
+      .foregroundStyle(.white)
+      .lineLimit(1)
+      .minimumScaleFactor(0.6)
+      .padding(.horizontal, 6)
+      .padding(.vertical, 2)
+      .background(
+        Capsule(style: .continuous)
+          .fill(
+            LinearGradient(
+              colors: [
+                etaColor(context.state),
+                etaColor(context.state).opacity(0.78),
+              ],
+              startPoint: .topLeading,
+              endPoint: .bottomTrailing
+            )
           )
-        )
-    )
-    .overlay(
-      Capsule(style: .continuous)
-        .stroke(Color.white.opacity(0.16), lineWidth: 0.6)
-    )
-    .frame(maxWidth: 58, alignment: .leading)
+      )
+      .frame(maxWidth: 40, alignment: .center)
   }
 
   @ViewBuilder
@@ -83,17 +76,13 @@ struct BusArrivalLiveActivity: Widget {
     .lineLimit(1)
     .minimumScaleFactor(0.45)
     .monospacedDigit()
-    .padding(.horizontal, 8)
-    .padding(.vertical, 3)
+    .padding(.horizontal, 6)
+    .padding(.vertical, 2)
     .background(
       Capsule(style: .continuous)
         .fill(etaColor(context.state).opacity(0.14))
     )
-    .overlay(
-      Capsule(style: .continuous)
-        .stroke(etaColor(context.state).opacity(0.28), lineWidth: 0.6)
-    )
-    .frame(minWidth: 58, alignment: .trailing)
+    .frame(maxWidth: 52, alignment: .trailing)
   }
 
   @ViewBuilder
@@ -606,11 +595,13 @@ struct BusArrivalLiveActivity: Widget {
   }
 
   private func compactRouteName(_ text: String) -> String {
+    // Keep the compact-leading label short so the Dynamic Island stays narrow
+    // and does not visually crowd the status-bar clock.
     let trimmed = trimmedText(text) ?? text
-    if trimmed.count <= 4 {
+    if trimmed.count <= 3 {
       return trimmed
     }
-    return String(trimmed.prefix(4))
+    return String(trimmed.prefix(3))
   }
 
   private func routeBadgeTextColor(surface: ActivitySurface) -> Color {

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -777,32 +777,29 @@ private struct LockScreenActivityView: View {
   @Environment(\.colorScheme) private var colorScheme
 
   var body: some View {
-    // IMPORTANT: do NOT wrap this in a `ZStack { RoundedRectangle()… ; content }`.
-    // A bare Shape used as a ZStack sibling is greedy and expands to fill every
-    // size the system proposes. On the unlocked lock screen and during the
-    // lock-screen → Dynamic Island hand-off the system proposes a large size,
-    // which made the card balloon into a giant blank rectangle. Applying the
-    // card as a `.background` modifier keeps it sized to the content instead.
-    HStack(alignment: .top, spacing: 14) {
-      VStack(alignment: .leading, spacing: 8) {
-        HStack(alignment: .top, spacing: 10) {
+    // Keep this layout simple and content-sized. Do NOT add a custom card
+    // background (ZStack shape or a full-size `.background`) here: the system
+    // manages the Live Activity container and applies `.activityBackgroundTint`.
+    // Drawing our own full-bleed card fought the system sizing and made the
+    // view balloon into a blank rectangle on unlock and during the
+    // lock-screen → Dynamic Island hand-off.
+    HStack(spacing: 16) {
+      VStack(alignment: .leading, spacing: 6) {
+        HStack(spacing: 8) {
           lsRouteBadge(context.attributes.routeName)
-
-          VStack(alignment: .leading, spacing: 5) {
-            Text(context.attributes.pathName)
-              .font(.system(size: 14, weight: .semibold))
-              .foregroundStyle(lsSecondaryTextColor)
-              .lineLimit(1)
-              .minimumScaleFactor(0.8)
-              .truncationMode(.tail)
-
-            if let modeLabel = lsTrimmed(context.state.modeLabel) {
-              lsModePill(modeLabel)
-            }
-          }
+          Text(context.attributes.pathName)
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(lsSecondaryTextColor)
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+            .truncationMode(.tail)
         }
 
-        HStack(spacing: 6) {
+        if let modeLabel = lsTrimmed(context.state.modeLabel) {
+          lsModePill(modeLabel)
+        }
+
+        HStack(spacing: 5) {
           Image(systemName: "mappin.circle.fill")
             .font(.system(size: 14))
             .foregroundStyle(lsHighlightTextColor)
@@ -811,61 +808,40 @@ private struct LockScreenActivityView: View {
             .foregroundStyle(lsPrimaryTextColor)
             .lineLimit(1)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-          RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .fill(lsSectionFillColor)
-        )
 
         if let statusText = lsTrimmed(context.state.statusText) {
           Text(statusText)
             .font(.system(size: 12, weight: .medium))
             .foregroundStyle(lsSecondaryTextColor)
             .lineLimit(2)
-            .minimumScaleFactor(0.85)
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
 
         lsStopLineView(context.state)
-          .padding(.top, 2)
+          .padding(.top, 4)
       }
-      .frame(maxWidth: .infinity, alignment: .leading)
 
-      VStack(alignment: .trailing, spacing: 8) {
-        VStack(alignment: .trailing, spacing: 2) {
-          Text("到站")
-            .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(lsEtaColor(context.state).opacity(0.9))
+      Spacer(minLength: 8)
 
-          lsCountdownText(
-            context.state,
-            font: .system(size: 30, weight: .bold, design: .rounded)
-          )
-          .foregroundStyle(lsEtaColor(context.state))
-          .lineLimit(1)
-          .minimumScaleFactor(0.5)
-          .monospacedDigit()
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(
-          RoundedRectangle(cornerRadius: 16, style: .continuous)
-            .fill(lsEtaPanelFillColor)
+      VStack(alignment: .trailing, spacing: 4) {
+        Text("到站")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(lsEtaColor(context.state).opacity(0.9))
+
+        lsCountdownText(
+          context.state,
+          font: .system(size: 32, weight: .bold, design: .rounded)
         )
-        .overlay(
-          RoundedRectangle(cornerRadius: 16, style: .continuous)
-            .stroke(lsEtaPanelStrokeColor, lineWidth: 1)
-        )
+        .foregroundStyle(lsEtaColor(context.state))
+        .lineLimit(1)
+        .minimumScaleFactor(0.5)
+        .monospacedDigit()
 
         if let vehicleId = lsTrimmed(context.state.vehicleId) {
-          HStack(spacing: 4) {
-            Image(systemName: "bus.fill")
+          HStack(spacing: 3) {
+            Image(systemName: "bus")
               .font(.system(size: 10))
             Text(vehicleId)
               .font(.system(size: 11, weight: .medium, design: .monospaced))
-              .lineLimit(1)
           }
           .foregroundStyle(lsSecondaryTextColor)
         }
@@ -874,25 +850,14 @@ private struct LockScreenActivityView: View {
           Image(systemName: "arrow.clockwise")
             .font(.system(size: 8, weight: .semibold))
           Text(context.state.updatedAt, style: .relative)
-            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
             .lineLimit(1)
         }
         .foregroundStyle(lsTimestampTextColor)
       }
-      .fixedSize(horizontal: true, vertical: false)
     }
-    .padding(.horizontal, 16)
+    .padding(.horizontal, 20)
     .padding(.vertical, 14)
-    .background(
-      RoundedRectangle(cornerRadius: 24, style: .continuous)
-        .fill(lsCardFillColor)
-        .overlay(
-          RoundedRectangle(cornerRadius: 24, style: .continuous)
-            .stroke(lsCardStrokeColor, lineWidth: 1)
-        )
-    )
-    .padding(.horizontal, 6)
-    .padding(.vertical, 4)
     .widgetURL(
       BusArrivalDeepLink.route(
         provider: context.attributes.provider,

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -227,10 +227,10 @@ struct BusArrivalLiveActivity: Widget {
             .truncationMode(.tail)
         }
         Spacer(minLength: 6)
-        HStack(spacing: 4) {
-          Image(systemName: "clock")
+        HStack(spacing: 3) {
+          Image(systemName: "arrow.clockwise")
             .font(.system(size: 9, weight: .semibold))
-          Text(context.state.updatedAt, style: .time)
+          Text(context.state.updatedAt, style: .relative)
             .font(.system(size: 11, weight: .medium, design: .monospaced))
             .lineLimit(1)
             .fixedSize(horizontal: true, vertical: false)
@@ -792,41 +792,56 @@ private struct LockScreenActivityView: View {
       RoundedRectangle(cornerRadius: 24, style: .continuous)
         .stroke(lsCardStrokeColor, lineWidth: 1)
 
-      VStack(alignment: .leading, spacing: 8) {
-        HStack(alignment: .top, spacing: 8) {
-          if let vehicleId = lsTrimmed(context.state.vehicleId) {
-            HStack(spacing: 4) {
-              Image(systemName: "bus.fill")
-                .font(.system(size: 10))
-              Text(vehicleId)
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
+      HStack(alignment: .top, spacing: 14) {
+        VStack(alignment: .leading, spacing: 8) {
+          HStack(alignment: .top, spacing: 10) {
+            lsRouteBadge(context.attributes.routeName)
+
+            VStack(alignment: .leading, spacing: 5) {
+              Text(context.attributes.pathName)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(lsSecondaryTextColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .truncationMode(.tail)
+
+              if let modeLabel = lsTrimmed(context.state.modeLabel) {
+                lsModePill(modeLabel)
+              }
             }
-            .foregroundStyle(lsSecondaryTextColor)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 5)
-            .background(
-              Capsule(style: .continuous)
-                .fill(lsSectionFillColor)
-            )
           }
 
-          Spacer(minLength: 0)
-
-          HStack(spacing: 4) {
-            Image(systemName: "clock")
-              .font(.system(size: 9, weight: .semibold))
-            Text(context.state.updatedAt, style: .time)
-              .font(.system(size: 11, weight: .medium, design: .monospaced))
+          HStack(spacing: 6) {
+            Image(systemName: "mappin.circle.fill")
+              .font(.system(size: 14))
+              .foregroundStyle(lsHighlightTextColor)
+            Text(lsDisplayStopName(context.state))
+              .font(.system(size: 16, weight: .semibold))
+              .foregroundStyle(lsPrimaryTextColor)
               .lineLimit(1)
           }
-          .foregroundStyle(lsTimestampTextColor)
-          .padding(.horizontal, 8)
-          .padding(.vertical, 5)
+          .padding(.horizontal, 10)
+          .padding(.vertical, 7)
+          .frame(maxWidth: .infinity, alignment: .leading)
           .background(
-            Capsule(style: .continuous)
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
               .fill(lsSectionFillColor)
           )
 
+          if let statusText = lsTrimmed(context.state.statusText) {
+            Text(statusText)
+              .font(.system(size: 12, weight: .medium))
+              .foregroundStyle(lsSecondaryTextColor)
+              .lineLimit(2)
+              .minimumScaleFactor(0.85)
+              .frame(maxWidth: .infinity, alignment: .leading)
+          }
+
+          lsStopLineView(context.state)
+            .padding(.top, 2)
+        }
+
+        VStack(alignment: .trailing, spacing: 8) {
           VStack(alignment: .trailing, spacing: 2) {
             Text("到站")
               .font(.system(size: 10, weight: .semibold))
@@ -844,76 +859,37 @@ private struct LockScreenActivityView: View {
           .padding(.horizontal, 10)
           .padding(.vertical, 8)
           .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
               .fill(lsEtaPanelFillColor)
           )
           .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
               .stroke(lsEtaPanelStrokeColor, lineWidth: 1)
           )
-        }
 
-        HStack(alignment: .top, spacing: 10) {
-          lsRouteBadge(context.attributes.routeName)
-
-          VStack(alignment: .leading, spacing: 6) {
-            Text(context.attributes.pathName)
-              .font(.system(size: 14, weight: .semibold))
-              .foregroundStyle(lsSecondaryTextColor)
-              .lineLimit(1)
-              .minimumScaleFactor(0.8)
-              .truncationMode(.tail)
-
-            if let modeLabel = lsTrimmed(context.state.modeLabel) {
-              lsModePill(modeLabel)
+          if let vehicleId = lsTrimmed(context.state.vehicleId) {
+            HStack(spacing: 4) {
+              Image(systemName: "bus.fill")
+                .font(.system(size: 10))
+              Text(vehicleId)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .lineLimit(1)
             }
+            .foregroundStyle(lsSecondaryTextColor)
           }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .background(
-          RoundedRectangle(cornerRadius: 16, style: .continuous)
-            .fill(lsSectionFillColor)
-        )
 
-        VStack(alignment: .leading, spacing: 5) {
-          HStack(spacing: 6) {
-            Image(systemName: "mappin.circle.fill")
-              .font(.system(size: 14))
-              .foregroundStyle(lsHighlightTextColor)
-            Text(lsDisplayStopName(context.state))
-              .font(.system(size: 16, weight: .semibold))
-              .foregroundStyle(lsPrimaryTextColor)
+          HStack(spacing: 3) {
+            Image(systemName: "arrow.clockwise")
+              .font(.system(size: 8, weight: .semibold))
+            Text(context.state.updatedAt, style: .relative)
+              .font(.system(size: 10, weight: .medium, design: .monospaced))
               .lineLimit(1)
           }
-
-          if let statusText = lsTrimmed(context.state.statusText) {
-            Text(statusText)
-              .font(.system(size: 12, weight: .medium))
-              .foregroundStyle(lsSecondaryTextColor)
-              .lineLimit(1)
-              .minimumScaleFactor(0.88)
-              .truncationMode(.tail)
-          }
+          .foregroundStyle(lsTimestampTextColor)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(
-          RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .fill(lsSectionFillColor)
-        )
-
-        lsStopLineView(context.state)
-          .padding(.horizontal, 10)
-          .padding(.top, 8)
-          .padding(.bottom, 7)
-          .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-              .fill(lsSectionFillColor)
-          )
+        .fixedSize(horizontal: true, vertical: false)
       }
-      .padding(.horizontal, 14)
+      .padding(.horizontal, 16)
       .padding(.vertical, 14)
     }
     .padding(.horizontal, 6)

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -11,15 +11,16 @@ struct BusArrivalLiveActivity: Widget {
       DynamicIsland {
         DynamicIslandExpandedRegion(.leading) {
           expandedLeading(context: context)
-            .padding(.leading, 10)
+            .dynamicIsland(verticalPlacement: .belowIfTooWide)
+            .padding(.leading, 8)
         }
         DynamicIslandExpandedRegion(.trailing) {
           expandedTrailing(context: context)
-            .padding(.trailing, 10)
+            .padding(.trailing, 8)
         }
         DynamicIslandExpandedRegion(.bottom) {
           expandedBottom(context: context)
-            .padding(.horizontal, 10)
+            .padding(.horizontal, 8)
             .padding(.bottom, 4)
         }
       } compactLeading: {
@@ -791,122 +792,133 @@ private struct LockScreenActivityView: View {
       RoundedRectangle(cornerRadius: 24, style: .continuous)
         .stroke(lsCardStrokeColor, lineWidth: 1)
 
-      HStack(spacing: 16) {
-        VStack(alignment: .leading, spacing: 10) {
-          HStack(alignment: .top, spacing: 10) {
-            lsRouteBadge(context.attributes.routeName)
+      VStack(alignment: .leading, spacing: 10) {
+        HStack(alignment: .top) {
+          Spacer(minLength: 0)
 
-            VStack(alignment: .leading, spacing: 6) {
-              Text(context.attributes.pathName)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(lsSecondaryTextColor)
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
-                .truncationMode(.tail)
+          VStack(alignment: .trailing, spacing: 8) {
+            VStack(alignment: .trailing, spacing: 4) {
+              Text("到站")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(lsEtaColor(context.state).opacity(0.9))
 
-              if let modeLabel = lsTrimmed(context.state.modeLabel) {
-                lsModePill(modeLabel)
-              }
-            }
-          }
-
-          HStack(spacing: 6) {
-            Image(systemName: "mappin.circle.fill")
-              .font(.system(size: 14))
-              .foregroundStyle(lsHighlightTextColor)
-            Text(lsDisplayStopName(context.state))
-              .font(.system(size: 16, weight: .semibold))
-              .foregroundStyle(lsPrimaryTextColor)
+              lsCountdownText(
+                context.state,
+                font: .system(size: 32, weight: .bold, design: .rounded)
+              )
+              .foregroundStyle(lsEtaColor(context.state))
               .lineLimit(1)
-          }
-          .padding(.horizontal, 10)
-          .padding(.vertical, 8)
-          .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-              .fill(lsSectionFillColor)
-          )
+              .minimumScaleFactor(0.5)
+              .monospacedDigit()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+              RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(lsEtaPanelFillColor)
+            )
+            .overlay(
+              RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(lsEtaPanelStrokeColor, lineWidth: 1)
+            )
 
-          if let statusText = lsTrimmed(context.state.statusText) {
-            Text(statusText)
-              .font(.system(size: 12, weight: .medium))
-              .foregroundStyle(lsSecondaryTextColor)
-              .lineLimit(2)
-              .minimumScaleFactor(0.9)
-              .padding(.horizontal, 10)
-              .padding(.vertical, 8)
-              .frame(maxWidth: .infinity, alignment: .leading)
+            HStack(spacing: 6) {
+              if let vehicleId = lsTrimmed(context.state.vehicleId) {
+                HStack(spacing: 4) {
+                  Image(systemName: "bus.fill")
+                    .font(.system(size: 10))
+                  Text(vehicleId)
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                }
+                .foregroundStyle(lsSecondaryTextColor)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 5)
+                .background(
+                  Capsule(style: .continuous)
+                    .fill(lsSectionFillColor)
+                )
+              }
+
+              HStack(spacing: 4) {
+                Image(systemName: "clock")
+                  .font(.system(size: 9, weight: .semibold))
+                Text(context.state.updatedAt, style: .time)
+                  .font(.system(size: 11, weight: .medium, design: .monospaced))
+              }
+              .foregroundStyle(lsTimestampTextColor)
+              .padding(.horizontal, 8)
+              .padding(.vertical, 5)
               .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                Capsule(style: .continuous)
                   .fill(lsSectionFillColor)
               )
+            }
           }
+        }
 
-          lsStopLineView(context.state)
+        HStack(alignment: .top, spacing: 10) {
+          lsRouteBadge(context.attributes.routeName)
+
+          VStack(alignment: .leading, spacing: 6) {
+            Text(context.attributes.pathName)
+              .font(.system(size: 14, weight: .semibold))
+              .foregroundStyle(lsSecondaryTextColor)
+              .lineLimit(1)
+              .minimumScaleFactor(0.8)
+              .truncationMode(.tail)
+
+            if let modeLabel = lsTrimmed(context.state.modeLabel) {
+              lsModePill(modeLabel)
+            }
+          }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+          RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .fill(lsSectionFillColor)
+        )
+
+        HStack(spacing: 6) {
+          Image(systemName: "mappin.circle.fill")
+            .font(.system(size: 14))
+            .foregroundStyle(lsHighlightTextColor)
+          Text(lsDisplayStopName(context.state))
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(lsPrimaryTextColor)
+            .lineLimit(1)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+          RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(lsSectionFillColor)
+        )
+
+        if let statusText = lsTrimmed(context.state.statusText) {
+          Text(statusText)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(lsSecondaryTextColor)
+            .lineLimit(2)
+            .minimumScaleFactor(0.9)
             .padding(.horizontal, 10)
-            .padding(.top, 10)
-            .padding(.bottom, 8)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-              RoundedRectangle(cornerRadius: 16, style: .continuous)
+              RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .fill(lsSectionFillColor)
             )
         }
 
-        VStack(alignment: .trailing, spacing: 8) {
-          VStack(alignment: .trailing, spacing: 4) {
-            Text("到站")
-              .font(.system(size: 11, weight: .semibold))
-              .foregroundStyle(lsEtaColor(context.state).opacity(0.9))
-
-            lsCountdownText(
-              context.state,
-              font: .system(size: 32, weight: .bold, design: .rounded)
-            )
-            .foregroundStyle(lsEtaColor(context.state))
-            .lineLimit(1)
-            .minimumScaleFactor(0.5)
-            .monospacedDigit()
-          }
-          .padding(.horizontal, 12)
-          .padding(.vertical, 10)
+        lsStopLineView(context.state)
+          .padding(.horizontal, 10)
+          .padding(.top, 10)
+          .padding(.bottom, 8)
           .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-              .fill(lsEtaPanelFillColor)
-          )
-          .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-              .stroke(lsEtaPanelStrokeColor, lineWidth: 1)
-          )
-
-          if let vehicleId = lsTrimmed(context.state.vehicleId) {
-            HStack(spacing: 4) {
-              Image(systemName: "bus.fill")
-                .font(.system(size: 10))
-              Text(vehicleId)
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
-            }
-            .foregroundStyle(lsSecondaryTextColor)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 5)
-            .background(
-              Capsule(style: .continuous)
-                .fill(lsSectionFillColor)
-            )
-          }
-
-          HStack(spacing: 4) {
-            Image(systemName: "clock")
-              .font(.system(size: 9, weight: .semibold))
-            Text(context.state.updatedAt, style: .time)
-              .font(.system(size: 11, weight: .medium, design: .monospaced))
-          }
-          .foregroundStyle(lsTimestampTextColor)
-          .padding(.horizontal, 8)
-          .padding(.vertical, 5)
-          .background(
-            Capsule(style: .continuous)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
               .fill(lsSectionFillColor)
           )
-        }
       }
       .padding(.horizontal, 16)
       .padding(.vertical, 16)

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -42,14 +42,13 @@ struct BusArrivalLiveActivity: Widget {
       .foregroundStyle(.white)
       .lineLimit(1)
       .minimumScaleFactor(0.55)
-      .padding(.horizontal, 6)
+      .padding(.horizontal, 7)
       .padding(.vertical, 2)
       .background(
         Capsule(style: .continuous)
           .fill(etaColor(context.state).opacity(0.9))
       )
-      .frame(width: 42, alignment: .leading)
-      .clipped()
+      .frame(maxWidth: 56, alignment: .leading)
   }
 
   @ViewBuilder
@@ -97,6 +96,8 @@ struct BusArrivalLiveActivity: Widget {
           .font(.system(size: 12, weight: .medium))
           .foregroundStyle(.secondary)
           .lineLimit(1)
+          .minimumScaleFactor(0.8)
+          .truncationMode(.tail)
       }
 
       if let modeLabel = trimmedText(context.state.modeLabel) {
@@ -155,6 +156,8 @@ struct BusArrivalLiveActivity: Widget {
             .font(.system(size: 11, weight: .medium))
             .foregroundStyle(.secondary)
             .lineLimit(1)
+            .minimumScaleFactor(0.85)
+            .truncationMode(.tail)
         }
         Spacer(minLength: 6)
         Text(context.state.updatedAt, style: .time)
@@ -178,6 +181,8 @@ struct BusArrivalLiveActivity: Widget {
     Text(name)
       .font(.system(size: 14, weight: .heavy, design: .rounded))
       .foregroundStyle(routeBadgeTextColor(surface: surface))
+      .lineLimit(1)
+      .minimumScaleFactor(0.7)
       .padding(.horizontal, 8)
       .padding(.vertical, 3)
       .background(
@@ -212,31 +217,45 @@ struct BusArrivalLiveActivity: Widget {
     colorScheme: ColorScheme = .dark
   ) -> some View {
     if let stopLine = stopLineData(state) {
-      VStack(spacing: 6) {
+      // Markers and labels share the same equal-width columns so each dot
+      // lines up exactly above its stop name.
+      VStack(spacing: 5) {
         HStack(spacing: 0) {
           ForEach(stopLine.stopNames.indices, id: \.self) { index in
-            stopMarker(
-              isCurrent: index == stopLine.currentStopIndex,
-              isHighlighted: index == stopLine.highlightedStopIndex,
-              surface: surface,
-              colorScheme: colorScheme
-            )
-            .frame(width: 18)
-
-            if index < stopLine.stopNames.count - 1 {
-              stopConnector(
-                intensity: stopConnectorOpacity(
-                  currentStopIndex: stopLine.currentStopIndex,
-                  connectorIndex: index
-                ),
+            ZStack {
+              HStack(spacing: 0) {
+                stopConnectorSegment(
+                  visible: index > 0,
+                  intensity: stopConnectorOpacity(
+                    currentStopIndex: stopLine.currentStopIndex,
+                    connectorIndex: index - 1
+                  ),
+                  surface: surface,
+                  colorScheme: colorScheme
+                )
+                stopConnectorSegment(
+                  visible: index < stopLine.stopNames.count - 1,
+                  intensity: stopConnectorOpacity(
+                    currentStopIndex: stopLine.currentStopIndex,
+                    connectorIndex: index
+                  ),
+                  surface: surface,
+                  colorScheme: colorScheme
+                )
+              }
+              stopMarker(
+                isCurrent: index == stopLine.currentStopIndex,
+                isHighlighted: index == stopLine.highlightedStopIndex,
                 surface: surface,
                 colorScheme: colorScheme
               )
             }
+            .frame(maxWidth: .infinity)
           }
         }
+        .frame(height: 20)
 
-        HStack(alignment: .top, spacing: 6) {
+        HStack(alignment: .top, spacing: 0) {
           ForEach(stopLine.stopNames.indices, id: \.self) { index in
             stopLineLabel(
               stopLine.stopNames[index],
@@ -266,19 +285,37 @@ struct BusArrivalLiveActivity: Widget {
           Spacer(minLength: 0)
         }
       } else {
-        VStack(spacing: 6) {
+        VStack(spacing: 5) {
           HStack(spacing: 0) {
-            stopMarker(isCurrent: false, isHighlighted: false, surface: surface, colorScheme: colorScheme)
-              .frame(width: 18)
-            stopConnector(intensity: 0.4, surface: surface, colorScheme: colorScheme)
-            stopMarker(isCurrent: true, isHighlighted: true, surface: surface, colorScheme: colorScheme)
-              .frame(width: 18)
-            stopConnector(intensity: 0.22, surface: surface, colorScheme: colorScheme)
-            stopMarker(isCurrent: false, isHighlighted: false, surface: surface, colorScheme: colorScheme)
-              .frame(width: 18)
+            ForEach(0..<3, id: \.self) { index in
+              ZStack {
+                HStack(spacing: 0) {
+                  stopConnectorSegment(
+                    visible: index > 0,
+                    intensity: index == 1 ? 0.4 : 0.22,
+                    surface: surface,
+                    colorScheme: colorScheme
+                  )
+                  stopConnectorSegment(
+                    visible: index < 2,
+                    intensity: index == 0 ? 0.4 : 0.22,
+                    surface: surface,
+                    colorScheme: colorScheme
+                  )
+                }
+                stopMarker(
+                  isCurrent: index == 1,
+                  isHighlighted: index == 1,
+                  surface: surface,
+                  colorScheme: colorScheme
+                )
+              }
+              .frame(maxWidth: .infinity)
+            }
           }
+          .frame(height: 20)
 
-          HStack(alignment: .center, spacing: 8) {
+          HStack(alignment: .top, spacing: 0) {
             stopLineLabel(
               previousStopName ?? "起點",
               isCurrent: false,
@@ -343,12 +380,20 @@ struct BusArrivalLiveActivity: Widget {
   }
 
   @ViewBuilder
-  private func stopConnector(intensity: Double, surface: ActivitySurface, colorScheme: ColorScheme = .dark) -> some View {
-    Capsule(style: .continuous)
-      .fill(stopConnectorColor(surface: surface, intensity: intensity, colorScheme: colorScheme))
+  private func stopConnectorSegment(
+    visible: Bool,
+    intensity: Double,
+    surface: ActivitySurface,
+    colorScheme: ColorScheme = .dark
+  ) -> some View {
+    Rectangle()
+      .fill(
+        visible
+          ? stopConnectorColor(surface: surface, intensity: intensity, colorScheme: colorScheme)
+          : Color.clear
+      )
       .frame(maxWidth: .infinity)
       .frame(height: 2)
-      .padding(.horizontal, 4)
   }
 
   @ViewBuilder
@@ -362,7 +407,7 @@ struct BusArrivalLiveActivity: Widget {
     Text(compactStopLineLabel(text))
       .font(
         .system(
-          size: isCurrent ? 10.5 : 9.5,
+          size: isCurrent ? 11 : 10,
           weight: isCurrent || isHighlighted ? .semibold : .medium
         )
       )
@@ -374,11 +419,10 @@ struct BusArrivalLiveActivity: Widget {
           colorScheme: colorScheme
         )
       )
-      .lineLimit(2)
-      .minimumScaleFactor(0.7)
-      .lineSpacing(-1)
+      .lineLimit(1)
+      .minimumScaleFactor(0.6)
       .multilineTextAlignment(.center)
-      .frame(maxWidth: .infinity, minHeight: 28, alignment: .top)
+      .frame(maxWidth: .infinity, alignment: .center)
   }
 
   private func stopLineData(
@@ -485,10 +529,9 @@ struct BusArrivalLiveActivity: Widget {
   }
 
   private func routeBadgeTextColor(surface: ActivitySurface) -> Color {
-    if surface == .dynamicIsland {
-      return .primary
-    }
-    return .white
+    // The badge always sits on the cyan gradient, so white keeps proper
+    // contrast on every surface (`.primary` could resolve to near-black).
+    .white
   }
 
   private func modePillTextColor(surface: ActivitySurface, colorScheme: ColorScheme) -> Color {
@@ -666,6 +709,8 @@ private struct LockScreenActivityView: View {
             .font(.system(size: 13, weight: .medium))
             .foregroundStyle(lsSecondaryTextColor)
             .lineLimit(1)
+            .minimumScaleFactor(0.8)
+            .truncationMode(.tail)
         }
 
         if let modeLabel = lsTrimmed(context.state.modeLabel) {
@@ -806,6 +851,8 @@ private struct LockScreenActivityView: View {
     Text(name)
       .font(.system(size: 14, weight: .heavy, design: .rounded))
       .foregroundStyle(Color.white)
+      .lineLimit(1)
+      .minimumScaleFactor(0.7)
       .padding(.horizontal, 8)
       .padding(.vertical, 3)
       .background(
@@ -865,17 +912,30 @@ private struct LockScreenActivityView: View {
       let currentIdx = (state.lineCurrentStopIndex.map { $0 >= 0 && $0 < count ? $0 : 0 }) ?? 0
       let highlightIdx = state.lineHighlightedStopIndex.flatMap { $0 >= 0 && $0 < count ? $0 : nil }
 
-      VStack(spacing: 6) {
+      // Markers and labels share the same equal-width columns so each dot
+      // lines up exactly above its stop name.
+      VStack(spacing: 5) {
         HStack(spacing: 0) {
           ForEach(state.lineStopNames.indices, id: \.self) { index in
-            lsStopMarker(isCurrent: index == currentIdx, isHighlighted: index == highlightIdx)
-              .frame(width: 18)
-            if index < count - 1 {
-              lsStopConnector(intensity: index < currentIdx ? 0.46 : 0.18)
+            ZStack {
+              HStack(spacing: 0) {
+                lsStopConnectorSegment(
+                  visible: index > 0,
+                  intensity: index - 1 < currentIdx ? 0.46 : 0.18
+                )
+                lsStopConnectorSegment(
+                  visible: index < count - 1,
+                  intensity: index < currentIdx ? 0.46 : 0.18
+                )
+              }
+              lsStopMarker(isCurrent: index == currentIdx, isHighlighted: index == highlightIdx)
             }
+            .frame(maxWidth: .infinity)
           }
         }
-        HStack(alignment: .top, spacing: 6) {
+        .frame(height: 20)
+
+        HStack(alignment: .top, spacing: 0) {
           ForEach(state.lineStopNames.indices, id: \.self) { index in
             lsStopLabel(
               state.lineStopNames[index],
@@ -897,15 +957,28 @@ private struct LockScreenActivityView: View {
           Spacer(minLength: 0)
         }
       } else {
-        VStack(spacing: 6) {
+        VStack(spacing: 5) {
           HStack(spacing: 0) {
-            lsStopMarker(isCurrent: false, isHighlighted: false).frame(width: 18)
-            lsStopConnector(intensity: 0.4)
-            lsStopMarker(isCurrent: true, isHighlighted: true).frame(width: 18)
-            lsStopConnector(intensity: 0.22)
-            lsStopMarker(isCurrent: false, isHighlighted: false).frame(width: 18)
+            ForEach(0..<3, id: \.self) { index in
+              ZStack {
+                HStack(spacing: 0) {
+                  lsStopConnectorSegment(
+                    visible: index > 0,
+                    intensity: index == 1 ? 0.4 : 0.22
+                  )
+                  lsStopConnectorSegment(
+                    visible: index < 2,
+                    intensity: index == 0 ? 0.4 : 0.22
+                  )
+                }
+                lsStopMarker(isCurrent: index == 1, isHighlighted: index == 1)
+              }
+              .frame(maxWidth: .infinity)
+            }
           }
-          HStack(alignment: .center, spacing: 8) {
+          .frame(height: 20)
+
+          HStack(alignment: .top, spacing: 0) {
             lsStopLabel(prev ?? "起點", isCurrent: false, isHighlighted: false)
             lsStopLabel(current, isCurrent: true, isHighlighted: true)
             lsStopLabel(next ?? "終點", isCurrent: false, isHighlighted: false)
@@ -944,12 +1017,11 @@ private struct LockScreenActivityView: View {
   }
 
   @ViewBuilder
-  private func lsStopConnector(intensity: Double) -> some View {
-    Capsule(style: .continuous)
-      .fill(lsSecondaryTextColor.opacity(max(intensity, 0.12)))
+  private func lsStopConnectorSegment(visible: Bool, intensity: Double) -> some View {
+    Rectangle()
+      .fill(visible ? lsSecondaryTextColor.opacity(max(intensity, 0.12)) : Color.clear)
       .frame(maxWidth: .infinity)
       .frame(height: 2)
-      .padding(.horizontal, 4)
   }
 
   @ViewBuilder
@@ -958,15 +1030,14 @@ private struct LockScreenActivityView: View {
     let color: Color = isCurrent ? lsPrimaryTextColor : (isHighlighted ? lsHighlightTextColor : lsSecondaryTextColor)
     Text(label)
       .font(.system(
-        size: isCurrent ? 10.5 : 9.5,
+        size: isCurrent ? 11 : 10,
         weight: isCurrent || isHighlighted ? .semibold : .medium
       ))
       .foregroundStyle(color)
-      .lineLimit(2)
-      .minimumScaleFactor(0.7)
-      .lineSpacing(-1)
+      .lineLimit(1)
+      .minimumScaleFactor(0.6)
       .multilineTextAlignment(.center)
-      .frame(maxWidth: .infinity, minHeight: 28, alignment: .top)
+      .frame(maxWidth: .infinity, alignment: .center)
   }
 
   private func lsCompactStopLabel(_ text: String) -> String {

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -777,112 +777,120 @@ private struct LockScreenActivityView: View {
   @Environment(\.colorScheme) private var colorScheme
 
   var body: some View {
-    ZStack {
+    // IMPORTANT: do NOT wrap this in a `ZStack { RoundedRectangle()… ; content }`.
+    // A bare Shape used as a ZStack sibling is greedy and expands to fill every
+    // size the system proposes. On the unlocked lock screen and during the
+    // lock-screen → Dynamic Island hand-off the system proposes a large size,
+    // which made the card balloon into a giant blank rectangle. Applying the
+    // card as a `.background` modifier keeps it sized to the content instead.
+    HStack(alignment: .top, spacing: 14) {
+      VStack(alignment: .leading, spacing: 8) {
+        HStack(alignment: .top, spacing: 10) {
+          lsRouteBadge(context.attributes.routeName)
+
+          VStack(alignment: .leading, spacing: 5) {
+            Text(context.attributes.pathName)
+              .font(.system(size: 14, weight: .semibold))
+              .foregroundStyle(lsSecondaryTextColor)
+              .lineLimit(1)
+              .minimumScaleFactor(0.8)
+              .truncationMode(.tail)
+
+            if let modeLabel = lsTrimmed(context.state.modeLabel) {
+              lsModePill(modeLabel)
+            }
+          }
+        }
+
+        HStack(spacing: 6) {
+          Image(systemName: "mappin.circle.fill")
+            .font(.system(size: 14))
+            .foregroundStyle(lsHighlightTextColor)
+          Text(lsDisplayStopName(context.state))
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(lsPrimaryTextColor)
+            .lineLimit(1)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+          RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(lsSectionFillColor)
+        )
+
+        if let statusText = lsTrimmed(context.state.statusText) {
+          Text(statusText)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(lsSecondaryTextColor)
+            .lineLimit(2)
+            .minimumScaleFactor(0.85)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        lsStopLineView(context.state)
+          .padding(.top, 2)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      VStack(alignment: .trailing, spacing: 8) {
+        VStack(alignment: .trailing, spacing: 2) {
+          Text("到站")
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(lsEtaColor(context.state).opacity(0.9))
+
+          lsCountdownText(
+            context.state,
+            font: .system(size: 30, weight: .bold, design: .rounded)
+          )
+          .foregroundStyle(lsEtaColor(context.state))
+          .lineLimit(1)
+          .minimumScaleFactor(0.5)
+          .monospacedDigit()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+          RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .fill(lsEtaPanelFillColor)
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .stroke(lsEtaPanelStrokeColor, lineWidth: 1)
+        )
+
+        if let vehicleId = lsTrimmed(context.state.vehicleId) {
+          HStack(spacing: 4) {
+            Image(systemName: "bus.fill")
+              .font(.system(size: 10))
+            Text(vehicleId)
+              .font(.system(size: 11, weight: .medium, design: .monospaced))
+              .lineLimit(1)
+          }
+          .foregroundStyle(lsSecondaryTextColor)
+        }
+
+        HStack(spacing: 3) {
+          Image(systemName: "arrow.clockwise")
+            .font(.system(size: 8, weight: .semibold))
+          Text(context.state.updatedAt, style: .relative)
+            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .lineLimit(1)
+        }
+        .foregroundStyle(lsTimestampTextColor)
+      }
+      .fixedSize(horizontal: true, vertical: false)
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 14)
+    .background(
       RoundedRectangle(cornerRadius: 24, style: .continuous)
         .fill(lsCardFillColor)
-      RoundedRectangle(cornerRadius: 24, style: .continuous)
-        .stroke(lsCardStrokeColor, lineWidth: 1)
-
-      HStack(alignment: .top, spacing: 14) {
-        VStack(alignment: .leading, spacing: 8) {
-          HStack(alignment: .top, spacing: 10) {
-            lsRouteBadge(context.attributes.routeName)
-
-            VStack(alignment: .leading, spacing: 5) {
-              Text(context.attributes.pathName)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(lsSecondaryTextColor)
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
-                .truncationMode(.tail)
-
-              if let modeLabel = lsTrimmed(context.state.modeLabel) {
-                lsModePill(modeLabel)
-              }
-            }
-          }
-
-          HStack(spacing: 6) {
-            Image(systemName: "mappin.circle.fill")
-              .font(.system(size: 14))
-              .foregroundStyle(lsHighlightTextColor)
-            Text(lsDisplayStopName(context.state))
-              .font(.system(size: 16, weight: .semibold))
-              .foregroundStyle(lsPrimaryTextColor)
-              .lineLimit(1)
-          }
-          .padding(.horizontal, 10)
-          .padding(.vertical, 7)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-              .fill(lsSectionFillColor)
-          )
-
-          if let statusText = lsTrimmed(context.state.statusText) {
-            Text(statusText)
-              .font(.system(size: 12, weight: .medium))
-              .foregroundStyle(lsSecondaryTextColor)
-              .lineLimit(2)
-              .minimumScaleFactor(0.85)
-              .frame(maxWidth: .infinity, alignment: .leading)
-          }
-
-          lsStopLineView(context.state)
-            .padding(.top, 2)
-        }
-
-        VStack(alignment: .trailing, spacing: 8) {
-          VStack(alignment: .trailing, spacing: 2) {
-            Text("到站")
-              .font(.system(size: 10, weight: .semibold))
-              .foregroundStyle(lsEtaColor(context.state).opacity(0.9))
-
-            lsCountdownText(
-              context.state,
-              font: .system(size: 30, weight: .bold, design: .rounded)
-            )
-            .foregroundStyle(lsEtaColor(context.state))
-            .lineLimit(1)
-            .minimumScaleFactor(0.5)
-            .monospacedDigit()
-          }
-          .padding(.horizontal, 10)
-          .padding(.vertical, 8)
-          .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-              .fill(lsEtaPanelFillColor)
-          )
-          .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-              .stroke(lsEtaPanelStrokeColor, lineWidth: 1)
-          )
-
-          if let vehicleId = lsTrimmed(context.state.vehicleId) {
-            HStack(spacing: 4) {
-              Image(systemName: "bus.fill")
-                .font(.system(size: 10))
-              Text(vehicleId)
-                .font(.system(size: 11, weight: .medium, design: .monospaced))
-                .lineLimit(1)
-            }
-            .foregroundStyle(lsSecondaryTextColor)
-          }
-
-          HStack(spacing: 3) {
-            Image(systemName: "arrow.clockwise")
-              .font(.system(size: 8, weight: .semibold))
-            Text(context.state.updatedAt, style: .relative)
-              .font(.system(size: 10, weight: .medium, design: .monospaced))
-              .lineLimit(1)
-          }
-          .foregroundStyle(lsTimestampTextColor)
-        }
-        .fixedSize(horizontal: true, vertical: false)
-      }
-      .padding(.horizontal, 16)
-      .padding(.vertical, 14)
-    }
+        .overlay(
+          RoundedRectangle(cornerRadius: 24, style: .continuous)
+            .stroke(lsCardStrokeColor, lineWidth: 1)
+        )
+    )
     .padding(.horizontal, 6)
     .padding(.vertical, 4)
     .widgetURL(

--- a/ios/YABusWidgets/BusArrivalLiveActivity.swift
+++ b/ios/YABusWidgets/BusArrivalLiveActivity.swift
@@ -215,49 +215,39 @@ struct BusArrivalLiveActivity: Widget {
       VStack(spacing: 6) {
         HStack(spacing: 0) {
           ForEach(stopLine.stopNames.indices, id: \.self) { index in
-            stopMarker(
+            routeStopColumnMarker(
               isCurrent: index == stopLine.currentStopIndex,
               isHighlighted: index == stopLine.highlightedStopIndex,
+              previousConnectorVisible: index > 0,
+              nextConnectorVisible: index < stopLine.stopNames.count - 1,
+              previousConnectorIntensity: stopConnectorOpacity(
+                currentStopIndex: stopLine.currentStopIndex,
+                connectorIndex: index - 1
+              ),
+              nextConnectorIntensity: stopConnectorOpacity(
+                currentStopIndex: stopLine.currentStopIndex,
+                connectorIndex: index
+              ),
+              etaLabel: index == stopLine.currentStopIndex
+                ? routeBarEtaLabel(state)
+                : nil,
+              state: state,
               surface: surface,
               colorScheme: colorScheme
             )
-            .frame(width: 18)
-
-            if index < stopLine.stopNames.count - 1 {
-              stopConnector(
-                intensity: stopConnectorOpacity(
-                  currentStopIndex: stopLine.currentStopIndex,
-                  connectorIndex: index
-                ),
-                surface: surface,
-                colorScheme: colorScheme
-              )
-            }
+            .frame(maxWidth: .infinity)
           }
         }
 
         HStack(alignment: .top, spacing: 6) {
           ForEach(stopLine.stopNames.indices, id: \.self) { index in
-            VStack(spacing: 1) {
-              stopLineLabel(
-                stopLine.stopNames[index],
-                isCurrent: index == stopLine.currentStopIndex,
-                isHighlighted: index == stopLine.highlightedStopIndex,
-                surface: surface,
-                colorScheme: colorScheme
-              )
-
-              if index == stopLine.currentStopIndex,
-                let etaLabel = routeBarEtaLabel(state) {
-                Text(etaLabel)
-                  .font(.system(size: 10, weight: .bold, design: .rounded))
-                  .foregroundStyle(etaColor(state))
-                  .lineLimit(1)
-                  .minimumScaleFactor(0.6)
-                  .monospacedDigit()
-              }
-            }
-            .frame(maxWidth: .infinity, alignment: .top)
+            stopLineLabel(
+              stopLine.stopNames[index],
+              isCurrent: index == stopLine.currentStopIndex,
+              isHighlighted: index == stopLine.highlightedStopIndex,
+              surface: surface,
+              colorScheme: colorScheme
+            )
           }
         }
       }
@@ -267,8 +257,24 @@ struct BusArrivalLiveActivity: Widget {
       let currentStopName = displayStopName(state)
 
       if previousStopName == nil && nextStopName == nil {
-        HStack {
-          Spacer(minLength: 0)
+        VStack(spacing: 6) {
+          HStack(spacing: 0) {
+            Spacer(minLength: 0)
+            routeStopColumnMarker(
+              isCurrent: true,
+              isHighlighted: true,
+              previousConnectorVisible: false,
+              nextConnectorVisible: false,
+              previousConnectorIntensity: 0,
+              nextConnectorIntensity: 0,
+              etaLabel: routeBarEtaLabel(state),
+              state: state,
+              surface: surface,
+              colorScheme: colorScheme
+            )
+            .frame(maxWidth: .infinity)
+            Spacer(minLength: 0)
+          }
           stopLineLabel(
             currentStopName,
             isCurrent: true,
@@ -276,19 +282,49 @@ struct BusArrivalLiveActivity: Widget {
             surface: surface,
             colorScheme: colorScheme
           )
-          Spacer(minLength: 0)
         }
       } else {
         VStack(spacing: 6) {
           HStack(spacing: 0) {
-            stopMarker(isCurrent: false, isHighlighted: false, surface: surface, colorScheme: colorScheme)
-              .frame(width: 18)
-            stopConnector(intensity: 0.4, surface: surface, colorScheme: colorScheme)
-            stopMarker(isCurrent: true, isHighlighted: true, surface: surface, colorScheme: colorScheme)
-              .frame(width: 18)
-            stopConnector(intensity: 0.22, surface: surface, colorScheme: colorScheme)
-            stopMarker(isCurrent: false, isHighlighted: false, surface: surface, colorScheme: colorScheme)
-              .frame(width: 18)
+            routeStopColumnMarker(
+              isCurrent: false,
+              isHighlighted: false,
+              previousConnectorVisible: false,
+              nextConnectorVisible: true,
+              previousConnectorIntensity: 0,
+              nextConnectorIntensity: 0.4,
+              etaLabel: nil,
+              state: state,
+              surface: surface,
+              colorScheme: colorScheme
+            )
+            .frame(maxWidth: .infinity)
+            routeStopColumnMarker(
+              isCurrent: true,
+              isHighlighted: true,
+              previousConnectorVisible: true,
+              nextConnectorVisible: true,
+              previousConnectorIntensity: 0.4,
+              nextConnectorIntensity: 0.22,
+              etaLabel: routeBarEtaLabel(state),
+              state: state,
+              surface: surface,
+              colorScheme: colorScheme
+            )
+            .frame(maxWidth: .infinity)
+            routeStopColumnMarker(
+              isCurrent: false,
+              isHighlighted: false,
+              previousConnectorVisible: true,
+              nextConnectorVisible: false,
+              previousConnectorIntensity: 0.22,
+              nextConnectorIntensity: 0,
+              etaLabel: nil,
+              state: state,
+              surface: surface,
+              colorScheme: colorScheme
+            )
+            .frame(maxWidth: .infinity)
           }
 
           HStack(alignment: .top, spacing: 8) {
@@ -299,24 +335,13 @@ struct BusArrivalLiveActivity: Widget {
               surface: surface,
               colorScheme: colorScheme
             )
-            VStack(spacing: 1) {
-              stopLineLabel(
-                currentStopName,
-                isCurrent: true,
-                isHighlighted: true,
-                surface: surface,
-                colorScheme: colorScheme
-              )
-              if let etaLabel = routeBarEtaLabel(state) {
-                Text(etaLabel)
-                  .font(.system(size: 10, weight: .bold, design: .rounded))
-                  .foregroundStyle(etaColor(state))
-                  .lineLimit(1)
-                  .minimumScaleFactor(0.6)
-                  .monospacedDigit()
-              }
-            }
-            .frame(maxWidth: .infinity, alignment: .top)
+            stopLineLabel(
+              currentStopName,
+              isCurrent: true,
+              isHighlighted: true,
+              surface: surface,
+              colorScheme: colorScheme
+            )
             stopLineLabel(
               nextStopName ?? "終點",
               isCurrent: false,
@@ -373,6 +398,73 @@ struct BusArrivalLiveActivity: Widget {
       .frame(maxWidth: .infinity)
       .frame(height: 2)
       .padding(.horizontal, 4)
+  }
+
+  @ViewBuilder
+  private func routeStopColumnMarker(
+    isCurrent: Bool,
+    isHighlighted: Bool,
+    previousConnectorVisible: Bool,
+    nextConnectorVisible: Bool,
+    previousConnectorIntensity: Double,
+    nextConnectorIntensity: Double,
+    etaLabel: String?,
+    state: BusArrivalAttributes.ContentState,
+    surface: ActivitySurface,
+    colorScheme: ColorScheme = .dark
+  ) -> some View {
+    VStack(spacing: 1) {
+      ZStack {
+        HStack(spacing: 0) {
+          stopHalfConnector(
+            visible: previousConnectorVisible,
+            intensity: previousConnectorIntensity,
+            surface: surface,
+            colorScheme: colorScheme
+          )
+          stopHalfConnector(
+            visible: nextConnectorVisible,
+            intensity: nextConnectorIntensity,
+            surface: surface,
+            colorScheme: colorScheme
+          )
+        }
+
+        stopMarker(
+          isCurrent: isCurrent,
+          isHighlighted: isHighlighted,
+          surface: surface,
+          colorScheme: colorScheme
+        )
+      }
+      .frame(height: 20)
+
+      if let etaLabel {
+        Text(etaLabel)
+          .font(.system(size: 10, weight: .bold, design: .rounded))
+          .foregroundStyle(etaColor(state))
+          .lineLimit(1)
+          .minimumScaleFactor(0.6)
+          .monospacedDigit()
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func stopHalfConnector(
+    visible: Bool,
+    intensity: Double,
+    surface: ActivitySurface,
+    colorScheme: ColorScheme = .dark
+  ) -> some View {
+    Rectangle()
+      .fill(
+        visible
+          ? stopConnectorColor(surface: surface, intensity: intensity, colorScheme: colorScheme)
+          : Color.clear
+      )
+      .frame(maxWidth: .infinity)
+      .frame(height: 2)
   }
 
   @ViewBuilder

--- a/lib/app/bus_app.dart
+++ b/lib/app/bus_app.dart
@@ -18,6 +18,7 @@ import '../core/app_route_observer.dart';
 import '../core/ios_widget_integration.dart';
 import '../core/models.dart';
 import '../core/route_detail_launch_bridge.dart';
+import '../core/startup_permission_service.dart';
 import '../core/web_update_checker_stub.dart'
     if (dart.library.html) '../core/web_update_checker_web.dart'
     as web_update;
@@ -378,7 +379,14 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
           _maybeScheduleAnnouncementOpen();
         });
     _scheduleIOSWidgetSync();
+    _scheduleStartupPermissionPrompt();
     _initWebUpdateChecker();
+  }
+
+  void _scheduleStartupPermissionPrompt() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(StartupPermissionService.instance.requestInitialPermissions());
+    });
   }
 
   void _initWebUpdateChecker() {

--- a/lib/core/app_controller.dart
+++ b/lib/core/app_controller.dart
@@ -153,9 +153,9 @@ class AppController extends ChangeNotifier {
                 '${favorite.pathId}:'
                 '${favorite.stopId}:'
                 '${favorite.stopName ?? ''}:'
-                '${favorite.effectiveDestinationPathId ?? 0}:'
-                '${favorite.effectiveDestinationStopId ?? 0}:'
-                '${favorite.effectiveDestinationStopName ?? ''}',
+                '${favorite.destinationPathId ?? 0}:'
+                '${favorite.destinationStopId ?? 0}:'
+                '${favorite.destinationStopName ?? ''}',
           ),
         ),
       )
@@ -1017,26 +1017,23 @@ class AppController extends ChangeNotifier {
   }
 
   List<Map<String, dynamic>> _buildWearUsageProfilesPayload() {
-    final providerProfiles =
-        _routeUsageProfiles
-            .where((entry) => entry.provider == _settings.provider)
-            .toList()
-          ..sort((a, b) => b.totalOpens.compareTo(a.totalOpens));
+    final providerProfiles = _routeUsageProfiles
+        .where((entry) => entry.provider == _settings.provider)
+        .toList()
+      ..sort((a, b) => b.totalOpens.compareTo(a.totalOpens));
     final limited = providerProfiles.take(40);
     return limited
-        .map(
-          (profile) => {
-            'provider': profile.provider.name,
-            'routeKey': profile.routeKey,
-            'routeName': profile.routeName,
-            'totalOpens': profile.totalOpens,
-            'lastOpenedAtMs': profile.lastOpenedAtMs,
-            'hourlyOpens': profile.hourlyOpens.map(
-              (key, value) => MapEntry(key.toString(), value),
-            ),
-            'recentSelectionMs': profile.selectionTimestampsWithin(),
-          },
-        )
+        .map((profile) => {
+              'provider': profile.provider.name,
+              'routeKey': profile.routeKey,
+              'routeName': profile.routeName,
+              'totalOpens': profile.totalOpens,
+              'lastOpenedAtMs': profile.lastOpenedAtMs,
+              'hourlyOpens': profile.hourlyOpens.map(
+                (key, value) => MapEntry(key.toString(), value),
+              ),
+              'recentSelectionMs': profile.selectionTimestampsWithin(),
+            })
         .toList(growable: false);
   }
 
@@ -1070,8 +1067,14 @@ class AppController extends ChangeNotifier {
           ? suggestion.profile.routeName
           : (detail?.route.routeName ?? routeId),
       'provider': suggestion.profile.provider.name,
-      if (path != null) ...{'pathId': path.pathId, 'pathName': path.name},
-      if (stop != null) ...{'stopId': stop.stopId, 'stopName': stop.stopName},
+      if (path != null) ...{
+        'pathId': path.pathId,
+        'pathName': path.name,
+      },
+      if (stop != null) ...{
+        'stopId': stop.stopId,
+        'stopName': stop.stopName,
+      },
       'reason': suggestion.reason,
       if (suggestion.distanceMeters != null)
         'distanceMeters': suggestion.distanceMeters,
@@ -1742,8 +1745,7 @@ class AppController extends ChangeNotifier {
     // Desktop platforms always auto-download database updates regardless of
     // the saved mode, since they typically have stable Wi-Fi/Ethernet and
     // Connectivity detection may not work reliably on desktop.
-    final isDesktop =
-        !kIsWeb &&
+    final isDesktop = !kIsWeb &&
         (defaultTargetPlatform == TargetPlatform.windows ||
             defaultTargetPlatform == TargetPlatform.linux ||
             defaultTargetPlatform == TargetPlatform.macOS);
@@ -2230,8 +2232,7 @@ class AppController extends ChangeNotifier {
     final signature = smartRouteSignature;
     final nowMs = DateTime.now().millisecondsSinceEpoch;
     final signatureUnchanged = _lastWearSmartSignature == signature;
-    final tooSoon =
-        nowMs - _lastWearSmartPushAtMs <
+    final tooSoon = nowMs - _lastWearSmartPushAtMs <
         const Duration(minutes: 5).inMilliseconds;
     if (signatureUnchanged && tooSoon) {
       return;
@@ -2306,7 +2307,6 @@ class AppController extends ChangeNotifier {
     FavoriteStop favorite, {
     String? groupName,
   }) async {
-    final normalizedFavorite = _favoriteWithoutSelfDestination(favorite);
     final targetGroup = groupName?.trim().isNotEmpty == true
         ? groupName!.trim()
         : (_favoriteGroups.isEmpty
@@ -2321,9 +2321,7 @@ class AppController extends ChangeNotifier {
       (sum, list) => sum + list.length,
     );
     final alreadyExists =
-        _favoriteGroups[targetGroup]?.any(
-          (item) => item.sameAs(normalizedFavorite),
-        ) ??
+        _favoriteGroups[targetGroup]?.any((item) => item.sameAs(favorite)) ??
         false;
     if (!alreadyExists && currentTotal >= maxFavoritesTotal) {
       throw FavoriteGroupFullException(targetGroup, maxFavoritesTotal);
@@ -2335,39 +2333,39 @@ class AppController extends ChangeNotifier {
     };
     next.putIfAbsent(targetGroup, () => <FavoriteStop>[]);
     final existingIndex = next[targetGroup]!.indexWhere(
-      (item) => item.sameAs(normalizedFavorite),
+      (item) => item.sameAs(favorite),
     );
     final replacedExisting = existingIndex != -1;
     if (existingIndex == -1) {
-      next[targetGroup]!.add(normalizedFavorite);
+      next[targetGroup]!.add(favorite);
     } else {
       final existing = next[targetGroup]![existingIndex];
-      final routeId = normalizedFavorite.routeId?.trim().isNotEmpty == true
-          ? normalizedFavorite.routeId
+      final routeId = favorite.routeId?.trim().isNotEmpty == true
+          ? favorite.routeId
           : existing.routeId;
-      final routeName = normalizedFavorite.routeName?.trim().isNotEmpty == true
-          ? normalizedFavorite.routeName
+      final routeName = favorite.routeName?.trim().isNotEmpty == true
+          ? favorite.routeName
           : existing.routeName;
-      final stopName = normalizedFavorite.stopName?.trim().isNotEmpty == true
-          ? normalizedFavorite.stopName
+      final stopName = favorite.stopName?.trim().isNotEmpty == true
+          ? favorite.stopName
           : existing.stopName;
-      final destinationStopId = normalizedFavorite.effectiveDestinationStopId;
+      final destinationStopId = favorite.destinationStopId;
       final mergedDestinationStopId =
-          destinationStopId ?? existing.effectiveDestinationStopId;
+          destinationStopId ?? existing.destinationStopId;
       final mergedDestinationPathId = mergedDestinationStopId == null
           ? null
           : (destinationStopId == null
-                ? existing.effectiveDestinationPathId
-                : normalizedFavorite.effectiveDestinationPathId);
+                ? existing.destinationPathId
+                : (favorite.destinationPathId ?? favorite.pathId));
       final mergedDestinationStopName = destinationStopId == null
-          ? existing.effectiveDestinationStopName
-          : normalizedFavorite.effectiveDestinationStopName;
+          ? existing.destinationStopName
+          : favorite.destinationStopName;
 
       next[targetGroup]![existingIndex] = FavoriteStop(
-        provider: normalizedFavorite.provider,
-        routeKey: normalizedFavorite.routeKey,
-        pathId: normalizedFavorite.pathId,
-        stopId: normalizedFavorite.stopId,
+        provider: favorite.provider,
+        routeKey: favorite.routeKey,
+        pathId: favorite.pathId,
+        stopId: favorite.stopId,
         routeId: routeId,
         routeName: routeName,
         stopName: stopName,
@@ -2383,32 +2381,17 @@ class AppController extends ChangeNotifier {
     await AndroidHomeIntegration.refreshFavoriteWidgets();
     await _syncWearOsSnapshot(requestRefresh: false);
     final savedFavorite = next[targetGroup]!.firstWhere(
-      (item) => item.sameAs(normalizedFavorite),
-      orElse: () => normalizedFavorite,
+      (item) => item.sameAs(favorite),
+      orElse: () => favorite,
     );
     await analytics.logFavoriteStopSaved(
-      provider: normalizedFavorite.provider,
-      routeKey: normalizedFavorite.routeKey,
+      provider: favorite.provider,
+      routeKey: favorite.routeKey,
       replacedExisting: replacedExisting,
-      hasDestination: savedFavorite.hasDestination,
+      hasDestination: savedFavorite.destinationStopId != null,
     );
     notifyListeners();
     return targetGroup;
-  }
-
-  FavoriteStop _favoriteWithoutSelfDestination(FavoriteStop favorite) {
-    if (!favorite.destinationMatchesStop) {
-      return favorite;
-    }
-    return FavoriteStop(
-      provider: favorite.provider,
-      routeKey: favorite.routeKey,
-      pathId: favorite.pathId,
-      stopId: favorite.stopId,
-      routeId: favorite.routeId,
-      routeName: favorite.routeName,
-      stopName: favorite.stopName,
-    );
   }
 
   Future<bool> updateFavoriteDestination(
@@ -2423,22 +2406,13 @@ class AppController extends ChangeNotifier {
       return false;
     }
 
-    final requestedDestinationStopId =
+    final normalizedDestinationStopId =
         destinationStopId != null && destinationStopId > 0
         ? destinationStopId
         : null;
-    final requestedDestinationPathId = requestedDestinationStopId == null
+    final normalizedDestinationPathId = normalizedDestinationStopId == null
         ? null
         : (destinationPathId ?? favorite.pathId);
-    final isSelfDestination =
-        requestedDestinationStopId == favorite.stopId &&
-        requestedDestinationPathId == favorite.pathId;
-    final normalizedDestinationStopId = isSelfDestination
-        ? null
-        : requestedDestinationStopId;
-    final normalizedDestinationPathId = isSelfDestination
-        ? null
-        : requestedDestinationPathId;
     final normalizedDestinationStopName = normalizedDestinationStopId == null
         ? null
         : (destinationStopName?.trim().isNotEmpty == true
@@ -2453,9 +2427,9 @@ class AppController extends ChangeNotifier {
       }
 
       found = true;
-      if (item.effectiveDestinationPathId == normalizedDestinationPathId &&
-          item.effectiveDestinationStopId == normalizedDestinationStopId &&
-          item.effectiveDestinationStopName == normalizedDestinationStopName) {
+      if (item.destinationPathId == normalizedDestinationPathId &&
+          item.destinationStopId == normalizedDestinationStopId &&
+          item.destinationStopName == normalizedDestinationStopName) {
         return item;
       }
 
@@ -2504,7 +2478,7 @@ class AppController extends ChangeNotifier {
     await analytics.logFavoriteStopRemoved(
       provider: favorite.provider,
       routeKey: favorite.routeKey,
-      hadDestination: favorite.hasDestination,
+      hadDestination: favorite.destinationStopId != null,
     );
     notifyListeners();
   }
@@ -2564,16 +2538,9 @@ class AppController extends ChangeNotifier {
                 ? resolved.route.routeId
                 : null);
 
-      final nextDestinationPathId = favorite.effectiveDestinationPathId;
-      final nextDestinationStopId = favorite.effectiveDestinationStopId;
-      final nextDestinationStopName = favorite.effectiveDestinationStopName;
-
       if (nextRouteName == favorite.routeName &&
           nextStopName == favorite.stopName &&
-          nextRouteId == favorite.routeId &&
-          nextDestinationPathId == favorite.destinationPathId &&
-          nextDestinationStopId == favorite.destinationStopId &&
-          nextDestinationStopName == favorite.destinationStopName) {
+          nextRouteId == favorite.routeId) {
         return favorite;
       }
 
@@ -2586,9 +2553,9 @@ class AppController extends ChangeNotifier {
         routeId: nextRouteId,
         routeName: nextRouteName,
         stopName: nextStopName,
-        destinationPathId: nextDestinationPathId,
-        destinationStopId: nextDestinationStopId,
-        destinationStopName: nextDestinationStopName,
+        destinationPathId: favorite.destinationPathId,
+        destinationStopId: favorite.destinationStopId,
+        destinationStopName: favorite.destinationStopName,
       );
     }).toList();
 

--- a/lib/core/app_controller.dart
+++ b/lib/core/app_controller.dart
@@ -153,9 +153,9 @@ class AppController extends ChangeNotifier {
                 '${favorite.pathId}:'
                 '${favorite.stopId}:'
                 '${favorite.stopName ?? ''}:'
-                '${favorite.destinationPathId ?? 0}:'
-                '${favorite.destinationStopId ?? 0}:'
-                '${favorite.destinationStopName ?? ''}',
+                '${favorite.effectiveDestinationPathId ?? 0}:'
+                '${favorite.effectiveDestinationStopId ?? 0}:'
+                '${favorite.effectiveDestinationStopName ?? ''}',
           ),
         ),
       )
@@ -1017,23 +1017,26 @@ class AppController extends ChangeNotifier {
   }
 
   List<Map<String, dynamic>> _buildWearUsageProfilesPayload() {
-    final providerProfiles = _routeUsageProfiles
-        .where((entry) => entry.provider == _settings.provider)
-        .toList()
-      ..sort((a, b) => b.totalOpens.compareTo(a.totalOpens));
+    final providerProfiles =
+        _routeUsageProfiles
+            .where((entry) => entry.provider == _settings.provider)
+            .toList()
+          ..sort((a, b) => b.totalOpens.compareTo(a.totalOpens));
     final limited = providerProfiles.take(40);
     return limited
-        .map((profile) => {
-              'provider': profile.provider.name,
-              'routeKey': profile.routeKey,
-              'routeName': profile.routeName,
-              'totalOpens': profile.totalOpens,
-              'lastOpenedAtMs': profile.lastOpenedAtMs,
-              'hourlyOpens': profile.hourlyOpens.map(
-                (key, value) => MapEntry(key.toString(), value),
-              ),
-              'recentSelectionMs': profile.selectionTimestampsWithin(),
-            })
+        .map(
+          (profile) => {
+            'provider': profile.provider.name,
+            'routeKey': profile.routeKey,
+            'routeName': profile.routeName,
+            'totalOpens': profile.totalOpens,
+            'lastOpenedAtMs': profile.lastOpenedAtMs,
+            'hourlyOpens': profile.hourlyOpens.map(
+              (key, value) => MapEntry(key.toString(), value),
+            ),
+            'recentSelectionMs': profile.selectionTimestampsWithin(),
+          },
+        )
         .toList(growable: false);
   }
 
@@ -1067,14 +1070,8 @@ class AppController extends ChangeNotifier {
           ? suggestion.profile.routeName
           : (detail?.route.routeName ?? routeId),
       'provider': suggestion.profile.provider.name,
-      if (path != null) ...{
-        'pathId': path.pathId,
-        'pathName': path.name,
-      },
-      if (stop != null) ...{
-        'stopId': stop.stopId,
-        'stopName': stop.stopName,
-      },
+      if (path != null) ...{'pathId': path.pathId, 'pathName': path.name},
+      if (stop != null) ...{'stopId': stop.stopId, 'stopName': stop.stopName},
       'reason': suggestion.reason,
       if (suggestion.distanceMeters != null)
         'distanceMeters': suggestion.distanceMeters,
@@ -1745,7 +1742,8 @@ class AppController extends ChangeNotifier {
     // Desktop platforms always auto-download database updates regardless of
     // the saved mode, since they typically have stable Wi-Fi/Ethernet and
     // Connectivity detection may not work reliably on desktop.
-    final isDesktop = !kIsWeb &&
+    final isDesktop =
+        !kIsWeb &&
         (defaultTargetPlatform == TargetPlatform.windows ||
             defaultTargetPlatform == TargetPlatform.linux ||
             defaultTargetPlatform == TargetPlatform.macOS);
@@ -2232,7 +2230,8 @@ class AppController extends ChangeNotifier {
     final signature = smartRouteSignature;
     final nowMs = DateTime.now().millisecondsSinceEpoch;
     final signatureUnchanged = _lastWearSmartSignature == signature;
-    final tooSoon = nowMs - _lastWearSmartPushAtMs <
+    final tooSoon =
+        nowMs - _lastWearSmartPushAtMs <
         const Duration(minutes: 5).inMilliseconds;
     if (signatureUnchanged && tooSoon) {
       return;
@@ -2307,6 +2306,7 @@ class AppController extends ChangeNotifier {
     FavoriteStop favorite, {
     String? groupName,
   }) async {
+    final normalizedFavorite = _favoriteWithoutSelfDestination(favorite);
     final targetGroup = groupName?.trim().isNotEmpty == true
         ? groupName!.trim()
         : (_favoriteGroups.isEmpty
@@ -2321,7 +2321,9 @@ class AppController extends ChangeNotifier {
       (sum, list) => sum + list.length,
     );
     final alreadyExists =
-        _favoriteGroups[targetGroup]?.any((item) => item.sameAs(favorite)) ??
+        _favoriteGroups[targetGroup]?.any(
+          (item) => item.sameAs(normalizedFavorite),
+        ) ??
         false;
     if (!alreadyExists && currentTotal >= maxFavoritesTotal) {
       throw FavoriteGroupFullException(targetGroup, maxFavoritesTotal);
@@ -2333,39 +2335,39 @@ class AppController extends ChangeNotifier {
     };
     next.putIfAbsent(targetGroup, () => <FavoriteStop>[]);
     final existingIndex = next[targetGroup]!.indexWhere(
-      (item) => item.sameAs(favorite),
+      (item) => item.sameAs(normalizedFavorite),
     );
     final replacedExisting = existingIndex != -1;
     if (existingIndex == -1) {
-      next[targetGroup]!.add(favorite);
+      next[targetGroup]!.add(normalizedFavorite);
     } else {
       final existing = next[targetGroup]![existingIndex];
-      final routeId = favorite.routeId?.trim().isNotEmpty == true
-          ? favorite.routeId
+      final routeId = normalizedFavorite.routeId?.trim().isNotEmpty == true
+          ? normalizedFavorite.routeId
           : existing.routeId;
-      final routeName = favorite.routeName?.trim().isNotEmpty == true
-          ? favorite.routeName
+      final routeName = normalizedFavorite.routeName?.trim().isNotEmpty == true
+          ? normalizedFavorite.routeName
           : existing.routeName;
-      final stopName = favorite.stopName?.trim().isNotEmpty == true
-          ? favorite.stopName
+      final stopName = normalizedFavorite.stopName?.trim().isNotEmpty == true
+          ? normalizedFavorite.stopName
           : existing.stopName;
-      final destinationStopId = favorite.destinationStopId;
+      final destinationStopId = normalizedFavorite.effectiveDestinationStopId;
       final mergedDestinationStopId =
-          destinationStopId ?? existing.destinationStopId;
+          destinationStopId ?? existing.effectiveDestinationStopId;
       final mergedDestinationPathId = mergedDestinationStopId == null
           ? null
           : (destinationStopId == null
-                ? existing.destinationPathId
-                : (favorite.destinationPathId ?? favorite.pathId));
+                ? existing.effectiveDestinationPathId
+                : normalizedFavorite.effectiveDestinationPathId);
       final mergedDestinationStopName = destinationStopId == null
-          ? existing.destinationStopName
-          : favorite.destinationStopName;
+          ? existing.effectiveDestinationStopName
+          : normalizedFavorite.effectiveDestinationStopName;
 
       next[targetGroup]![existingIndex] = FavoriteStop(
-        provider: favorite.provider,
-        routeKey: favorite.routeKey,
-        pathId: favorite.pathId,
-        stopId: favorite.stopId,
+        provider: normalizedFavorite.provider,
+        routeKey: normalizedFavorite.routeKey,
+        pathId: normalizedFavorite.pathId,
+        stopId: normalizedFavorite.stopId,
         routeId: routeId,
         routeName: routeName,
         stopName: stopName,
@@ -2381,17 +2383,32 @@ class AppController extends ChangeNotifier {
     await AndroidHomeIntegration.refreshFavoriteWidgets();
     await _syncWearOsSnapshot(requestRefresh: false);
     final savedFavorite = next[targetGroup]!.firstWhere(
-      (item) => item.sameAs(favorite),
-      orElse: () => favorite,
+      (item) => item.sameAs(normalizedFavorite),
+      orElse: () => normalizedFavorite,
     );
     await analytics.logFavoriteStopSaved(
-      provider: favorite.provider,
-      routeKey: favorite.routeKey,
+      provider: normalizedFavorite.provider,
+      routeKey: normalizedFavorite.routeKey,
       replacedExisting: replacedExisting,
-      hasDestination: savedFavorite.destinationStopId != null,
+      hasDestination: savedFavorite.hasDestination,
     );
     notifyListeners();
     return targetGroup;
+  }
+
+  FavoriteStop _favoriteWithoutSelfDestination(FavoriteStop favorite) {
+    if (!favorite.destinationMatchesStop) {
+      return favorite;
+    }
+    return FavoriteStop(
+      provider: favorite.provider,
+      routeKey: favorite.routeKey,
+      pathId: favorite.pathId,
+      stopId: favorite.stopId,
+      routeId: favorite.routeId,
+      routeName: favorite.routeName,
+      stopName: favorite.stopName,
+    );
   }
 
   Future<bool> updateFavoriteDestination(
@@ -2406,13 +2423,22 @@ class AppController extends ChangeNotifier {
       return false;
     }
 
-    final normalizedDestinationStopId =
+    final requestedDestinationStopId =
         destinationStopId != null && destinationStopId > 0
         ? destinationStopId
         : null;
-    final normalizedDestinationPathId = normalizedDestinationStopId == null
+    final requestedDestinationPathId = requestedDestinationStopId == null
         ? null
         : (destinationPathId ?? favorite.pathId);
+    final isSelfDestination =
+        requestedDestinationStopId == favorite.stopId &&
+        requestedDestinationPathId == favorite.pathId;
+    final normalizedDestinationStopId = isSelfDestination
+        ? null
+        : requestedDestinationStopId;
+    final normalizedDestinationPathId = isSelfDestination
+        ? null
+        : requestedDestinationPathId;
     final normalizedDestinationStopName = normalizedDestinationStopId == null
         ? null
         : (destinationStopName?.trim().isNotEmpty == true
@@ -2427,9 +2453,9 @@ class AppController extends ChangeNotifier {
       }
 
       found = true;
-      if (item.destinationPathId == normalizedDestinationPathId &&
-          item.destinationStopId == normalizedDestinationStopId &&
-          item.destinationStopName == normalizedDestinationStopName) {
+      if (item.effectiveDestinationPathId == normalizedDestinationPathId &&
+          item.effectiveDestinationStopId == normalizedDestinationStopId &&
+          item.effectiveDestinationStopName == normalizedDestinationStopName) {
         return item;
       }
 
@@ -2478,7 +2504,7 @@ class AppController extends ChangeNotifier {
     await analytics.logFavoriteStopRemoved(
       provider: favorite.provider,
       routeKey: favorite.routeKey,
-      hadDestination: favorite.destinationStopId != null,
+      hadDestination: favorite.hasDestination,
     );
     notifyListeners();
   }
@@ -2538,9 +2564,16 @@ class AppController extends ChangeNotifier {
                 ? resolved.route.routeId
                 : null);
 
+      final nextDestinationPathId = favorite.effectiveDestinationPathId;
+      final nextDestinationStopId = favorite.effectiveDestinationStopId;
+      final nextDestinationStopName = favorite.effectiveDestinationStopName;
+
       if (nextRouteName == favorite.routeName &&
           nextStopName == favorite.stopName &&
-          nextRouteId == favorite.routeId) {
+          nextRouteId == favorite.routeId &&
+          nextDestinationPathId == favorite.destinationPathId &&
+          nextDestinationStopId == favorite.destinationStopId &&
+          nextDestinationStopName == favorite.destinationStopName) {
         return favorite;
       }
 
@@ -2553,9 +2586,9 @@ class AppController extends ChangeNotifier {
         routeId: nextRouteId,
         routeName: nextRouteName,
         stopName: nextStopName,
-        destinationPathId: favorite.destinationPathId,
-        destinationStopId: favorite.destinationStopId,
-        destinationStopName: favorite.destinationStopName,
+        destinationPathId: nextDestinationPathId,
+        destinationStopId: nextDestinationStopId,
+        destinationStopName: nextDestinationStopName,
       );
     }).toList();
 

--- a/lib/core/bus_repository.dart
+++ b/lib/core/bus_repository.dart
@@ -2255,9 +2255,77 @@ class BusRepository {
       id: id,
       type: payload['type']?.toString() ?? '',
       note: note,
-      full: fullValue == true || fullValue?.toString() == '1',
-      carOnStop: carOnStopValue == true || carOnStopValue?.toString() == '1',
+      full: _truthyPayloadValue(fullValue),
+      carOnStop: _truthyPayloadValue(carOnStopValue),
+      electric: _payloadIndicatesElectric(payload),
     );
+  }
+
+  bool _truthyPayloadValue(Object? value) {
+    if (value == true) {
+      return true;
+    }
+    final normalized = value?.toString().trim().toLowerCase();
+    return normalized == '1' ||
+        normalized == 'true' ||
+        normalized == 'yes' ||
+        normalized == 'y';
+  }
+
+  bool _payloadIndicatesElectric(Map<dynamic, dynamic> payload) {
+    const explicitKeys = [
+      'electric',
+      'isElectric',
+      'is_electric',
+      'ev',
+      'isEv',
+      'is_ev',
+    ];
+    for (final key in explicitKeys) {
+      if (_truthyPayloadValue(payload[key])) {
+        return true;
+      }
+    }
+
+    const textKeys = [
+      'note',
+      'message',
+      'vehicle_type',
+      'vehicleType',
+      'bus_type',
+      'busType',
+      'car_type',
+      'carType',
+      'energy',
+      'fuel',
+      'fuel_type',
+      'power_type',
+      'powerType',
+      'type_name',
+      'vehicle_kind',
+      'kind',
+      'category',
+      'tags',
+    ];
+    for (final key in textKeys) {
+      final value = payload[key]?.toString().trim();
+      if (value != null && _textIndicatesElectric(value)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool _textIndicatesElectric(String value) {
+    final lower = value.toLowerCase();
+    return value.contains('電動') ||
+        value.contains('純電') ||
+        value.contains('電巴') ||
+        lower.contains('electric') ||
+        lower.contains('e-bus') ||
+        lower.contains('e_bus') ||
+        RegExp(r'(^|[^a-z])ev([^a-z]|$)').hasMatch(lower);
   }
 
   RoutePathPoint? _parseRoutePathPoint(Map<dynamic, dynamic> payload) {

--- a/lib/core/bus_repository.dart
+++ b/lib/core/bus_repository.dart
@@ -1417,6 +1417,7 @@ class BusRepository {
         msg: livePayload?.msg,
         t: livePayload?.t,
         buses: livePayload?.buses ?? const [],
+        etas: livePayload?.etas ?? const [],
       );
       stopsByPath.putIfAbsent(row.pathId, () => <StopInfo>[]).add(stop);
     }
@@ -1527,6 +1528,7 @@ class BusRepository {
         msg: livePayload?.msg,
         t: livePayload?.t,
         buses: livePayload?.buses ?? const [],
+        etas: livePayload?.etas ?? const [],
       );
       stopsByPath.putIfAbsent(pathId, () => <StopInfo>[]).add(stop);
     }
@@ -1611,6 +1613,7 @@ class BusRepository {
               msg: payload?.msg,
               t: payload?.t,
               buses: payload?.buses ?? const [],
+              etas: payload?.etas ?? const [],
             );
           }),
         );
@@ -1957,6 +1960,7 @@ class BusRepository {
               .whereType<Map>()
               .map(_parseBusVehicle)
               .toList(),
+          etas: _parseStopEtas(rawStop['etas']),
         );
       }
     }
@@ -2088,6 +2092,7 @@ class BusRepository {
                 .whereType<Map>()
                 .map(_parseBusVehicle)
                 .toList(),
+            etas: _parseStopEtas(rawStop['etas']),
           );
         }
       }
@@ -2259,6 +2264,39 @@ class BusRepository {
       carOnStop: _truthyPayloadValue(carOnStopValue),
       electric: _payloadIndicatesElectric(payload),
     );
+  }
+
+  List<StopEta> _parseStopEtas(Object? rawEtas) {
+    if (rawEtas is! List) {
+      return const [];
+    }
+
+    final result = <StopEta>[];
+    for (final rawEta in rawEtas) {
+      if (rawEta is! Map) {
+        continue;
+      }
+      final vehicleId =
+          _nonEmptyString(rawEta['plate']) ??
+          _nonEmptyString(rawEta['vehicle_id']) ??
+          _nonEmptyString(rawEta['id']);
+      final message = _nonEmptyString(rawEta['message']);
+      final eta = StopEta(
+        sec: _nullableInt(rawEta['eta']),
+        msg: message,
+        vehicleId: vehicleId,
+      );
+      if (eta.sec == null && eta.msg == null && eta.vehicleId == null) {
+        continue;
+      }
+      result.add(eta);
+    }
+    return result;
+  }
+
+  String? _nonEmptyString(Object? value) {
+    final text = value?.toString().trim();
+    return text == null || text.isEmpty ? null : text;
   }
 
   bool _truthyPayloadValue(Object? value) {
@@ -3504,12 +3542,14 @@ class LiveStopPayload {
     required this.msg,
     required this.t,
     required this.buses,
+    required this.etas,
   });
 
   final int? sec;
   final String? msg;
   final String? t;
   final List<BusVehicle> buses;
+  final List<StopEta> etas;
 }
 
 typedef LiveStopMap = Map<String, LiveStopPayload>;

--- a/lib/core/live_activity_service.dart
+++ b/lib/core/live_activity_service.dart
@@ -5,6 +5,7 @@ class LiveActivityDisplayState {
   const LiveActivityDisplayState({
     required this.stopId,
     required this.stopName,
+    this.alertStopName,
     this.previousStopName,
     this.nextStopName,
     this.lineStopNames,
@@ -22,6 +23,7 @@ class LiveActivityDisplayState {
 
   final int stopId;
   final String stopName;
+  final String? alertStopName;
   final String? previousStopName;
   final String? nextStopName;
   final List<String>? lineStopNames;
@@ -40,6 +42,7 @@ class LiveActivityDisplayState {
     return <String, Object?>{
       'displayStopId': stopId,
       'displayStopName': stopName,
+      'alertStopName': alertStopName,
       'previousStopName': previousStopName,
       'nextStopName': nextStopName,
       'lineStopNames': lineStopNames,

--- a/lib/core/live_activity_service.dart
+++ b/lib/core/live_activity_service.dart
@@ -74,6 +74,19 @@ class LiveActivityService {
 
   static bool get isActive => _activeActivityId != null;
 
+  /// The identifier of the most recently started Live Activity, if any.
+  ///
+  /// Callers that start an activity should hold on to this value and pass it
+  /// back as `ownerActivityId` when updating or ending, so that a screen
+  /// whose activity has been replaced (e.g. by another route screen) cannot
+  /// overwrite the new activity with stale data for the wrong bus/route.
+  static String? get activeActivityId => _activeActivityId;
+
+  /// Whether [activityId] still identifies the currently active activity.
+  static bool ownsActivity(String? activityId) {
+    return activityId != null && activityId == _activeActivityId;
+  }
+
   static Future<bool> startLiveActivity({
     required String routeName,
     required String pathName,
@@ -110,25 +123,54 @@ class LiveActivityService {
     }
   }
 
-  static Future<void> updateLiveActivity(LiveActivityDisplayState state) async {
+  /// Updates the active Live Activity.
+  ///
+  /// When [ownerActivityId] is provided, the update is skipped unless it
+  /// matches the currently active activity. Returns `true` when the native
+  /// side reports the activity is still alive and was updated.
+  static Future<bool> updateLiveActivity(
+    LiveActivityDisplayState state, {
+    String? ownerActivityId,
+  }) async {
     if (!_isIOS || _activeActivityId == null) {
-      return;
+      return false;
+    }
+    if (ownerActivityId != null && ownerActivityId != _activeActivityId) {
+      // Another caller owns the current activity; do not overwrite it with
+      // data belonging to a different route/bus.
+      return false;
     }
 
     try {
-      await _channel.invokeMethod<void>(
+      final updated = await _channel.invokeMethod<bool>(
         'updateLiveActivity',
         state.toArguments(),
       );
+      if (updated == false) {
+        // The native side no longer has this activity (dismissed/ended).
+        _activeActivityId = null;
+        return false;
+      }
+      return true;
     } on PlatformException {
       // Ignore; activity may have been dismissed by the user.
+      return false;
     } on MissingPluginException {
       // Ignore; plugin not registered yet.
+      return false;
     }
   }
 
-  static Future<void> endLiveActivity() async {
+  /// Ends the active Live Activity.
+  ///
+  /// When [ownerActivityId] is provided, the activity is only ended if it
+  /// matches the currently active one, so a disposed screen cannot tear down
+  /// an activity started later by another screen.
+  static Future<void> endLiveActivity({String? ownerActivityId}) async {
     if (!_isIOS) {
+      return;
+    }
+    if (ownerActivityId != null && ownerActivityId != _activeActivityId) {
       return;
     }
 

--- a/lib/core/models.dart
+++ b/lib/core/models.dart
@@ -377,14 +377,14 @@ class AppSettings {
       appUpdateChannel: _defaultAppUpdateChannel(),
       appUpdateCheckMode:
           const bool.fromEnvironment('APP_BUILD_AAB', defaultValue: false)
-          ? AppUpdateCheckMode.off
-          : (const String.fromEnvironment(
-                      'APP_UPDATE_CHANNEL',
-                      defaultValue: 'nightly',
-                    ) ==
-                    'developer'
-                ? AppUpdateCheckMode.off
-                : AppUpdateCheckMode.popup),
+              ? AppUpdateCheckMode.off
+              : (const String.fromEnvironment(
+                    'APP_UPDATE_CHANNEL',
+                    defaultValue: 'nightly',
+                  ) ==
+                  'developer'
+              ? AppUpdateCheckMode.off
+              : AppUpdateCheckMode.popup),
       desktopDiscordPresenceEnabled: true,
       desktopDiscordShowProvider: false,
       desktopDiscordShowScreen: true,
@@ -491,12 +491,12 @@ class AppSettings {
             (const bool.fromEnvironment('APP_BUILD_AAB', defaultValue: false)
                 ? 'off'
                 : (const String.fromEnvironment(
-                            'APP_UPDATE_CHANNEL',
-                            defaultValue: 'nightly',
-                          ) ==
-                          'developer'
-                      ? 'off'
-                      : 'popup')),
+                          'APP_UPDATE_CHANNEL',
+                          defaultValue: 'nightly',
+                        ) ==
+                        'developer'
+                    ? 'off'
+                    : 'popup')),
       ),
       desktopDiscordPresenceEnabled:
           json['desktopDiscordPresenceEnabled'] as bool? ?? true,
@@ -752,34 +752,20 @@ class FavoriteStop {
   });
 
   factory FavoriteStop.fromJson(Map<String, dynamic> json) {
-    final pathId = (json['pathId'] as num?)?.toInt() ?? 0;
-    final stopId = (json['stopId'] as num?)?.toInt() ?? 0;
-    final rawDestinationPathId = (json['destinationPathId'] as num?)?.toInt();
-    final rawDestinationStopIdValue = (json['destinationStopId'] as num?)
-        ?.toInt();
-    final rawDestinationStopId =
-        rawDestinationStopIdValue != null && rawDestinationStopIdValue > 0
-        ? rawDestinationStopIdValue
-        : null;
-    final destinationMatchesStop =
-        rawDestinationStopId != null &&
-        rawDestinationStopId == stopId &&
-        (rawDestinationPathId == null || rawDestinationPathId == pathId);
     return FavoriteStop(
       provider: busProviderFromString(json['provider'] as String? ?? 'tpe'),
       routeKey: (json['routeKey'] as num?)?.toInt() ?? 0,
-      pathId: pathId,
-      stopId: stopId,
+      pathId: (json['pathId'] as num?)?.toInt() ?? 0,
+      stopId: (json['stopId'] as num?)?.toInt() ?? 0,
       routeId: (json['routeId'] as String?)?.trim().isNotEmpty == true
           ? (json['routeId'] as String).trim()
           : null,
       routeName: json['routeName'] as String?,
       stopName: json['stopName'] as String?,
-      destinationPathId: destinationMatchesStop ? null : rawDestinationPathId,
-      destinationStopId: destinationMatchesStop ? null : rawDestinationStopId,
-      destinationStopName: destinationMatchesStop
-          ? null
-          : (json['destinationStopName'] as String?)?.trim().isNotEmpty == true
+      destinationPathId: (json['destinationPathId'] as num?)?.toInt(),
+      destinationStopId: (json['destinationStopId'] as num?)?.toInt(),
+      destinationStopName:
+          (json['destinationStopName'] as String?)?.trim().isNotEmpty == true
           ? (json['destinationStopName'] as String).trim()
           : null,
     );
@@ -798,32 +784,6 @@ class FavoriteStop {
 
   String get stableKey => '${provider.name}:$routeKey:$pathId:$stopId';
 
-  bool get destinationMatchesStop {
-    final destinationId = destinationStopId;
-    if (destinationId == null) {
-      return false;
-    }
-    return destinationId == stopId && (destinationPathId ?? pathId) == pathId;
-  }
-
-  bool get hasDestination =>
-      destinationStopId != null &&
-      destinationStopId! > 0 &&
-      !destinationMatchesStop;
-
-  int? get effectiveDestinationPathId {
-    return hasDestination ? destinationPathId ?? pathId : null;
-  }
-
-  int? get effectiveDestinationStopId {
-    return hasDestination ? destinationStopId : null;
-  }
-
-  String? get effectiveDestinationStopName {
-    final name = destinationStopName?.trim();
-    return hasDestination && name != null && name.isNotEmpty ? name : null;
-  }
-
   Map<String, dynamic> toJson() {
     return {
       'provider': provider.name,
@@ -833,12 +793,10 @@ class FavoriteStop {
       if (routeId != null) 'routeId': routeId,
       if (routeName != null) 'routeName': routeName,
       if (stopName != null) 'stopName': stopName,
-      if (effectiveDestinationPathId != null)
-        'destinationPathId': effectiveDestinationPathId,
-      if (effectiveDestinationStopId != null)
-        'destinationStopId': effectiveDestinationStopId,
-      if (effectiveDestinationStopName != null)
-        'destinationStopName': effectiveDestinationStopName,
+      if (destinationPathId != null) 'destinationPathId': destinationPathId,
+      if (destinationStopId != null) 'destinationStopId': destinationStopId,
+      if (destinationStopName != null)
+        'destinationStopName': destinationStopName,
     };
   }
 

--- a/lib/core/models.dart
+++ b/lib/core/models.dart
@@ -1378,6 +1378,14 @@ class BusVehicle {
   final bool electric;
 }
 
+class StopEta {
+  const StopEta({this.sec, this.msg, this.vehicleId});
+
+  final int? sec;
+  final String? msg;
+  final String? vehicleId;
+}
+
 class StopInfo {
   const StopInfo({
     required this.routeKey,
@@ -1391,6 +1399,7 @@ class StopInfo {
     this.msg,
     this.t,
     this.buses = const [],
+    this.etas = const [],
   });
 
   factory StopInfo.fromMap(Map<String, Object?> map) {
@@ -1416,12 +1425,14 @@ class StopInfo {
   final String? msg;
   final String? t;
   final List<BusVehicle> buses;
+  final List<StopEta> etas;
 
   StopInfo copyWith({
     int? sec,
     String? msg,
     String? t,
     List<BusVehicle>? buses,
+    List<StopEta>? etas,
   }) {
     return StopInfo(
       routeKey: routeKey,
@@ -1435,6 +1446,7 @@ class StopInfo {
       msg: msg ?? this.msg,
       t: t ?? this.t,
       buses: buses ?? this.buses,
+      etas: etas ?? this.etas,
     );
   }
 }
@@ -1575,19 +1587,39 @@ DateTime? _parseStopRealtimeUpdatedAt(String? value, DateTime now) {
   return parsed;
 }
 
-int? effectiveStopEtaSeconds(StopInfo stop, {DateTime? now}) {
-  final seconds = stop.sec;
+String? normalizeBusVehicleId(String? vehicleId) {
+  final cleaned = vehicleId?.trim().replaceAll(' ', '') ?? '';
+  if (cleaned.isEmpty) {
+    return null;
+  }
+  return cleaned.toUpperCase();
+}
+
+StopEta? stopEtaForVehicle(StopInfo stop, String? vehicleId) {
+  final normalizedVehicleId = normalizeBusVehicleId(vehicleId);
+  if (normalizedVehicleId == null) {
+    return null;
+  }
+
+  for (final eta in stop.etas) {
+    if (normalizeBusVehicleId(eta.vehicleId) == normalizedVehicleId) {
+      return eta;
+    }
+  }
+  return null;
+}
+
+int? _effectiveEtaSeconds(int? seconds, String? updatedAtText, DateTime now) {
   if (seconds == null || seconds <= 0) {
     return seconds;
   }
 
-  final currentTime = now ?? DateTime.now();
-  final updatedAt = _parseStopRealtimeUpdatedAt(stop.t, currentTime);
+  final updatedAt = _parseStopRealtimeUpdatedAt(updatedAtText, now);
   if (updatedAt == null) {
     return seconds;
   }
 
-  final elapsedSeconds = currentTime.difference(updatedAt).inSeconds;
+  final elapsedSeconds = now.difference(updatedAt).inSeconds;
   if (elapsedSeconds <= 0) {
     return seconds;
   }
@@ -1598,6 +1630,30 @@ int? effectiveStopEtaSeconds(StopInfo stop, {DateTime? now}) {
   }
 
   return math.max(0, seconds - elapsedSeconds);
+}
+
+int? effectiveStopEtaSeconds(StopInfo stop, {DateTime? now}) {
+  return _effectiveEtaSeconds(stop.sec, stop.t, now ?? DateTime.now());
+}
+
+int? effectiveStopEtaSecondsForVehicle(
+  StopInfo stop,
+  String? vehicleId, {
+  DateTime? now,
+}) {
+  final eta = stopEtaForVehicle(stop, vehicleId);
+  if (eta == null) {
+    return effectiveStopEtaSeconds(stop, now: now);
+  }
+  return _effectiveEtaSeconds(eta.sec, stop.t, now ?? DateTime.now());
+}
+
+String? effectiveStopEtaMessageForVehicle(StopInfo stop, String? vehicleId) {
+  final etaMessage = stopEtaForVehicle(stop, vehicleId)?.msg?.trim();
+  if (etaMessage != null && etaMessage.isNotEmpty) {
+    return etaMessage;
+  }
+  return stop.msg;
 }
 
 EtaPresentation buildEtaPresentation(
@@ -1667,7 +1723,8 @@ bool hasRealtimeStopData(StopInfo stop) {
   return stop.sec != null ||
       (stop.msg?.trim().isNotEmpty ?? false) ||
       (stop.t?.trim().isNotEmpty ?? false) ||
-      stop.buses.isNotEmpty;
+      stop.buses.isNotEmpty ||
+      stop.etas.isNotEmpty;
 }
 
 String formatDistance(double meters) {

--- a/lib/core/models.dart
+++ b/lib/core/models.dart
@@ -1367,6 +1367,7 @@ class BusVehicle {
     required this.note,
     required this.full,
     required this.carOnStop,
+    this.electric = false,
   });
 
   final String id;
@@ -1374,6 +1375,7 @@ class BusVehicle {
   final String note;
   final bool full;
   final bool carOnStop;
+  final bool electric;
 }
 
 class StopInfo {
@@ -1544,6 +1546,60 @@ String formatEtaBadgeText(String text) {
   return trimmed;
 }
 
+DateTime? _parseStopRealtimeUpdatedAt(String? value, DateTime now) {
+  final text = value?.trim();
+  if (text == null || text.isEmpty) {
+    return null;
+  }
+
+  final numericValue = int.tryParse(text);
+  if (numericValue != null) {
+    if (numericValue > 1000000000000) {
+      return DateTime.fromMillisecondsSinceEpoch(
+        numericValue,
+        isUtc: true,
+      ).toLocal();
+    }
+    if (numericValue > 1000000000) {
+      return DateTime.fromMillisecondsSinceEpoch(
+        numericValue * 1000,
+        isUtc: true,
+      ).toLocal();
+    }
+  }
+
+  final parsed = DateTime.tryParse(text)?.toLocal();
+  if (parsed == null || parsed.isAfter(now.add(const Duration(seconds: 15)))) {
+    return null;
+  }
+  return parsed;
+}
+
+int? effectiveStopEtaSeconds(StopInfo stop, {DateTime? now}) {
+  final seconds = stop.sec;
+  if (seconds == null || seconds <= 0) {
+    return seconds;
+  }
+
+  final currentTime = now ?? DateTime.now();
+  final updatedAt = _parseStopRealtimeUpdatedAt(stop.t, currentTime);
+  if (updatedAt == null) {
+    return seconds;
+  }
+
+  final elapsedSeconds = currentTime.difference(updatedAt).inSeconds;
+  if (elapsedSeconds <= 0) {
+    return seconds;
+  }
+
+  // Avoid turning very stale fallback data into fake arrivals.
+  if (elapsedSeconds > math.max(seconds + 120, 600)) {
+    return seconds;
+  }
+
+  return math.max(0, seconds - elapsedSeconds);
+}
+
 EtaPresentation buildEtaPresentation(
   StopInfo stop, {
   required bool alwaysShowSeconds,
@@ -1565,7 +1621,7 @@ EtaPresentation buildEtaPresentation(
     );
   }
 
-  final seconds = stop.sec;
+  final seconds = effectiveStopEtaSeconds(stop);
   if (seconds == null) {
     return EtaPresentation(
       text: '--',

--- a/lib/core/models.dart
+++ b/lib/core/models.dart
@@ -377,14 +377,14 @@ class AppSettings {
       appUpdateChannel: _defaultAppUpdateChannel(),
       appUpdateCheckMode:
           const bool.fromEnvironment('APP_BUILD_AAB', defaultValue: false)
-              ? AppUpdateCheckMode.off
-              : (const String.fromEnvironment(
-                    'APP_UPDATE_CHANNEL',
-                    defaultValue: 'nightly',
-                  ) ==
-                  'developer'
-              ? AppUpdateCheckMode.off
-              : AppUpdateCheckMode.popup),
+          ? AppUpdateCheckMode.off
+          : (const String.fromEnvironment(
+                      'APP_UPDATE_CHANNEL',
+                      defaultValue: 'nightly',
+                    ) ==
+                    'developer'
+                ? AppUpdateCheckMode.off
+                : AppUpdateCheckMode.popup),
       desktopDiscordPresenceEnabled: true,
       desktopDiscordShowProvider: false,
       desktopDiscordShowScreen: true,
@@ -491,12 +491,12 @@ class AppSettings {
             (const bool.fromEnvironment('APP_BUILD_AAB', defaultValue: false)
                 ? 'off'
                 : (const String.fromEnvironment(
-                          'APP_UPDATE_CHANNEL',
-                          defaultValue: 'nightly',
-                        ) ==
-                        'developer'
-                    ? 'off'
-                    : 'popup')),
+                            'APP_UPDATE_CHANNEL',
+                            defaultValue: 'nightly',
+                          ) ==
+                          'developer'
+                      ? 'off'
+                      : 'popup')),
       ),
       desktopDiscordPresenceEnabled:
           json['desktopDiscordPresenceEnabled'] as bool? ?? true,
@@ -752,20 +752,34 @@ class FavoriteStop {
   });
 
   factory FavoriteStop.fromJson(Map<String, dynamic> json) {
+    final pathId = (json['pathId'] as num?)?.toInt() ?? 0;
+    final stopId = (json['stopId'] as num?)?.toInt() ?? 0;
+    final rawDestinationPathId = (json['destinationPathId'] as num?)?.toInt();
+    final rawDestinationStopIdValue = (json['destinationStopId'] as num?)
+        ?.toInt();
+    final rawDestinationStopId =
+        rawDestinationStopIdValue != null && rawDestinationStopIdValue > 0
+        ? rawDestinationStopIdValue
+        : null;
+    final destinationMatchesStop =
+        rawDestinationStopId != null &&
+        rawDestinationStopId == stopId &&
+        (rawDestinationPathId == null || rawDestinationPathId == pathId);
     return FavoriteStop(
       provider: busProviderFromString(json['provider'] as String? ?? 'tpe'),
       routeKey: (json['routeKey'] as num?)?.toInt() ?? 0,
-      pathId: (json['pathId'] as num?)?.toInt() ?? 0,
-      stopId: (json['stopId'] as num?)?.toInt() ?? 0,
+      pathId: pathId,
+      stopId: stopId,
       routeId: (json['routeId'] as String?)?.trim().isNotEmpty == true
           ? (json['routeId'] as String).trim()
           : null,
       routeName: json['routeName'] as String?,
       stopName: json['stopName'] as String?,
-      destinationPathId: (json['destinationPathId'] as num?)?.toInt(),
-      destinationStopId: (json['destinationStopId'] as num?)?.toInt(),
-      destinationStopName:
-          (json['destinationStopName'] as String?)?.trim().isNotEmpty == true
+      destinationPathId: destinationMatchesStop ? null : rawDestinationPathId,
+      destinationStopId: destinationMatchesStop ? null : rawDestinationStopId,
+      destinationStopName: destinationMatchesStop
+          ? null
+          : (json['destinationStopName'] as String?)?.trim().isNotEmpty == true
           ? (json['destinationStopName'] as String).trim()
           : null,
     );
@@ -784,6 +798,32 @@ class FavoriteStop {
 
   String get stableKey => '${provider.name}:$routeKey:$pathId:$stopId';
 
+  bool get destinationMatchesStop {
+    final destinationId = destinationStopId;
+    if (destinationId == null) {
+      return false;
+    }
+    return destinationId == stopId && (destinationPathId ?? pathId) == pathId;
+  }
+
+  bool get hasDestination =>
+      destinationStopId != null &&
+      destinationStopId! > 0 &&
+      !destinationMatchesStop;
+
+  int? get effectiveDestinationPathId {
+    return hasDestination ? destinationPathId ?? pathId : null;
+  }
+
+  int? get effectiveDestinationStopId {
+    return hasDestination ? destinationStopId : null;
+  }
+
+  String? get effectiveDestinationStopName {
+    final name = destinationStopName?.trim();
+    return hasDestination && name != null && name.isNotEmpty ? name : null;
+  }
+
   Map<String, dynamic> toJson() {
     return {
       'provider': provider.name,
@@ -793,10 +833,12 @@ class FavoriteStop {
       if (routeId != null) 'routeId': routeId,
       if (routeName != null) 'routeName': routeName,
       if (stopName != null) 'stopName': stopName,
-      if (destinationPathId != null) 'destinationPathId': destinationPathId,
-      if (destinationStopId != null) 'destinationStopId': destinationStopId,
-      if (destinationStopName != null)
-        'destinationStopName': destinationStopName,
+      if (effectiveDestinationPathId != null)
+        'destinationPathId': effectiveDestinationPathId,
+      if (effectiveDestinationStopId != null)
+        'destinationStopId': effectiveDestinationStopId,
+      if (effectiveDestinationStopName != null)
+        'destinationStopName': effectiveDestinationStopName,
     };
   }
 

--- a/lib/core/startup_permission_service.dart
+++ b/lib/core/startup_permission_service.dart
@@ -1,0 +1,92 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class StartupPermissionService {
+  StartupPermissionService._();
+
+  static final instance = StartupPermissionService._();
+
+  static const _photosPromptAttemptedKey =
+      'startup_permissions.photos_prompt_attempted';
+  static const _notificationsPromptAttemptedKey =
+      'startup_permissions.notifications_prompt_attempted';
+
+  bool _requestInProgress = false;
+
+  Future<void> requestInitialPermissions() async {
+    if (kIsWeb || !Platform.isIOS || _requestInProgress) {
+      return;
+    }
+
+    _requestInProgress = true;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final requestedPhotos = await _requestIfNeeded(
+        prefs: prefs,
+        preferenceKey: _photosPromptAttemptedKey,
+        permission: Permission.photos,
+        isSatisfied: _photosPermissionSatisfied,
+      );
+      if (requestedPhotos) {
+        await Future<void>.delayed(const Duration(milliseconds: 350));
+      }
+      await _requestIfNeeded(
+        prefs: prefs,
+        preferenceKey: _notificationsPromptAttemptedKey,
+        permission: Permission.notification,
+        isSatisfied: _notificationPermissionSatisfied,
+      );
+    } finally {
+      _requestInProgress = false;
+    }
+  }
+
+  Future<bool> _requestIfNeeded({
+    required SharedPreferences prefs,
+    required String preferenceKey,
+    required Permission permission,
+    required bool Function(PermissionStatus status) isSatisfied,
+  }) async {
+    if (prefs.getBool(preferenceKey) == true) {
+      return false;
+    }
+
+    PermissionStatus status;
+    try {
+      status = await permission.status;
+    } on PlatformException {
+      return false;
+    }
+
+    if (isSatisfied(status) ||
+        status.isPermanentlyDenied ||
+        status.isRestricted) {
+      await prefs.setBool(preferenceKey, true);
+      return false;
+    }
+
+    if (!status.isDenied) {
+      return false;
+    }
+
+    try {
+      await permission.request();
+      await prefs.setBool(preferenceKey, true);
+      return true;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  bool _photosPermissionSatisfied(PermissionStatus status) {
+    return status.isGranted || status.isLimited;
+  }
+
+  bool _notificationPermissionSatisfied(PermissionStatus status) {
+    return status.isGranted || status.isProvisional;
+  }
+}

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -148,8 +148,8 @@ class _FavoritesScreenState extends State<FavoritesScreen>
               '${favorite.routeKey}:'
               '${favorite.pathId}:'
               '${favorite.stopId}:'
-              '${favorite.destinationPathId ?? 0}:'
-              '${favorite.destinationStopId ?? 0}',
+              '${favorite.effectiveDestinationPathId ?? 0}:'
+              '${favorite.effectiveDestinationStopId ?? 0}',
         )
         .join('|');
   }
@@ -563,7 +563,8 @@ class _FavoritesScreenState extends State<FavoritesScreen>
                   return ListTile(
                     title: Text(stop.stopName),
                     subtitle: Text('第 ${index + 1} 站'),
-                    trailing: stop.stopId == item.reference.destinationStopId
+                    trailing:
+                        stop.stopId == item.reference.effectiveDestinationStopId
                         ? const Icon(Icons.flag_rounded)
                         : null,
                     onTap: () => Navigator.of(context).pop(stop),
@@ -741,11 +742,10 @@ class _FavoritesScreenState extends State<FavoritesScreen>
       itemBuilder: (context, index) {
         final item = items[index];
         final destinationSummary =
-            item.reference.destinationStopName?.trim().isNotEmpty == true
-            ? item.reference.destinationStopName!.trim()
-            : (item.reference.destinationStopId == null
-                  ? null
-                  : '站牌 ${item.reference.destinationStopId}');
+            item.reference.effectiveDestinationStopName ??
+            (item.reference.effectiveDestinationStopId == null
+                ? null
+                : '站牌 ${item.reference.effectiveDestinationStopId}');
         return Dismissible(
           key: ValueKey(_favoriteItemKey(item.reference)),
           direction: DismissDirection.endToStart,
@@ -798,9 +798,9 @@ class _FavoritesScreenState extends State<FavoritesScreen>
                   ? PopupMenuButton<_FavoriteDestinationAction>(
                       tooltip: '目的地設定',
                       icon: Icon(
-                        item.reference.destinationStopId == null
-                            ? Icons.flag_outlined
-                            : Icons.flag_rounded,
+                        item.reference.hasDestination
+                            ? Icons.flag_rounded
+                            : Icons.flag_outlined,
                       ),
                       onSelected: (action) {
                         unawaited(
@@ -818,7 +818,7 @@ class _FavoritesScreenState extends State<FavoritesScreen>
                             value: _FavoriteDestinationAction.setDestination,
                             child: Text('設定目的地'),
                           ),
-                          if (item.reference.destinationStopId != null)
+                          if (item.reference.hasDestination)
                             const PopupMenuItem(
                               value:
                                   _FavoriteDestinationAction.clearDestination,
@@ -848,8 +848,10 @@ class _FavoritesScreenState extends State<FavoritesScreen>
                   routeNameHint: item.route.routeName,
                   initialPathId: item.reference.pathId,
                   initialStopId: item.reference.stopId,
-                  initialDestinationPathId: item.reference.destinationPathId,
-                  initialDestinationStopId: item.reference.destinationStopId,
+                  initialDestinationPathId:
+                      item.reference.effectiveDestinationPathId,
+                  initialDestinationStopId:
+                      item.reference.effectiveDestinationStopId,
                 );
               },
             ),

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -148,8 +148,8 @@ class _FavoritesScreenState extends State<FavoritesScreen>
               '${favorite.routeKey}:'
               '${favorite.pathId}:'
               '${favorite.stopId}:'
-              '${favorite.effectiveDestinationPathId ?? 0}:'
-              '${favorite.effectiveDestinationStopId ?? 0}',
+              '${favorite.destinationPathId ?? 0}:'
+              '${favorite.destinationStopId ?? 0}',
         )
         .join('|');
   }
@@ -563,8 +563,7 @@ class _FavoritesScreenState extends State<FavoritesScreen>
                   return ListTile(
                     title: Text(stop.stopName),
                     subtitle: Text('第 ${index + 1} 站'),
-                    trailing:
-                        stop.stopId == item.reference.effectiveDestinationStopId
+                    trailing: stop.stopId == item.reference.destinationStopId
                         ? const Icon(Icons.flag_rounded)
                         : null,
                     onTap: () => Navigator.of(context).pop(stop),
@@ -742,10 +741,11 @@ class _FavoritesScreenState extends State<FavoritesScreen>
       itemBuilder: (context, index) {
         final item = items[index];
         final destinationSummary =
-            item.reference.effectiveDestinationStopName ??
-            (item.reference.effectiveDestinationStopId == null
-                ? null
-                : '站牌 ${item.reference.effectiveDestinationStopId}');
+            item.reference.destinationStopName?.trim().isNotEmpty == true
+            ? item.reference.destinationStopName!.trim()
+            : (item.reference.destinationStopId == null
+                  ? null
+                  : '站牌 ${item.reference.destinationStopId}');
         return Dismissible(
           key: ValueKey(_favoriteItemKey(item.reference)),
           direction: DismissDirection.endToStart,
@@ -798,9 +798,9 @@ class _FavoritesScreenState extends State<FavoritesScreen>
                   ? PopupMenuButton<_FavoriteDestinationAction>(
                       tooltip: '目的地設定',
                       icon: Icon(
-                        item.reference.hasDestination
-                            ? Icons.flag_rounded
-                            : Icons.flag_outlined,
+                        item.reference.destinationStopId == null
+                            ? Icons.flag_outlined
+                            : Icons.flag_rounded,
                       ),
                       onSelected: (action) {
                         unawaited(
@@ -818,7 +818,7 @@ class _FavoritesScreenState extends State<FavoritesScreen>
                             value: _FavoriteDestinationAction.setDestination,
                             child: Text('設定目的地'),
                           ),
-                          if (item.reference.hasDestination)
+                          if (item.reference.destinationStopId != null)
                             const PopupMenuItem(
                               value:
                                   _FavoriteDestinationAction.clearDestination,
@@ -848,10 +848,8 @@ class _FavoritesScreenState extends State<FavoritesScreen>
                   routeNameHint: item.route.routeName,
                   initialPathId: item.reference.pathId,
                   initialStopId: item.reference.stopId,
-                  initialDestinationPathId:
-                      item.reference.effectiveDestinationPathId,
-                  initialDestinationStopId:
-                      item.reference.effectiveDestinationStopId,
+                  initialDestinationPathId: item.reference.destinationPathId,
+                  initialDestinationStopId: item.reference.destinationStopId,
                 );
               },
             ),

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../app/bus_app.dart';
 import '../core/app_controller.dart';
@@ -10,6 +11,7 @@ import '../core/models.dart';
 import '../widgets/eta_badge.dart';
 import 'favorite_groups_screen.dart';
 import '../widgets/background_image_wrapper.dart';
+import '../widgets/cat_state_card.dart';
 import 'route_detail_navigation.dart';
 
 class FavoritesScreen extends StatefulWidget {
@@ -513,6 +515,7 @@ class _FavoritesScreenState extends State<FavoritesScreen>
     if (!mounted) {
       return;
     }
+    unawaited(HapticFeedback.lightImpact());
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('已從 $groupName 移除 ${item.stop.stopName}')),
     );
@@ -587,6 +590,7 @@ class _FavoritesScreenState extends State<FavoritesScreen>
         return;
       }
       if (didChange) {
+        unawaited(HapticFeedback.lightImpact());
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('已將目的地設為 ${destination.stopName}')),
         );
@@ -606,6 +610,7 @@ class _FavoritesScreenState extends State<FavoritesScreen>
       return;
     }
     if (didChange) {
+      unawaited(HapticFeedback.selectionClick());
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('已清除這個最愛的目的地設定')));
@@ -710,7 +715,13 @@ class _FavoritesScreenState extends State<FavoritesScreen>
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
-          child: Text('載入最愛失敗：$_error'),
+          child: CatStateCard(
+            mood: CatStateMood.cry,
+            title: '最愛清單卡住了',
+            message: _error,
+            actionLabel: '再試一次',
+            onAction: () => _scheduleRefresh(forceResolveStatic: true),
+          ),
         ),
       );
     }
@@ -818,6 +829,7 @@ class _FavoritesScreenState extends State<FavoritesScreen>
                     )
                   : null,
               onTap: () async {
+                unawaited(HapticFeedback.selectionClick());
                 await controller.recordRouteSelection(
                   provider: item.reference.provider,
                   routeKey: item.reference.routeKey,
@@ -860,7 +872,11 @@ class _EmptyFavoritesState extends StatelessWidget {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(24),
-        child: Text(message, textAlign: TextAlign.center),
+        child: CatStateCard(
+          mood: CatStateMood.sad,
+          title: '貓貓還沒有固定站牌',
+          message: message,
+        ),
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -537,13 +537,14 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
       context,
       routeKey: suggestion.profile.routeKey,
       provider: suggestion.profile.provider,
-      routeIdHint: suggestion.detail?.route.routeId ?? suggestion.favorite?.routeId,
+      routeIdHint:
+          suggestion.detail?.route.routeId ?? suggestion.favorite?.routeId,
       routeNameHint:
           suggestion.detail?.route.routeName ?? suggestion.profile.routeName,
       initialPathId: pathId,
       initialStopId: stopId,
-      initialDestinationPathId: favorite?.destinationPathId,
-      initialDestinationStopId: favorite?.destinationStopId,
+      initialDestinationPathId: favorite?.effectiveDestinationPathId,
+      initialDestinationStopId: favorite?.effectiveDestinationStopId,
     );
   }
 
@@ -700,11 +701,10 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
     final recommendedStop = suggestion.recommendedStop;
     final favorite = suggestion.favorite;
     final destinationLabel =
-        favorite?.destinationStopName?.trim().isNotEmpty == true
-        ? favorite!.destinationStopName!.trim()
-        : favorite?.destinationStopId == null
-        ? null
-        : '目的地站牌 ${favorite!.destinationStopId}';
+        favorite?.effectiveDestinationStopName ??
+        (favorite?.effectiveDestinationStopId == null
+            ? null
+            : '目的地站牌 ${favorite!.effectiveDestinationStopId}');
     final showDistance =
         suggestion.favoriteStop == null && suggestion.distanceMeters != null;
     // ignore: unused_local_variable

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -537,14 +537,13 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
       context,
       routeKey: suggestion.profile.routeKey,
       provider: suggestion.profile.provider,
-      routeIdHint:
-          suggestion.detail?.route.routeId ?? suggestion.favorite?.routeId,
+      routeIdHint: suggestion.detail?.route.routeId ?? suggestion.favorite?.routeId,
       routeNameHint:
           suggestion.detail?.route.routeName ?? suggestion.profile.routeName,
       initialPathId: pathId,
       initialStopId: stopId,
-      initialDestinationPathId: favorite?.effectiveDestinationPathId,
-      initialDestinationStopId: favorite?.effectiveDestinationStopId,
+      initialDestinationPathId: favorite?.destinationPathId,
+      initialDestinationStopId: favorite?.destinationStopId,
     );
   }
 
@@ -701,10 +700,11 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
     final recommendedStop = suggestion.recommendedStop;
     final favorite = suggestion.favorite;
     final destinationLabel =
-        favorite?.effectiveDestinationStopName ??
-        (favorite?.effectiveDestinationStopId == null
-            ? null
-            : '目的地站牌 ${favorite!.effectiveDestinationStopId}');
+        favorite?.destinationStopName?.trim().isNotEmpty == true
+        ? favorite!.destinationStopName!.trim()
+        : favorite?.destinationStopId == null
+        ? null
+        : '目的地站牌 ${favorite!.destinationStopId}';
     final showDistance =
         suggestion.favoriteStop == null && suggestion.distanceMeters != null;
     // ignore: unused_local_variable

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -2240,7 +2240,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       };
     }
 
-    final seconds = stop.sec;
+    final seconds = effectiveStopEtaSeconds(stop);
     if (seconds == null) {
       return null;
     }
@@ -2401,7 +2401,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       return message;
     }
 
-    final seconds = stop.sec;
+    final seconds = effectiveStopEtaSeconds(stop);
     if (seconds == null) {
       return '--';
     }
@@ -2421,8 +2421,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
   bool _isBusApproachingStop(StopInfo stop) {
     final message = stop.msg?.trim() ?? '';
+    final seconds = effectiveStopEtaSeconds(stop);
     return stop.buses.isNotEmpty ||
-        (stop.sec != null && stop.sec! <= 0) ||
+        (seconds != null && seconds <= 0) ||
         message.contains('進站') ||
         message.contains('到站');
   }
@@ -3774,9 +3775,20 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
   bool _isElectricVehicle(BusVehicle vehicle) {
     final vehicleId = vehicle.id.trim().toUpperCase();
-    return vehicleId.startsWith('E') ||
+    final note = vehicle.note.toLowerCase();
+    final type = vehicle.type.toLowerCase();
+    return vehicle.electric ||
+        vehicleId.startsWith('E') ||
         vehicleId.endsWith('FV') ||
-        vehicle.note.contains('電');
+        vehicle.note.contains('電動') ||
+        vehicle.note.contains('純電') ||
+        vehicle.note.contains('電巴') ||
+        note.contains('electric') ||
+        note.contains('e-bus') ||
+        note.contains('e_bus') ||
+        type.contains('electric') ||
+        type.contains('e-bus') ||
+        type.contains('e_bus');
   }
 
   String _vehicleStatusLabel(StopInfo stop) {
@@ -3784,6 +3796,18 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       return '${stop.buses.length} 輛靠近';
     }
     return stop.buses.first.id;
+  }
+
+  String _formatEffectiveEtaStatusLabel(int seconds) {
+    if (seconds < 60) {
+      return '$seconds秒';
+    }
+    final minutes = seconds ~/ 60;
+    final leftoverSeconds = seconds % 60;
+    if (leftoverSeconds == 0) {
+      return '$minutes分';
+    }
+    return '$minutes分$leftoverSeconds秒';
   }
 
   String _vehicleStatusTooltip(StopInfo stop) {
@@ -3805,50 +3829,84 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     StopInfo stop, {
     required bool isNearest,
   }) {
-    final seconds = stop.sec;
+    final seconds = effectiveStopEtaSeconds(stop);
     final hasMultipleBuses = stop.buses.length > 1;
     final hasArrivingBus =
         stop.buses.any((vehicle) => vehicle.carOnStop) ||
         (seconds != null && seconds <= 0);
     final isLessThanOneMinute =
         seconds != null && seconds > 0 && seconds < 60;
+    final isUrgentEta = seconds != null && seconds >= 60 && seconds < 180;
     final hasFullBus = stop.buses.any((vehicle) => vehicle.full);
     final hasElectricBus = stop.buses.any(_isElectricVehicle);
     final hasAccessibleBus = stop.buses.any((vehicle) => vehicle.type == '1');
-    final vehicle = stop.buses.first;
+    final vehicle = stop.buses.firstWhere(
+      _isElectricVehicle,
+      orElse: () => stop.buses.first,
+    );
+    final vehicleIcon = hasElectricBus
+        ? Icons.electric_bolt_rounded
+        : Icons.directions_bus_filled_rounded;
 
     if (hasArrivingBus) {
       return _VehicleStatusStyle(
-        icon: Icons.directions_bus_filled_rounded,
+        icon: vehicleIcon,
         label: hasMultipleBuses ? '${stop.buses.length} 輛進站' : '進站中',
         backgroundColor: Colors.red.shade700,
         foregroundColor: Colors.white,
         borderColor: Colors.red.shade200.withValues(alpha: 0.85),
         glowColor: Colors.red.shade500.withValues(alpha: 0.38),
         showStackedBuses: hasMultipleBuses,
+        keepLabelWhenCompact: true,
       );
     }
 
     if (isLessThanOneMinute) {
       return _VehicleStatusStyle(
-        icon: Icons.timer_rounded,
-        label: '<1 分',
+        icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.timer_rounded,
+        label: _formatEffectiveEtaStatusLabel(seconds),
         backgroundColor: Colors.deepOrange.shade600,
         foregroundColor: Colors.white,
         borderColor: Colors.orange.shade200.withValues(alpha: 0.8),
         glowColor: Colors.deepOrange.shade400.withValues(alpha: 0.32),
         showStackedBuses: hasMultipleBuses,
+        keepLabelWhenCompact: true,
+      );
+    }
+
+    if (isUrgentEta) {
+      return _VehicleStatusStyle(
+        icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.timer_rounded,
+        label: _formatEffectiveEtaStatusLabel(seconds),
+        backgroundColor: Colors.orange.shade700,
+        foregroundColor: Colors.white,
+        borderColor: Colors.orange.shade200.withValues(alpha: 0.78),
+        glowColor: Colors.orange.shade400.withValues(alpha: 0.28),
+        showStackedBuses: hasMultipleBuses,
+        keepLabelWhenCompact: true,
       );
     }
 
     if (hasFullBus) {
       return _VehicleStatusStyle(
-        icon: Icons.groups_rounded,
+        icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.groups_rounded,
         label: hasMultipleBuses ? '${stop.buses.length} 輛 · 客滿' : '客滿',
         backgroundColor: Colors.brown.shade600,
         foregroundColor: Colors.white,
         borderColor: Colors.orange.shade200.withValues(alpha: 0.75),
         glowColor: Colors.brown.shade400.withValues(alpha: 0.28),
+        showStackedBuses: hasMultipleBuses,
+      );
+    }
+
+    if (hasElectricBus) {
+      return _VehicleStatusStyle(
+        icon: Icons.electric_bolt_rounded,
+        label: hasMultipleBuses ? '${stop.buses.length} 輛靠近' : vehicle.id,
+        backgroundColor: Colors.amber.shade500,
+        foregroundColor: Colors.black87,
+        borderColor: Colors.amber.shade100.withValues(alpha: 0.9),
+        glowColor: Colors.amber.shade400.withValues(alpha: 0.3),
         showStackedBuses: hasMultipleBuses,
       );
     }
@@ -3877,17 +3935,6 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       );
     }
 
-    if (hasElectricBus) {
-      return _VehicleStatusStyle(
-        icon: Icons.electric_bolt_rounded,
-        label: vehicle.id,
-        backgroundColor: Colors.amber.shade500,
-        foregroundColor: Colors.black87,
-        borderColor: Colors.amber.shade100.withValues(alpha: 0.9),
-        glowColor: Colors.amber.shade400.withValues(alpha: 0.3),
-      );
-    }
-
     if (hasAccessibleBus) {
       return _VehicleStatusStyle(
         icon: Icons.accessible_rounded,
@@ -3907,6 +3954,16 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       borderColor: theme.colorScheme.primaryContainer.withValues(alpha: 0.6),
       glowColor: theme.colorScheme.primary.withValues(alpha: 0.16),
     );
+  }
+
+  String? _vehicleStatusPillLabel(
+    _VehicleStatusStyle statusStyle, {
+    required bool compact,
+  }) {
+    if (compact && !statusStyle.keepLabelWhenCompact) {
+      return null;
+    }
+    return statusStyle.label;
   }
 
   double _measureMaxLineWidth(
@@ -4071,7 +4128,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         },
         child: _RouteStatusPill(
           icon: statusStyle.icon,
-          label: compact ? null : statusStyle.label,
+          label: _vehicleStatusPillLabel(statusStyle, compact: compact),
           backgroundColor: statusStyle.backgroundColor,
           foregroundColor: statusStyle.foregroundColor,
           borderColor: statusStyle.borderColor,
@@ -4175,9 +4232,10 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
                       (false, true, _) => _estimateRouteStatusPillWidth(
                         context,
                         icon: vehicleStatusStyle!.icon,
-                        label: useCompactVehicleStatus
-                            ? null
-                            : vehicleStatusStyle.label,
+                        label: _vehicleStatusPillLabel(
+                          vehicleStatusStyle,
+                          compact: useCompactVehicleStatus,
+                        ),
                         showStackedBuses: vehicleStatusStyle.showStackedBuses,
                       ),
                       (false, false, true) => _estimateRouteStatusPillWidth(
@@ -4629,6 +4687,7 @@ class _VehicleStatusStyle {
     required this.borderColor,
     required this.glowColor,
     this.showStackedBuses = false,
+    this.keepLabelWhenCompact = false,
   });
 
   final IconData icon;
@@ -4638,6 +4697,7 @@ class _VehicleStatusStyle {
   final Color borderColor;
   final Color glowColor;
   final bool showStackedBuses;
+  final bool keepLabelWhenCompact;
 }
 
 class _RouteStatusPill extends StatelessWidget {

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -24,6 +24,7 @@ import '../core/route_detail_launch_bridge.dart';
 import '../core/trip_monitor_notifications.dart';
 import '../core/twbusforum.dart';
 import '../widgets/background_image_wrapper.dart';
+import '../widgets/cat_state_card.dart';
 import '../widgets/eta_badge.dart';
 import '../widgets/route_bus_map_sheet.dart';
 import '../widgets/ad_banner_widget.dart';
@@ -371,6 +372,14 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     } catch (_) {
       // Silently ignore alert fetch errors.
     }
+  }
+
+  void _playSelectionHaptic() {
+    unawaited(HapticFeedback.selectionClick());
+  }
+
+  void _playSuccessHaptic() {
+    unawaited(HapticFeedback.lightImpact());
   }
 
   Future<void> _markCurrentRouteAlertsAsRead() async {
@@ -1946,6 +1955,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (!mounted) {
       return;
     }
+    _playSuccessHaptic();
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text('已將 ${stop.stopName} 設為上車站。')));
@@ -1968,6 +1978,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (!mounted) {
       return;
     }
+    _playSuccessHaptic();
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text('已將 ${stop.stopName} 設為下車提醒。')));
@@ -1990,6 +2001,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (!mounted) {
       return;
     }
+    _playSelectionHaptic();
     final message = fallbackBoardingStop == null
         ? '已清除手動上車站，之後拿到定位會再自動判斷。'
         : '已改回使用目前位置判斷上車站。';
@@ -2012,6 +2024,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       _destinationStopName = null;
     });
     await _configureBackgroundTripMonitorIfNeeded();
+    _playSelectionHaptic();
   }
 
   ScrollController _scrollControllerForPath(int pathId) {
@@ -3123,6 +3136,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     final message = assignedDestinationName == null
         ? '已加入 $selectedGroup'
         : '已加入 $selectedGroup，目的地：$assignedDestinationName';
+    _playSuccessHaptic();
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(message)));
@@ -3758,35 +3772,141 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     return stop.stopName;
   }
 
+  bool _isElectricVehicle(BusVehicle vehicle) {
+    final vehicleId = vehicle.id.trim().toUpperCase();
+    return vehicleId.startsWith('E') ||
+        vehicleId.endsWith('FV') ||
+        vehicle.note.contains('電');
+  }
+
   String _vehicleStatusLabel(StopInfo stop) {
     if (stop.buses.length > 1) {
-      return '${stop.buses.length} 輛公車';
+      return '${stop.buses.length} 輛靠近';
     }
     return stop.buses.first.id;
   }
 
-  IconData _vehicleStatusIcon(StopInfo stop, {required bool isNearest}) {
-    if (isNearest) {
-      return Icons.gps_fixed_rounded;
+  String _vehicleStatusTooltip(StopInfo stop) {
+    final ids = stop.buses.map((vehicle) => vehicle.id).join('、');
+    final flags = <String>[
+      if (stop.buses.any((vehicle) => vehicle.carOnStop)) '進站中',
+      if (stop.buses.any((vehicle) => vehicle.full)) '客滿',
+      if (stop.buses.any(_isElectricVehicle)) '電動車',
+      if (stop.buses.any((vehicle) => vehicle.type == '1')) '無障礙',
+    ];
+    if (flags.isEmpty) {
+      return ids;
     }
-    return stop.buses.first.type == '1'
-        ? Icons.accessible_rounded
-        : Icons.directions_bus_rounded;
+    return '$ids · ${flags.join(' · ')}';
   }
 
-  Color _vehicleStatusBackgroundColor(
+  _VehicleStatusStyle _vehicleStatusStyle(
     ThemeData theme,
     StopInfo stop, {
     required bool isNearest,
   }) {
+    final seconds = stop.sec;
+    final hasMultipleBuses = stop.buses.length > 1;
+    final hasArrivingBus =
+        stop.buses.any((vehicle) => vehicle.carOnStop) ||
+        (seconds != null && seconds <= 0);
+    final isLessThanOneMinute =
+        seconds != null && seconds > 0 && seconds < 60;
+    final hasFullBus = stop.buses.any((vehicle) => vehicle.full);
+    final hasElectricBus = stop.buses.any(_isElectricVehicle);
+    final hasAccessibleBus = stop.buses.any((vehicle) => vehicle.type == '1');
     final vehicle = stop.buses.first;
+
+    if (hasArrivingBus) {
+      return _VehicleStatusStyle(
+        icon: Icons.directions_bus_filled_rounded,
+        label: hasMultipleBuses ? '${stop.buses.length} 輛進站' : '進站中',
+        backgroundColor: Colors.red.shade700,
+        foregroundColor: Colors.white,
+        borderColor: Colors.red.shade200.withValues(alpha: 0.85),
+        glowColor: Colors.red.shade500.withValues(alpha: 0.38),
+        showStackedBuses: hasMultipleBuses,
+      );
+    }
+
+    if (isLessThanOneMinute) {
+      return _VehicleStatusStyle(
+        icon: Icons.timer_rounded,
+        label: '<1 分',
+        backgroundColor: Colors.deepOrange.shade600,
+        foregroundColor: Colors.white,
+        borderColor: Colors.orange.shade200.withValues(alpha: 0.8),
+        glowColor: Colors.deepOrange.shade400.withValues(alpha: 0.32),
+        showStackedBuses: hasMultipleBuses,
+      );
+    }
+
+    if (hasFullBus) {
+      return _VehicleStatusStyle(
+        icon: Icons.groups_rounded,
+        label: hasMultipleBuses ? '${stop.buses.length} 輛 · 客滿' : '客滿',
+        backgroundColor: Colors.brown.shade600,
+        foregroundColor: Colors.white,
+        borderColor: Colors.orange.shade200.withValues(alpha: 0.75),
+        glowColor: Colors.brown.shade400.withValues(alpha: 0.28),
+        showStackedBuses: hasMultipleBuses,
+      );
+    }
+
     if (isNearest) {
-      return Colors.cyan.shade400;
+      return _VehicleStatusStyle(
+        icon: Icons.gps_fixed_rounded,
+        label: _vehicleStatusLabel(stop),
+        backgroundColor: Colors.cyan.shade400,
+        foregroundColor: Colors.black87,
+        borderColor: Colors.cyan.shade100.withValues(alpha: 0.8),
+        glowColor: Colors.cyan.shade300.withValues(alpha: 0.32),
+        showStackedBuses: hasMultipleBuses,
+      );
     }
-    if (vehicle.id.startsWith('E') || vehicle.id.endsWith('FV')) {
-      return Colors.amber.shade600;
+
+    if (hasMultipleBuses) {
+      return _VehicleStatusStyle(
+        icon: Icons.directions_bus_rounded,
+        label: _vehicleStatusLabel(stop),
+        backgroundColor: theme.colorScheme.secondaryContainer,
+        foregroundColor: theme.colorScheme.onSecondaryContainer,
+        borderColor: theme.colorScheme.secondary.withValues(alpha: 0.45),
+        glowColor: theme.colorScheme.secondary.withValues(alpha: 0.2),
+        showStackedBuses: true,
+      );
     }
-    return theme.colorScheme.primary;
+
+    if (hasElectricBus) {
+      return _VehicleStatusStyle(
+        icon: Icons.electric_bolt_rounded,
+        label: vehicle.id,
+        backgroundColor: Colors.amber.shade500,
+        foregroundColor: Colors.black87,
+        borderColor: Colors.amber.shade100.withValues(alpha: 0.9),
+        glowColor: Colors.amber.shade400.withValues(alpha: 0.3),
+      );
+    }
+
+    if (hasAccessibleBus) {
+      return _VehicleStatusStyle(
+        icon: Icons.accessible_rounded,
+        label: vehicle.id,
+        backgroundColor: Colors.indigo.shade500,
+        foregroundColor: Colors.white,
+        borderColor: Colors.indigo.shade100.withValues(alpha: 0.7),
+        glowColor: Colors.indigo.shade300.withValues(alpha: 0.2),
+      );
+    }
+
+    return _VehicleStatusStyle(
+      icon: Icons.directions_bus_rounded,
+      label: vehicle.id,
+      backgroundColor: theme.colorScheme.primary,
+      foregroundColor: theme.colorScheme.onPrimary,
+      borderColor: theme.colorScheme.primaryContainer.withValues(alpha: 0.6),
+      glowColor: theme.colorScheme.primary.withValues(alpha: 0.16),
+    );
   }
 
   double _measureMaxLineWidth(
@@ -3811,6 +3931,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     BuildContext context, {
     required IconData icon,
     String? label,
+    bool showStackedBuses = false,
   }) {
     final hasLabel = label != null && label.trim().isNotEmpty;
     final labelWidth = hasLabel
@@ -3822,7 +3943,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         : 0.0;
     final horizontalPadding = hasLabel ? 28.0 : 20.0;
     final gap = hasLabel ? 8.0 : 0.0;
-    return horizontalPadding + 18.0 + gap + labelWidth;
+    final iconWidth = showStackedBuses ? 28.0 : 18.0;
+    return horizontalPadding + iconWidth + gap + labelWidth;
   }
 
   bool _shouldUseCompactVehicleStatus(
@@ -3846,10 +3968,12 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         height: 1.2,
       ),
     );
+    final statusStyle = _vehicleStatusStyle(theme, stop, isNearest: isNearest);
     final fullPillWidth = _estimateRouteStatusPillWidth(
       context,
-      icon: _vehicleStatusIcon(stop, isNearest: isNearest),
-      label: _vehicleStatusLabel(stop),
+      icon: statusStyle.icon,
+      label: statusStyle.label,
+      showStackedBuses: statusStyle.showStackedBuses,
     );
     final hasAlert = _stopHasAlert(stop);
     final alertWidth = hasAlert ? 16.0 : 0.0;
@@ -3927,24 +4051,15 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     }
 
     if (stop.buses.isNotEmpty) {
-      final backgroundColor = _vehicleStatusBackgroundColor(
-        theme,
-        stop,
-        isNearest: isNearest,
-      );
-      final foregroundColor = backgroundColor.computeLuminance() > 0.6
-          ? Colors.black87
-          : Colors.white;
-      final label = _vehicleStatusLabel(stop);
-      final tooltip = stop.buses.length == 1
-          ? stop.buses.first.id
-          : stop.buses.map((vehicle) => vehicle.id).join('、');
+      final statusStyle = _vehicleStatusStyle(theme, stop, isNearest: isNearest);
 
       return PopupMenuButton<BusVehicle>(
         padding: EdgeInsets.zero,
-        tooltip: tooltip,
-        onSelected: (vehicle) =>
-            unawaited(_handleVehicleAction(vehicle, _VehicleAction.twBusForum)),
+        tooltip: _vehicleStatusTooltip(stop),
+        onSelected: (vehicle) {
+          _playSelectionHaptic();
+          unawaited(_handleVehicleAction(vehicle, _VehicleAction.twBusForum));
+        },
         itemBuilder: (context) {
           return [
             for (final vehicle in stop.buses)
@@ -3955,10 +4070,13 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           ];
         },
         child: _RouteStatusPill(
-          icon: _vehicleStatusIcon(stop, isNearest: isNearest),
-          label: compact ? null : label,
-          backgroundColor: backgroundColor,
-          foregroundColor: foregroundColor,
+          icon: statusStyle.icon,
+          label: compact ? null : statusStyle.label,
+          backgroundColor: statusStyle.backgroundColor,
+          foregroundColor: statusStyle.foregroundColor,
+          borderColor: statusStyle.borderColor,
+          glowColor: statusStyle.glowColor,
+          showStackedBuses: statusStyle.showStackedBuses,
         ),
       );
     }
@@ -4002,7 +4120,10 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       borderRadius: BorderRadius.circular(20),
       child: InkWell(
         borderRadius: BorderRadius.circular(20),
-        onTap: () => unawaited(_openStopActionsWithShortcut(stop)),
+        onTap: () {
+          _playSelectionHaptic();
+          unawaited(_openStopActionsWithShortcut(stop));
+        },
         child: Padding(
           padding: const EdgeInsets.fromLTRB(8, 10, 8, 10),
           child: Row(
@@ -4034,6 +4155,13 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
                       isDestination: isDestination,
                       compact: useCompactVehicleStatus,
                     );
+                    final vehicleStatusStyle = stop.buses.isEmpty
+                        ? null
+                        : _vehicleStatusStyle(
+                            theme,
+                            stop,
+                            isNearest: isNearest,
+                          );
                     final trailingStatusWidth = switch ((
                       isDestination,
                       stop.buses.isNotEmpty,
@@ -4046,10 +4174,11 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
                       ),
                       (false, true, _) => _estimateRouteStatusPillWidth(
                         context,
-                        icon: _vehicleStatusIcon(stop, isNearest: isNearest),
+                        icon: vehicleStatusStyle!.icon,
                         label: useCompactVehicleStatus
                             ? null
-                            : _vehicleStatusLabel(stop),
+                            : vehicleStatusStyle!.label,
+                        showStackedBuses: vehicleStatusStyle!.showStackedBuses,
                       ),
                       (false, false, true) => _estimateRouteStatusPillWidth(
                         context,
@@ -4166,12 +4295,33 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           ),
         Expanded(
           child: _tabController == null
-              ? const Center(child: Text('目前沒有可顯示的方向'))
+              ? const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(24),
+                    child: CatStateCard(
+                      mood: CatStateMood.sad,
+                      title: '這條路線還沒有方向資料',
+                      message: '貓貓翻不到去程或返程，稍後再試試看。',
+                    ),
+                  ),
+                )
               : TabBarView(
                   controller: _tabController,
                   children: detail.paths.map((path) {
                     final pathStops =
                         detail.stopsByPath[path.pathId] ?? const <StopInfo>[];
+                    if (pathStops.isEmpty) {
+                      return const Center(
+                        child: Padding(
+                          padding: EdgeInsets.all(24),
+                          child: CatStateCard(
+                            mood: CatStateMood.sad,
+                            title: '這個方向沒有站牌',
+                            message: '可能是資料還沒同步完成，等一下再更新。',
+                          ),
+                        ),
+                      );
+                    }
                     return ListView.separated(
                       controller: _scrollControllerForPath(path.pathId),
                       padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
@@ -4404,7 +4554,13 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
             ? Center(
                 child: Padding(
                   padding: const EdgeInsets.all(24),
-                  child: Text(_error ?? '目前無法載入公車資訊'),
+                  child: CatStateCard(
+                    mood: CatStateMood.cry,
+                    title: '公車資訊被貓貓壓住了',
+                    message: _error ?? '目前無法載入公車資訊，稍後再更新一次。',
+                    actionLabel: '重新載入',
+                    onAction: () => unawaited(_refresh()),
+                  ),
                 ),
               )
             : LayoutBuilder(
@@ -4464,18 +4620,70 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
   }
 }
 
+class _VehicleStatusStyle {
+  const _VehicleStatusStyle({
+    required this.icon,
+    required this.label,
+    required this.backgroundColor,
+    required this.foregroundColor,
+    required this.borderColor,
+    required this.glowColor,
+    this.showStackedBuses = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color backgroundColor;
+  final Color foregroundColor;
+  final Color borderColor;
+  final Color glowColor;
+  final bool showStackedBuses;
+}
+
 class _RouteStatusPill extends StatelessWidget {
   const _RouteStatusPill({
     required this.icon,
     this.label,
     required this.backgroundColor,
     required this.foregroundColor,
+    this.borderColor,
+    this.glowColor,
+    this.showStackedBuses = false,
   });
 
   final IconData icon;
   final String? label;
   final Color backgroundColor;
   final Color foregroundColor;
+  final Color? borderColor;
+  final Color? glowColor;
+  final bool showStackedBuses;
+
+  Widget _buildIcon() {
+    if (!showStackedBuses) {
+      return Icon(icon, size: 18, color: foregroundColor);
+    }
+
+    return SizedBox(
+      width: 28,
+      height: 18,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned(
+            left: 8,
+            top: 1,
+            child: Icon(
+              Icons.directions_bus_rounded,
+              size: 16,
+              color: foregroundColor.withValues(alpha: 0.58),
+            ),
+          ),
+          Icon(icon, size: 18, color: foregroundColor),
+        ],
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -4488,11 +4696,21 @@ class _RouteStatusPill extends StatelessWidget {
       decoration: BoxDecoration(
         color: backgroundColor,
         borderRadius: BorderRadius.circular(999),
+        border: borderColor == null ? null : Border.all(color: borderColor!),
+        boxShadow: glowColor == null
+            ? null
+            : [
+                BoxShadow(
+                  color: glowColor!,
+                  blurRadius: 14,
+                  spreadRadius: 1,
+                ),
+              ],
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(icon, size: 18, color: foregroundColor),
+          _buildIcon(),
           if (hasLabel) ...[
             const SizedBox(width: 8),
             Text(

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -4177,8 +4177,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
                         icon: vehicleStatusStyle!.icon,
                         label: useCompactVehicleStatus
                             ? null
-                            : vehicleStatusStyle!.label,
-                        showStackedBuses: vehicleStatusStyle!.showStackedBuses,
+                            : vehicleStatusStyle.label,
+                        showStackedBuses: vehicleStatusStyle.showStackedBuses,
                       ),
                       (false, false, true) => _estimateRouteStatusPillWidth(
                         context,

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -545,6 +545,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           msg: previousStop.msg,
           t: previousStop.t,
           buses: previousStop.buses,
+          etas: previousStop.etas,
         );
       }).toList();
     }
@@ -2416,8 +2417,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     return nearestIndex == -1 ? null : nearestIndex;
   }
 
-  String _displayEtaText(StopInfo stop) {
-    final message = stop.msg?.trim() ?? '';
+  String _displayEtaText(StopInfo stop, {String? vehicleId}) {
+    final message =
+        effectiveStopEtaMessageForVehicle(stop, vehicleId)?.trim() ?? '';
     if (message.isNotEmpty) {
       if (message.contains('進站') || message.contains('到站')) {
         return '進站中';
@@ -2434,7 +2436,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       return message;
     }
 
-    final seconds = effectiveStopEtaSeconds(stop);
+    final seconds = effectiveStopEtaSecondsForVehicle(stop, vehicleId);
     if (seconds == null) {
       return '--';
     }
@@ -2456,6 +2458,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     final message = stop.msg?.trim() ?? '';
     final seconds = effectiveStopEtaSeconds(stop);
     return stop.buses.isNotEmpty ||
+        stop.etas.any((eta) => normalizeBusVehicleId(eta.vehicleId) != null) ||
         (seconds != null && seconds <= 0) ||
         message.contains('進站') ||
         message.contains('到站');
@@ -2540,7 +2543,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         nearestIndex >= boardingIndex &&
         busNearUser) {
       _liveActivityRideConfirmed = true;
-      _liveActivityRidingVehicleId = busVehicleId;
+      _liveActivityRidingVehicleId = normalizeBusVehicleId(busVehicleId);
       unawaited(TripMonitorNotifications.cancelBoardingCheckPrompt());
     }
 
@@ -2605,22 +2608,50 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     return parts.join(' · ');
   }
 
-  String? _vehicleIdForStop(StopInfo stop) {
-    if (stop.buses.isEmpty) {
-      return null;
+  String? _vehicleIdForStop(StopInfo stop, {String? preferredVehicleId}) {
+    final preferred = normalizeBusVehicleId(preferredVehicleId);
+    if (preferred != null &&
+        (stop.buses.any(
+              (vehicle) => normalizeBusVehicleId(vehicle.id) == preferred,
+            ) ||
+            stop.etas.any(
+              (eta) => normalizeBusVehicleId(eta.vehicleId) == preferred,
+            ))) {
+      return preferred;
     }
-    return stop.buses.first.id;
+
+    for (final vehicle in stop.buses) {
+      final vehicleId = normalizeBusVehicleId(vehicle.id);
+      if (vehicleId != null) {
+        return vehicleId;
+      }
+    }
+    for (final eta in stop.etas) {
+      final vehicleId = normalizeBusVehicleId(eta.vehicleId);
+      if (vehicleId != null) {
+        return vehicleId;
+      }
+    }
+    return null;
   }
 
   int? _findStopIndexForVehicleId(List<StopInfo> stops, String? vehicleId) {
-    final normalizedVehicleId = vehicleId?.trim();
-    if (normalizedVehicleId == null || normalizedVehicleId.isEmpty) {
+    final normalizedVehicleId = normalizeBusVehicleId(vehicleId);
+    if (normalizedVehicleId == null) {
       return null;
     }
     for (var index = 0; index < stops.length; index++) {
-      if (stops[index].buses.any(
-        (vehicle) => vehicle.id == normalizedVehicleId,
-      )) {
+      final stop = stops[index];
+      final vehicleSeenAtStop =
+          stop.buses.any(
+            (vehicle) =>
+                normalizeBusVehicleId(vehicle.id) == normalizedVehicleId,
+          ) ||
+          stop.etas.any(
+            (eta) =>
+                normalizeBusVehicleId(eta.vehicleId) == normalizedVehicleId,
+          );
+      if (vehicleSeenAtStop) {
         return index;
       }
     }
@@ -2628,13 +2659,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
   }
 
   String? _vehicleIdAtStop(StopInfo stop, String? preferredVehicleId) {
-    final normalizedVehicleId = preferredVehicleId?.trim();
-    if (normalizedVehicleId != null &&
-        normalizedVehicleId.isNotEmpty &&
-        stop.buses.any((vehicle) => vehicle.id == normalizedVehicleId)) {
-      return normalizedVehicleId;
-    }
-    return _vehicleIdForStop(stop);
+    return _vehicleIdForStop(stop, preferredVehicleId: preferredVehicleId);
   }
 
   ({String? previousStopName, String? nextStopName}) _adjacentStopNames(
@@ -2866,7 +2891,13 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       destinationIndex,
     );
     final boardingStop = pathStops[boardingIndex];
-    final boardingEtaText = _displayEtaText(boardingStop);
+    final boardingVehicleId = busIndex == null
+        ? _vehicleIdForStop(boardingStop)
+        : _vehicleIdForStop(pathStops[busIndex]);
+    final boardingEtaText = _displayEtaText(
+      boardingStop,
+      vehicleId: boardingVehicleId,
+    );
     final busStopsUntilBoarding = busIndex == null
         ? null
         : math.max(boardingIndex - busIndex, 0);
@@ -2877,9 +2908,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       boardingEtaText: boardingEtaText,
       boardingDistanceMeters: _distanceToStop(boardingStop),
       busIndex: busIndex,
-      busVehicleId: busIndex == null
-          ? null
-          : _vehicleIdForStop(pathStops[busIndex]),
+      busVehicleId: boardingVehicleId,
     );
 
     if (!hasBoarded) {
@@ -2907,34 +2936,38 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           destinationStop: destinationStop,
           busStopsUntilBoarding: busStopsUntilBoarding,
         ),
-        etaSeconds: effectiveStopEtaSeconds(boardingStop),
-        etaMessage: boardingStop.msg,
-        vehicleId: _vehicleIdForStop(boardingStop),
+        etaSeconds: effectiveStopEtaSecondsForVehicle(
+          boardingStop,
+          boardingVehicleId,
+        ),
+        etaMessage: effectiveStopEtaMessageForVehicle(
+          boardingStop,
+          boardingVehicleId,
+        ),
+        vehicleId: boardingVehicleId,
         progressValue: boardingProgressValue,
         progressTotal: boardingIndex + 1,
       );
     }
 
     final currentProgress = math.min(nearestIndex + 1, destinationIndex + 1);
-    final onboardStatusParts = <String>['已上車', '最近站牌 ${nearestStop.stopName}'];
-    if (nearestEtaText != '--') {
-      onboardStatusParts.add(nearestEtaText);
-    }
-    final preferredRidingVehicleId = _liveActivityRidingVehicleId?.trim();
-    final hasPreferredRidingVehicleId = preferredRidingVehicleId != null &&
-        preferredRidingVehicleId.isNotEmpty;
+    final preferredRidingVehicleId = normalizeBusVehicleId(
+      _liveActivityRidingVehicleId,
+    );
+    final hasPreferredRidingVehicleId = preferredRidingVehicleId != null;
     final ridingVehicleIndex = _findStopIndexForVehicleId(
       pathStops,
       preferredRidingVehicleId,
     );
-    final displayIndex = ridingVehicleIndex ??
+    final displayIndex =
+        ridingVehicleIndex ??
         (hasPreferredRidingVehicleId ? nearestIndex : busIndex ?? nearestIndex);
     final displayStop = pathStops[displayIndex];
-    final displayVehicleId = ridingVehicleIndex == null &&
-            hasPreferredRidingVehicleId
-        ? preferredRidingVehicleId
-        : _vehicleIdAtStop(displayStop, preferredRidingVehicleId);
-    if (ridingVehicleIndex != null || !hasPreferredRidingVehicleId) {
+    final displayVehicleId =
+        ridingVehicleIndex != null || !hasPreferredRidingVehicleId
+        ? _vehicleIdAtStop(displayStop, preferredRidingVehicleId)
+        : null;
+    if (displayVehicleId != null) {
       _liveActivityRidingVehicleId = displayVehicleId;
     }
     final stopLine = _buildLiveActivityStopLine(
@@ -2942,11 +2975,27 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       anchorIndex: displayIndex,
       highlightedIndex: destinationIndex,
     );
-    final adjacentStops = _adjacentStopNames(pathStops, displayStop.stopId);
+    final adjacentStops = _adjacentStopNames(pathStops, destinationStop.stopId);
+    final etaVehicleId = displayVehicleId ?? preferredRidingVehicleId;
+    final destinationEtaText = _displayEtaText(
+      destinationStop,
+      vehicleId: etaVehicleId,
+    );
+    final onboardStatusParts = <String>[
+      '已上車',
+      '目的地 ${destinationStop.stopName}',
+    ];
+    if (destinationEtaText != '--') {
+      onboardStatusParts.add(destinationEtaText);
+    }
+    onboardStatusParts.add('最近站牌 ${nearestStop.stopName}');
+    if (nearestEtaText != '--') {
+      onboardStatusParts.add(nearestEtaText);
+    }
 
     return LiveActivityDisplayState(
-      stopId: displayStop.stopId,
-      stopName: displayStop.stopName,
+      stopId: destinationStop.stopId,
+      stopName: destinationStop.stopName,
       alertStopName: destinationStop.stopName,
       previousStopName: adjacentStops.previousStopName,
       nextStopName: adjacentStops.nextStopName,
@@ -2955,8 +3004,14 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       lineHighlightedStopIndex: stopLine.highlightedStopIndex,
       modeLabel: '已上車',
       statusText: onboardStatusParts.join(' · '),
-      etaSeconds: effectiveStopEtaSeconds(displayStop),
-      etaMessage: displayStop.msg,
+      etaSeconds: effectiveStopEtaSecondsForVehicle(
+        destinationStop,
+        etaVehicleId,
+      ),
+      etaMessage: effectiveStopEtaMessageForVehicle(
+        destinationStop,
+        etaVehicleId,
+      ),
       vehicleId: displayVehicleId,
       progressValue: currentProgress,
       progressTotal: destinationIndex + 1,

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -98,6 +98,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
   int? _liveActivityPathId;
   int? _liveActivityRouteKey;
   String? _liveActivityProviderName;
+  String? _liveActivityId;
   String? _liveActivityRidingVehicleId;
   bool _liveActivityBoardingWindowOpen = false;
   bool _liveActivityRideConfirmed = false;
@@ -196,7 +197,11 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     }
     unawaited(TripMonitorNotifications.cancelBoardingCheckPrompt());
     unawaited(AndroidTripMonitor.stop());
-    unawaited(LiveActivityService.endLiveActivity());
+    if (_liveActivityId != null) {
+      unawaited(
+        LiveActivityService.endLiveActivity(ownerActivityId: _liveActivityId),
+      );
+    }
     super.dispose();
   }
 
@@ -564,9 +569,18 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
     final initialIndex = _resolveInitialPathIndex(detail.paths);
     _targetInitialPathId = detail.paths[initialIndex].pathId;
+    // Preserve the selection by pathId rather than raw tab index, so a
+    // refresh that reorders (or adds/removes) paths cannot silently switch
+    // the screen, and the Live Activity, to a different direction.
+    final previousSelectedPathId = _currentPathId;
+    final preservedIndex = previousSelectedPathId == null
+        ? -1
+        : pathIds.indexOf(previousSelectedPathId);
     final selectedIndex = _tabController == null
         ? initialIndex
-        : _tabController!.index.clamp(0, pathIds.length - 1);
+        : (preservedIndex != -1
+              ? preservedIndex
+              : _tabController!.index.clamp(0, pathIds.length - 1));
 
     if (_tabController?.length == pathIds.length) {
       _tabController!.index = selectedIndex;
@@ -2318,6 +2332,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (didStart) {
       setState(() {
         _liveActivityActive = true;
+        _liveActivityId = LiveActivityService.activeActivityId;
         _liveActivityStopId = displayState.stopId;
         _liveActivityPathId = pathInfo.pathId;
         _liveActivityRouteKey = widget.routeKey;
@@ -2326,6 +2341,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     } else {
       setState(() {
         _liveActivityActive = false;
+        _liveActivityId = null;
         _liveActivityStopId = null;
         _liveActivityPathId = null;
         _liveActivityRouteKey = null;
@@ -2336,13 +2352,20 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
   Future<void> _stopLiveActivity() async {
     await TripMonitorNotifications.cancelBoardingCheckPrompt();
-    await LiveActivityService.endLiveActivity();
+    // Only end the activity this screen started; another route screen may
+    // own the currently visible Live Activity.
+    if (_liveActivityId != null) {
+      await LiveActivityService.endLiveActivity(
+        ownerActivityId: _liveActivityId,
+      );
+    }
     if (!mounted) {
       return;
     }
     setState(() {
       _resetLiveActivityRideState();
       _liveActivityActive = false;
+      _liveActivityId = null;
       _liveActivityStopId = null;
       _liveActivityPathId = null;
       _liveActivityRouteKey = null;
@@ -2563,15 +2586,18 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
   String _buildWaitingBoardingText({
     required String pathName,
     required StopInfo boardingStop,
-    required StopInfo destinationStop,
+    StopInfo? destinationStop,
     required int? busStopsUntilBoarding,
   }) {
     final parts = <String>[
       _pathStatusPrefix(pathName),
       '尚未上車',
       '上車站 ${boardingStop.stopName}',
-      '目的地 ${destinationStop.stopName}',
     ];
+    if (destinationStop != null &&
+        destinationStop.stopId != boardingStop.stopId) {
+      parts.add('目的地 ${destinationStop.stopName}');
+    }
     final busDistanceSummary = _buildBusDistanceSummary(busStopsUntilBoarding);
     if (busDistanceSummary != null) {
       parts.add(busDistanceSummary);
@@ -2790,10 +2816,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           statusText: _buildWaitingBoardingText(
             pathName: pathInfo.name,
             boardingStop: boardingStop,
-            destinationStop: boardingStop,
             busStopsUntilBoarding: busStopsUntilBoarding,
           ),
-          etaSeconds: boardingStop.sec,
+          etaSeconds: effectiveStopEtaSeconds(boardingStop),
           etaMessage: boardingStop.msg,
           vehicleId: _vehicleIdForStop(boardingStop),
           progressValue: boardingProgressValue,
@@ -2825,7 +2850,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         lineHighlightedStopIndex: stopLine.highlightedStopIndex,
         modeLabel: '最近站牌',
         statusText: '尚未設定下車站',
-        etaSeconds: nearestStop.sec,
+        etaSeconds: effectiveStopEtaSeconds(nearestStop),
         etaMessage: nearestStop.msg,
         vehicleId: _vehicleIdForStop(nearestStop),
         progressValue: currentProgress,
@@ -2882,7 +2907,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           destinationStop: destinationStop,
           busStopsUntilBoarding: busStopsUntilBoarding,
         ),
-        etaSeconds: boardingStop.sec,
+        etaSeconds: effectiveStopEtaSeconds(boardingStop),
         etaMessage: boardingStop.msg,
         vehicleId: _vehicleIdForStop(boardingStop),
         progressValue: boardingProgressValue,
@@ -2930,7 +2955,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       lineHighlightedStopIndex: stopLine.highlightedStopIndex,
       modeLabel: '已上車',
       statusText: onboardStatusParts.join(' · '),
-      etaSeconds: displayStop.sec,
+      etaSeconds: effectiveStopEtaSeconds(displayStop),
       etaMessage: displayStop.msg,
       vehicleId: displayVehicleId,
       progressValue: currentProgress,
@@ -2946,6 +2971,15 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     RouteDetailData detail,
     PathInfo pathInfo,
   ) async {
+    // Only the route screen the user is actually looking at (top of the
+    // navigation stack) may drive the Live Activity. Without this guard a
+    // screen lower in the stack could keep pushing its own route data into
+    // an activity started by another screen, making the Dynamic Island show
+    // the wrong bus/route.
+    if (!_isRouteVisible) {
+      return;
+    }
+
     final displayState = _buildLiveActivityDisplayState(detail, pathInfo);
     if (displayState == null) {
       await _stopLiveActivity();
@@ -2954,6 +2988,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
     final needsRestart =
         !_liveActivityActive ||
+        !LiveActivityService.ownsActivity(_liveActivityId) ||
         _liveActivityPathId != pathInfo.pathId ||
         _liveActivityRouteKey != widget.routeKey ||
         _liveActivityProviderName != widget.provider.name;
@@ -2962,8 +2997,17 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       return;
     }
 
-    await LiveActivityService.updateLiveActivity(displayState);
+    final updated = await LiveActivityService.updateLiveActivity(
+      displayState,
+      ownerActivityId: _liveActivityId,
+    );
     if (!mounted) {
+      return;
+    }
+    if (!updated) {
+      // The activity was dismissed or replaced natively; restart it so the
+      // user keeps getting updates for the bus they are riding.
+      await _startLiveActivity(pathInfo, displayState);
       return;
     }
     if (_liveActivityStopId != displayState.stopId) {
@@ -3029,7 +3073,10 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
   }
 
   Future<void> _maybeRefreshBackgroundTripMonitor() async {
-    if (!_isIOS || _appIsForeground || _backgroundDataRefreshInFlight) {
+    if (!_isIOS ||
+        !_isRouteVisible ||
+        _appIsForeground ||
+        _backgroundDataRefreshInFlight) {
       return;
     }
 

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -1309,8 +1309,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       final manufacturer = androidInfo.manufacturer.toLowerCase();
       final brand = androidInfo.brand.toLowerCase();
 
-      final isTargetBrand =
-          manufacturer.contains('oppo') ||
+      final isTargetBrand = manufacturer.contains('oppo') ||
           brand.contains('oppo') ||
           manufacturer.contains('realme') ||
           brand.contains('realme') ||
@@ -2922,18 +2921,17 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       onboardStatusParts.add(nearestEtaText);
     }
     final preferredRidingVehicleId = _liveActivityRidingVehicleId?.trim();
-    final hasPreferredRidingVehicleId =
-        preferredRidingVehicleId != null && preferredRidingVehicleId.isNotEmpty;
+    final hasPreferredRidingVehicleId = preferredRidingVehicleId != null &&
+        preferredRidingVehicleId.isNotEmpty;
     final ridingVehicleIndex = _findStopIndexForVehicleId(
       pathStops,
       preferredRidingVehicleId,
     );
-    final displayIndex =
-        ridingVehicleIndex ??
+    final displayIndex = ridingVehicleIndex ??
         (hasPreferredRidingVehicleId ? nearestIndex : busIndex ?? nearestIndex);
     final displayStop = pathStops[displayIndex];
-    final displayVehicleId =
-        ridingVehicleIndex == null && hasPreferredRidingVehicleId
+    final displayVehicleId = ridingVehicleIndex == null &&
+            hasPreferredRidingVehicleId
         ? preferredRidingVehicleId
         : _vehicleIdAtStop(displayStop, preferredRidingVehicleId);
     if (ridingVehicleIndex != null || !hasPreferredRidingVehicleId) {
@@ -3223,7 +3221,6 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (await _shouldAssignFavoriteDestination()) {
       final destination = await _pickFavoriteDestinationStop(
         pathId: stop.pathId,
-        originStopId: stop.stopId,
       );
       if (!mounted) {
         return;
@@ -3286,22 +3283,16 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     return shouldAssign == true;
   }
 
-  Future<StopInfo?> _pickFavoriteDestinationStop({
-    required int pathId,
-    required int originStopId,
-  }) async {
+  Future<StopInfo?> _pickFavoriteDestinationStop({required int pathId}) async {
     final detail = _detail;
     if (detail == null) {
       return null;
     }
     final pathStops = detail.stopsByPath[pathId] ?? const <StopInfo>[];
-    final destinationStops = pathStops
-        .where((stop) => stop.stopId != originStopId)
-        .toList(growable: false);
-    if (destinationStops.isEmpty) {
+    if (pathStops.isEmpty) {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('這個方向沒有其他可選擇的目的地站牌。')));
+      ).showSnackBar(const SnackBar(content: Text('這個方向目前沒有可選擇的站牌。')));
       return null;
     }
 
@@ -3314,13 +3305,13 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           child: SizedBox(
             height: MediaQuery.of(context).size.height * 0.72,
             child: ListView.separated(
-              itemCount: destinationStops.length,
+              itemCount: pathStops.length,
               separatorBuilder: (_, _) => const Divider(height: 1),
               itemBuilder: (context, index) {
-                final destinationStop = destinationStops[index];
+                final destinationStop = pathStops[index];
                 return ListTile(
                   title: Text(destinationStop.stopName),
-                  subtitle: Text('第 ${destinationStop.sequence} 站'),
+                  subtitle: Text('第 ${index + 1} 站'),
                   onTap: () => Navigator.of(context).pop(destinationStop),
                 );
               },
@@ -3531,9 +3522,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
                         return ListTile(
                           leading: CircleAvatar(
                             child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 4,
-                              ),
+                              padding: const EdgeInsets.symmetric(horizontal: 4),
                               child: FittedBox(
                                 fit: BoxFit.scaleDown,
                                 child: Text(
@@ -3937,7 +3926,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     final hasArrivingBus =
         stop.buses.any((vehicle) => vehicle.carOnStop) ||
         (seconds != null && seconds <= 0);
-    final isLessThanOneMinute = seconds != null && seconds > 0 && seconds < 60;
+    final isLessThanOneMinute =
+        seconds != null && seconds > 0 && seconds < 60;
     final isUrgentEta = seconds != null && seconds >= 60 && seconds < 180;
     final hasFullBus = stop.buses.any((vehicle) => vehicle.full);
     final hasElectricBus = stop.buses.any(_isElectricVehicle);
@@ -3959,9 +3949,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
     if (isLessThanOneMinute) {
       return _VehicleStatusStyle(
-        icon: hasElectricBus
-            ? Icons.electric_bolt_rounded
-            : Icons.timer_rounded,
+        icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.timer_rounded,
         backgroundColor: Colors.deepOrange.shade600,
         foregroundColor: Colors.white,
         borderColor: Colors.orange.shade200.withValues(alpha: 0.8),
@@ -3972,9 +3960,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
     if (isUrgentEta) {
       return _VehicleStatusStyle(
-        icon: hasElectricBus
-            ? Icons.electric_bolt_rounded
-            : Icons.timer_rounded,
+        icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.timer_rounded,
         backgroundColor: Colors.orange.shade700,
         foregroundColor: Colors.white,
         borderColor: Colors.orange.shade200.withValues(alpha: 0.78),
@@ -3985,9 +3971,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
     if (hasFullBus) {
       return _VehicleStatusStyle(
-        icon: hasElectricBus
-            ? Icons.electric_bolt_rounded
-            : Icons.groups_rounded,
+        icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.groups_rounded,
         backgroundColor: Colors.brown.shade600,
         foregroundColor: Colors.white,
         borderColor: Colors.orange.shade200.withValues(alpha: 0.75),
@@ -4198,11 +4182,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     }
 
     if (stop.buses.isNotEmpty) {
-      final statusStyle = _vehicleStatusStyle(
-        theme,
-        stop,
-        isNearest: isNearest,
-      );
+      final statusStyle = _vehicleStatusStyle(theme, stop, isNearest: isNearest);
 
       return PopupMenuButton<BusVehicle>(
         padding: EdgeInsets.zero,
@@ -4836,7 +4816,13 @@ class _RouteStatusPill extends StatelessWidget {
         border: borderColor == null ? null : Border.all(color: borderColor!),
         boxShadow: glowColor == null
             ? null
-            : [BoxShadow(color: glowColor!, blurRadius: 14, spreadRadius: 1)],
+            : [
+                BoxShadow(
+                  color: glowColor!,
+                  blurRadius: 14,
+                  spreadRadius: 1,
+                ),
+              ],
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -5064,9 +5050,9 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
     if (!shared) {
       await Clipboard.setData(ClipboardData(text: url));
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('已複製連結')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('已複製連結')),
+      );
     }
   }
 
@@ -5202,7 +5188,8 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
     if (explicit != null) {
       return explicit;
     }
-    return date.weekday == DateTime.saturday || date.weekday == DateTime.sunday;
+    return date.weekday == DateTime.saturday ||
+        date.weekday == DateTime.sunday;
   }
 
   String _dateKey(DateTime date) {
@@ -5252,9 +5239,8 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
     final theme = Theme.of(context);
 
     // Filter entries that run on the selected date, then group by direction.
-    final activeEntries = _schedule!
-        .where(_isEntryActiveOnSelectedDate)
-        .toList();
+    final activeEntries =
+        _schedule!.where(_isEntryActiveOnSelectedDate).toList();
 
     if (activeEntries.isEmpty) {
       return [
@@ -5324,7 +5310,10 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   for (final entry in frequencyEntries)
-                    Text(entry.displayText, style: theme.textTheme.bodySmall),
+                    Text(
+                      entry.displayText,
+                      style: theme.textTheme.bodySmall,
+                    ),
                 ],
               ),
             ),
@@ -5343,7 +5332,10 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
                       color: theme.colorScheme.surfaceContainerHighest,
                       borderRadius: BorderRadius.circular(6),
                     ),
-                    child: Text(time, style: theme.textTheme.bodySmall),
+                    child: Text(
+                      time,
+                      style: theme.textTheme.bodySmall,
+                    ),
                   ),
               ],
             )
@@ -5464,7 +5456,8 @@ class _StopScheduleSheetState extends State<_StopScheduleSheet> {
     final key = _dateKey(date);
     final explicit = _holidayMap[key];
     if (explicit != null) return explicit;
-    return date.weekday == DateTime.saturday || date.weekday == DateTime.sunday;
+    return date.weekday == DateTime.saturday ||
+        date.weekday == DateTime.sunday;
   }
 
   String _dateKey(DateTime date) {
@@ -5604,7 +5597,9 @@ class _StopScheduleSheetState extends State<_StopScheduleSheet> {
                 ],
               ),
               const Divider(height: 16),
-              Expanded(child: _buildBody(theme, scrollController)),
+              Expanded(
+                child: _buildBody(theme, scrollController),
+              ),
             ],
           ),
         );
@@ -5730,10 +5725,7 @@ class _StopScheduleSheetState extends State<_StopScheduleSheet> {
               if (stopTimes.values.any((e) => e)) ...[
                 const SizedBox(width: 6),
                 Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 6,
-                    vertical: 2,
-                  ),
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                   decoration: BoxDecoration(
                     color: theme.colorScheme.tertiaryContainer,
                     borderRadius: BorderRadius.circular(4),

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -1309,7 +1309,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       final manufacturer = androidInfo.manufacturer.toLowerCase();
       final brand = androidInfo.brand.toLowerCase();
 
-      final isTargetBrand = manufacturer.contains('oppo') ||
+      final isTargetBrand =
+          manufacturer.contains('oppo') ||
           brand.contains('oppo') ||
           manufacturer.contains('realme') ||
           brand.contains('realme') ||
@@ -2921,17 +2922,18 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       onboardStatusParts.add(nearestEtaText);
     }
     final preferredRidingVehicleId = _liveActivityRidingVehicleId?.trim();
-    final hasPreferredRidingVehicleId = preferredRidingVehicleId != null &&
-        preferredRidingVehicleId.isNotEmpty;
+    final hasPreferredRidingVehicleId =
+        preferredRidingVehicleId != null && preferredRidingVehicleId.isNotEmpty;
     final ridingVehicleIndex = _findStopIndexForVehicleId(
       pathStops,
       preferredRidingVehicleId,
     );
-    final displayIndex = ridingVehicleIndex ??
+    final displayIndex =
+        ridingVehicleIndex ??
         (hasPreferredRidingVehicleId ? nearestIndex : busIndex ?? nearestIndex);
     final displayStop = pathStops[displayIndex];
-    final displayVehicleId = ridingVehicleIndex == null &&
-            hasPreferredRidingVehicleId
+    final displayVehicleId =
+        ridingVehicleIndex == null && hasPreferredRidingVehicleId
         ? preferredRidingVehicleId
         : _vehicleIdAtStop(displayStop, preferredRidingVehicleId);
     if (ridingVehicleIndex != null || !hasPreferredRidingVehicleId) {
@@ -3221,6 +3223,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (await _shouldAssignFavoriteDestination()) {
       final destination = await _pickFavoriteDestinationStop(
         pathId: stop.pathId,
+        originStopId: stop.stopId,
       );
       if (!mounted) {
         return;
@@ -3283,16 +3286,22 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     return shouldAssign == true;
   }
 
-  Future<StopInfo?> _pickFavoriteDestinationStop({required int pathId}) async {
+  Future<StopInfo?> _pickFavoriteDestinationStop({
+    required int pathId,
+    required int originStopId,
+  }) async {
     final detail = _detail;
     if (detail == null) {
       return null;
     }
     final pathStops = detail.stopsByPath[pathId] ?? const <StopInfo>[];
-    if (pathStops.isEmpty) {
+    final destinationStops = pathStops
+        .where((stop) => stop.stopId != originStopId)
+        .toList(growable: false);
+    if (destinationStops.isEmpty) {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('這個方向目前沒有可選擇的站牌。')));
+      ).showSnackBar(const SnackBar(content: Text('這個方向沒有其他可選擇的目的地站牌。')));
       return null;
     }
 
@@ -3305,13 +3314,13 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           child: SizedBox(
             height: MediaQuery.of(context).size.height * 0.72,
             child: ListView.separated(
-              itemCount: pathStops.length,
+              itemCount: destinationStops.length,
               separatorBuilder: (_, _) => const Divider(height: 1),
               itemBuilder: (context, index) {
-                final destinationStop = pathStops[index];
+                final destinationStop = destinationStops[index];
                 return ListTile(
                   title: Text(destinationStop.stopName),
-                  subtitle: Text('第 ${index + 1} 站'),
+                  subtitle: Text('第 ${destinationStop.sequence} 站'),
                   onTap: () => Navigator.of(context).pop(destinationStop),
                 );
               },
@@ -3522,7 +3531,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
                         return ListTile(
                           leading: CircleAvatar(
                             child: Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 4),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 4,
+                              ),
                               child: FittedBox(
                                 fit: BoxFit.scaleDown,
                                 child: Text(
@@ -3926,8 +3937,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     final hasArrivingBus =
         stop.buses.any((vehicle) => vehicle.carOnStop) ||
         (seconds != null && seconds <= 0);
-    final isLessThanOneMinute =
-        seconds != null && seconds > 0 && seconds < 60;
+    final isLessThanOneMinute = seconds != null && seconds > 0 && seconds < 60;
     final isUrgentEta = seconds != null && seconds >= 60 && seconds < 180;
     final hasFullBus = stop.buses.any((vehicle) => vehicle.full);
     final hasElectricBus = stop.buses.any(_isElectricVehicle);
@@ -3949,7 +3959,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
     if (isLessThanOneMinute) {
       return _VehicleStatusStyle(
-        icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.timer_rounded,
+        icon: hasElectricBus
+            ? Icons.electric_bolt_rounded
+            : Icons.timer_rounded,
         backgroundColor: Colors.deepOrange.shade600,
         foregroundColor: Colors.white,
         borderColor: Colors.orange.shade200.withValues(alpha: 0.8),
@@ -3960,7 +3972,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
     if (isUrgentEta) {
       return _VehicleStatusStyle(
-        icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.timer_rounded,
+        icon: hasElectricBus
+            ? Icons.electric_bolt_rounded
+            : Icons.timer_rounded,
         backgroundColor: Colors.orange.shade700,
         foregroundColor: Colors.white,
         borderColor: Colors.orange.shade200.withValues(alpha: 0.78),
@@ -3971,7 +3985,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
     if (hasFullBus) {
       return _VehicleStatusStyle(
-        icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.groups_rounded,
+        icon: hasElectricBus
+            ? Icons.electric_bolt_rounded
+            : Icons.groups_rounded,
         backgroundColor: Colors.brown.shade600,
         foregroundColor: Colors.white,
         borderColor: Colors.orange.shade200.withValues(alpha: 0.75),
@@ -4182,7 +4198,11 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     }
 
     if (stop.buses.isNotEmpty) {
-      final statusStyle = _vehicleStatusStyle(theme, stop, isNearest: isNearest);
+      final statusStyle = _vehicleStatusStyle(
+        theme,
+        stop,
+        isNearest: isNearest,
+      );
 
       return PopupMenuButton<BusVehicle>(
         padding: EdgeInsets.zero,
@@ -4816,13 +4836,7 @@ class _RouteStatusPill extends StatelessWidget {
         border: borderColor == null ? null : Border.all(color: borderColor!),
         boxShadow: glowColor == null
             ? null
-            : [
-                BoxShadow(
-                  color: glowColor!,
-                  blurRadius: 14,
-                  spreadRadius: 1,
-                ),
-              ],
+            : [BoxShadow(color: glowColor!, blurRadius: 14, spreadRadius: 1)],
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -5050,9 +5064,9 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
     if (!shared) {
       await Clipboard.setData(ClipboardData(text: url));
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('已複製連結')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('已複製連結')));
     }
   }
 
@@ -5188,8 +5202,7 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
     if (explicit != null) {
       return explicit;
     }
-    return date.weekday == DateTime.saturday ||
-        date.weekday == DateTime.sunday;
+    return date.weekday == DateTime.saturday || date.weekday == DateTime.sunday;
   }
 
   String _dateKey(DateTime date) {
@@ -5239,8 +5252,9 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
     final theme = Theme.of(context);
 
     // Filter entries that run on the selected date, then group by direction.
-    final activeEntries =
-        _schedule!.where(_isEntryActiveOnSelectedDate).toList();
+    final activeEntries = _schedule!
+        .where(_isEntryActiveOnSelectedDate)
+        .toList();
 
     if (activeEntries.isEmpty) {
       return [
@@ -5310,10 +5324,7 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   for (final entry in frequencyEntries)
-                    Text(
-                      entry.displayText,
-                      style: theme.textTheme.bodySmall,
-                    ),
+                    Text(entry.displayText, style: theme.textTheme.bodySmall),
                 ],
               ),
             ),
@@ -5332,10 +5343,7 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
                       color: theme.colorScheme.surfaceContainerHighest,
                       borderRadius: BorderRadius.circular(6),
                     ),
-                    child: Text(
-                      time,
-                      style: theme.textTheme.bodySmall,
-                    ),
+                    child: Text(time, style: theme.textTheme.bodySmall),
                   ),
               ],
             )
@@ -5456,8 +5464,7 @@ class _StopScheduleSheetState extends State<_StopScheduleSheet> {
     final key = _dateKey(date);
     final explicit = _holidayMap[key];
     if (explicit != null) return explicit;
-    return date.weekday == DateTime.saturday ||
-        date.weekday == DateTime.sunday;
+    return date.weekday == DateTime.saturday || date.weekday == DateTime.sunday;
   }
 
   String _dateKey(DateTime date) {
@@ -5597,9 +5604,7 @@ class _StopScheduleSheetState extends State<_StopScheduleSheet> {
                 ],
               ),
               const Divider(height: 16),
-              Expanded(
-                child: _buildBody(theme, scrollController),
-              ),
+              Expanded(child: _buildBody(theme, scrollController)),
             ],
           ),
         );
@@ -5725,7 +5730,10 @@ class _StopScheduleSheetState extends State<_StopScheduleSheet> {
               if (stopTimes.values.any((e) => e)) ...[
                 const SizedBox(width: 6),
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
+                  ),
                   decoration: BoxDecoration(
                     color: theme.colorScheme.tertiaryContainer,
                     borderRadius: BorderRadius.circular(4),

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -96,6 +96,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
   bool _isRouteVisible = true;
   int? _liveActivityStopId;
   int? _liveActivityPathId;
+  int? _liveActivityRouteKey;
+  String? _liveActivityProviderName;
+  String? _liveActivityRidingVehicleId;
   bool _liveActivityBoardingWindowOpen = false;
   bool _liveActivityRideConfirmed = false;
   DateTime? _liveActivityBoardingWindowOpenedAt;
@@ -2292,6 +2295,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     _liveActivityDestinationAlertStage = 0;
     _iosBoardingCheckPromptSent = false;
     _liveActivityLastNearestStopIndex = null;
+    _liveActivityRidingVehicleId = null;
   }
 
   Future<void> _startLiveActivity(
@@ -2316,12 +2320,16 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         _liveActivityActive = true;
         _liveActivityStopId = displayState.stopId;
         _liveActivityPathId = pathInfo.pathId;
+        _liveActivityRouteKey = widget.routeKey;
+        _liveActivityProviderName = widget.provider.name;
       });
     } else {
       setState(() {
         _liveActivityActive = false;
         _liveActivityStopId = null;
         _liveActivityPathId = null;
+        _liveActivityRouteKey = null;
+        _liveActivityProviderName = null;
       });
     }
   }
@@ -2337,6 +2345,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       _liveActivityActive = false;
       _liveActivityStopId = null;
       _liveActivityPathId = null;
+      _liveActivityRouteKey = null;
+      _liveActivityProviderName = null;
     });
   }
 
@@ -2481,6 +2491,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     required String boardingEtaText,
     required double? boardingDistanceMeters,
     required int? busIndex,
+    required String? busVehicleId,
   }) {
     final userNearBoardingStop =
         (boardingDistanceMeters != null && boardingDistanceMeters <= 180.0) ||
@@ -2506,6 +2517,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         nearestIndex >= boardingIndex &&
         busNearUser) {
       _liveActivityRideConfirmed = true;
+      _liveActivityRidingVehicleId = busVehicleId;
       unawaited(TripMonitorNotifications.cancelBoardingCheckPrompt());
     }
 
@@ -2572,6 +2584,31 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       return null;
     }
     return stop.buses.first.id;
+  }
+
+  int? _findStopIndexForVehicleId(List<StopInfo> stops, String? vehicleId) {
+    final normalizedVehicleId = vehicleId?.trim();
+    if (normalizedVehicleId == null || normalizedVehicleId.isEmpty) {
+      return null;
+    }
+    for (var index = 0; index < stops.length; index++) {
+      if (stops[index].buses.any(
+        (vehicle) => vehicle.id == normalizedVehicleId,
+      )) {
+        return index;
+      }
+    }
+    return null;
+  }
+
+  String? _vehicleIdAtStop(StopInfo stop, String? preferredVehicleId) {
+    final normalizedVehicleId = preferredVehicleId?.trim();
+    if (normalizedVehicleId != null &&
+        normalizedVehicleId.isNotEmpty &&
+        stop.buses.any((vehicle) => vehicle.id == normalizedVehicleId)) {
+      return normalizedVehicleId;
+    }
+    return _vehicleIdForStop(stop);
   }
 
   ({String? previousStopName, String? nextStopName}) _adjacentStopNames(
@@ -2724,6 +2761,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         boardingEtaText: boardingEtaText,
         boardingDistanceMeters: _distanceToStop(boardingStop),
         busIndex: busIndex,
+        busVehicleId: busIndex == null
+            ? null
+            : _vehicleIdForStop(pathStops[busIndex]),
       );
       if (!hasBoarded) {
         final boardingProgressValue = busIndex == null
@@ -2812,6 +2852,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       boardingEtaText: boardingEtaText,
       boardingDistanceMeters: _distanceToStop(boardingStop),
       busIndex: busIndex,
+      busVehicleId: busIndex == null
+          ? null
+          : _vehicleIdForStop(pathStops[busIndex]),
     );
 
     if (!hasBoarded) {
@@ -2852,16 +2895,34 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (nearestEtaText != '--') {
       onboardStatusParts.add(nearestEtaText);
     }
+    final preferredRidingVehicleId = _liveActivityRidingVehicleId?.trim();
+    final hasPreferredRidingVehicleId = preferredRidingVehicleId != null &&
+        preferredRidingVehicleId.isNotEmpty;
+    final ridingVehicleIndex = _findStopIndexForVehicleId(
+      pathStops,
+      preferredRidingVehicleId,
+    );
+    final displayIndex = ridingVehicleIndex ??
+        (hasPreferredRidingVehicleId ? nearestIndex : busIndex ?? nearestIndex);
+    final displayStop = pathStops[displayIndex];
+    final displayVehicleId = ridingVehicleIndex == null &&
+            hasPreferredRidingVehicleId
+        ? preferredRidingVehicleId
+        : _vehicleIdAtStop(displayStop, preferredRidingVehicleId);
+    if (ridingVehicleIndex != null || !hasPreferredRidingVehicleId) {
+      _liveActivityRidingVehicleId = displayVehicleId;
+    }
     final stopLine = _buildLiveActivityStopLine(
       pathStops,
-      anchorIndex: busIndex ?? nearestIndex,
+      anchorIndex: displayIndex,
       highlightedIndex: destinationIndex,
     );
-    final adjacentStops = _adjacentStopNames(pathStops, destinationStop.stopId);
+    final adjacentStops = _adjacentStopNames(pathStops, displayStop.stopId);
 
     return LiveActivityDisplayState(
-      stopId: destinationStop.stopId,
-      stopName: destinationStop.stopName,
+      stopId: displayStop.stopId,
+      stopName: displayStop.stopName,
+      alertStopName: destinationStop.stopName,
       previousStopName: adjacentStops.previousStopName,
       nextStopName: adjacentStops.nextStopName,
       lineStopNames: stopLine.stopNames,
@@ -2869,9 +2930,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       lineHighlightedStopIndex: stopLine.highlightedStopIndex,
       modeLabel: '已上車',
       statusText: onboardStatusParts.join(' · '),
-      etaSeconds: destinationStop.sec,
-      etaMessage: destinationStop.msg,
-      vehicleId: _vehicleIdForStop(destinationStop),
+      etaSeconds: displayStop.sec,
+      etaMessage: displayStop.msg,
+      vehicleId: displayVehicleId,
       progressValue: currentProgress,
       progressTotal: destinationIndex + 1,
       alertKind: _maybeIssueLiveActivityDestinationArrivalAlert(
@@ -2892,7 +2953,10 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     }
 
     final needsRestart =
-        !_liveActivityActive || _liveActivityPathId != pathInfo.pathId;
+        !_liveActivityActive ||
+        _liveActivityPathId != pathInfo.pathId ||
+        _liveActivityRouteKey != widget.routeKey ||
+        _liveActivityProviderName != widget.provider.name;
     if (needsRestart) {
       await _startLiveActivity(pathInfo, displayState);
       return;
@@ -3791,25 +3855,6 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         type.contains('e_bus');
   }
 
-  String _vehicleStatusLabel(StopInfo stop) {
-    if (stop.buses.length > 1) {
-      return '${stop.buses.length} 輛靠近';
-    }
-    return stop.buses.first.id;
-  }
-
-  String _formatEffectiveEtaStatusLabel(int seconds) {
-    if (seconds < 60) {
-      return '$seconds秒';
-    }
-    final minutes = seconds ~/ 60;
-    final leftoverSeconds = seconds % 60;
-    if (leftoverSeconds == 0) {
-      return '$minutes分';
-    }
-    return '$minutes分$leftoverSeconds秒';
-  }
-
   String _vehicleStatusTooltip(StopInfo stop) {
     final ids = stop.buses.map((vehicle) => vehicle.id).join('、');
     final flags = <String>[
@@ -3840,10 +3885,6 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     final hasFullBus = stop.buses.any((vehicle) => vehicle.full);
     final hasElectricBus = stop.buses.any(_isElectricVehicle);
     final hasAccessibleBus = stop.buses.any((vehicle) => vehicle.type == '1');
-    final vehicle = stop.buses.firstWhere(
-      _isElectricVehicle,
-      orElse: () => stop.buses.first,
-    );
     final vehicleIcon = hasElectricBus
         ? Icons.electric_bolt_rounded
         : Icons.directions_bus_filled_rounded;
@@ -3851,46 +3892,39 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (hasArrivingBus) {
       return _VehicleStatusStyle(
         icon: vehicleIcon,
-        label: hasMultipleBuses ? '${stop.buses.length} 輛進站' : '進站中',
         backgroundColor: Colors.red.shade700,
         foregroundColor: Colors.white,
         borderColor: Colors.red.shade200.withValues(alpha: 0.85),
         glowColor: Colors.red.shade500.withValues(alpha: 0.38),
         showStackedBuses: hasMultipleBuses,
-        keepLabelWhenCompact: true,
       );
     }
 
     if (isLessThanOneMinute) {
       return _VehicleStatusStyle(
         icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.timer_rounded,
-        label: _formatEffectiveEtaStatusLabel(seconds),
         backgroundColor: Colors.deepOrange.shade600,
         foregroundColor: Colors.white,
         borderColor: Colors.orange.shade200.withValues(alpha: 0.8),
         glowColor: Colors.deepOrange.shade400.withValues(alpha: 0.32),
         showStackedBuses: hasMultipleBuses,
-        keepLabelWhenCompact: true,
       );
     }
 
     if (isUrgentEta) {
       return _VehicleStatusStyle(
         icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.timer_rounded,
-        label: _formatEffectiveEtaStatusLabel(seconds),
         backgroundColor: Colors.orange.shade700,
         foregroundColor: Colors.white,
         borderColor: Colors.orange.shade200.withValues(alpha: 0.78),
         glowColor: Colors.orange.shade400.withValues(alpha: 0.28),
         showStackedBuses: hasMultipleBuses,
-        keepLabelWhenCompact: true,
       );
     }
 
     if (hasFullBus) {
       return _VehicleStatusStyle(
         icon: hasElectricBus ? Icons.electric_bolt_rounded : Icons.groups_rounded,
-        label: hasMultipleBuses ? '${stop.buses.length} 輛 · 客滿' : '客滿',
         backgroundColor: Colors.brown.shade600,
         foregroundColor: Colors.white,
         borderColor: Colors.orange.shade200.withValues(alpha: 0.75),
@@ -3902,7 +3936,6 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (hasElectricBus) {
       return _VehicleStatusStyle(
         icon: Icons.electric_bolt_rounded,
-        label: hasMultipleBuses ? '${stop.buses.length} 輛靠近' : vehicle.id,
         backgroundColor: Colors.amber.shade500,
         foregroundColor: Colors.black87,
         borderColor: Colors.amber.shade100.withValues(alpha: 0.9),
@@ -3914,7 +3947,6 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (isNearest) {
       return _VehicleStatusStyle(
         icon: Icons.gps_fixed_rounded,
-        label: _vehicleStatusLabel(stop),
         backgroundColor: Colors.cyan.shade400,
         foregroundColor: Colors.black87,
         borderColor: Colors.cyan.shade100.withValues(alpha: 0.8),
@@ -3926,7 +3958,6 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (hasMultipleBuses) {
       return _VehicleStatusStyle(
         icon: Icons.directions_bus_rounded,
-        label: _vehicleStatusLabel(stop),
         backgroundColor: theme.colorScheme.secondaryContainer,
         foregroundColor: theme.colorScheme.onSecondaryContainer,
         borderColor: theme.colorScheme.secondary.withValues(alpha: 0.45),
@@ -3938,7 +3969,6 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (hasAccessibleBus) {
       return _VehicleStatusStyle(
         icon: Icons.accessible_rounded,
-        label: vehicle.id,
         backgroundColor: Colors.indigo.shade500,
         foregroundColor: Colors.white,
         borderColor: Colors.indigo.shade100.withValues(alpha: 0.7),
@@ -3948,22 +3978,11 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 
     return _VehicleStatusStyle(
       icon: Icons.directions_bus_rounded,
-      label: vehicle.id,
       backgroundColor: theme.colorScheme.primary,
       foregroundColor: theme.colorScheme.onPrimary,
       borderColor: theme.colorScheme.primaryContainer.withValues(alpha: 0.6),
       glowColor: theme.colorScheme.primary.withValues(alpha: 0.16),
     );
-  }
-
-  String? _vehicleStatusPillLabel(
-    _VehicleStatusStyle statusStyle, {
-    required bool compact,
-  }) {
-    if (compact && !statusStyle.keepLabelWhenCompact) {
-      return null;
-    }
-    return statusStyle.label;
   }
 
   double _measureMaxLineWidth(
@@ -4029,7 +4048,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     final fullPillWidth = _estimateRouteStatusPillWidth(
       context,
       icon: statusStyle.icon,
-      label: statusStyle.label,
+      label: null,
       showStackedBuses: statusStyle.showStackedBuses,
     );
     final hasAlert = _stopHasAlert(stop);
@@ -4096,8 +4115,16 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     StopInfo stop, {
     required bool isNearest,
     required bool isDestination,
-    bool compact = false,
   }) {
+    if (isNearest) {
+      return const _RouteStatusPill(
+        icon: Icons.gps_fixed_rounded,
+        label: '你的位置',
+        backgroundColor: Color(0xFF4CAF50),
+        foregroundColor: Colors.white,
+      );
+    }
+
     if (isDestination) {
       return _RouteStatusPill(
         icon: Icons.flag_rounded,
@@ -4128,22 +4155,13 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         },
         child: _RouteStatusPill(
           icon: statusStyle.icon,
-          label: _vehicleStatusPillLabel(statusStyle, compact: compact),
+          label: null,
           backgroundColor: statusStyle.backgroundColor,
           foregroundColor: statusStyle.foregroundColor,
           borderColor: statusStyle.borderColor,
           glowColor: statusStyle.glowColor,
           showStackedBuses: statusStyle.showStackedBuses,
         ),
-      );
-    }
-
-    if (isNearest) {
-      return const _RouteStatusPill(
-        icon: Icons.gps_fixed_rounded,
-        label: '目前位置',
-        backgroundColor: Color(0xFF4CAF50),
-        foregroundColor: Colors.white,
       );
     }
 
@@ -4210,7 +4228,6 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
                       stop,
                       isNearest: isNearest,
                       isDestination: isDestination,
-                      compact: useCompactVehicleStatus,
                     );
                     final vehicleStatusStyle = stop.buses.isEmpty
                         ? null
@@ -4220,28 +4237,25 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
                             isNearest: isNearest,
                           );
                     final trailingStatusWidth = switch ((
+                      isNearest,
                       isDestination,
                       stop.buses.isNotEmpty,
-                      isNearest,
                     )) {
                       (true, _, _) => _estimateRouteStatusPillWidth(
+                        context,
+                        icon: Icons.gps_fixed_rounded,
+                        label: '你的位置',
+                      ),
+                      (false, true, _) => _estimateRouteStatusPillWidth(
                         context,
                         icon: Icons.flag_rounded,
                         label: '下車站',
                       ),
-                      (false, true, _) => _estimateRouteStatusPillWidth(
-                        context,
-                        icon: vehicleStatusStyle!.icon,
-                        label: _vehicleStatusPillLabel(
-                          vehicleStatusStyle,
-                          compact: useCompactVehicleStatus,
-                        ),
-                        showStackedBuses: vehicleStatusStyle.showStackedBuses,
-                      ),
                       (false, false, true) => _estimateRouteStatusPillWidth(
                         context,
-                        icon: Icons.gps_fixed_rounded,
-                        label: '目前位置',
+                        icon: vehicleStatusStyle!.icon,
+                        label: null,
+                        showStackedBuses: vehicleStatusStyle.showStackedBuses,
                       ),
                       _ => 0.0,
                     };
@@ -4681,23 +4695,19 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
 class _VehicleStatusStyle {
   const _VehicleStatusStyle({
     required this.icon,
-    required this.label,
     required this.backgroundColor,
     required this.foregroundColor,
     required this.borderColor,
     required this.glowColor,
     this.showStackedBuses = false,
-    this.keepLabelWhenCompact = false,
   });
 
   final IconData icon;
-  final String label;
   final Color backgroundColor;
   final Color foregroundColor;
   final Color borderColor;
   final Color glowColor;
   final bool showStackedBuses;
-  final bool keepLabelWhenCompact;
 }
 
 class _RouteStatusPill extends StatelessWidget {

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:geolocator/geolocator.dart';
 
 import '../app/bus_app.dart';
@@ -9,6 +10,7 @@ import '../core/app_controller.dart';
 import '../core/models.dart';
 import '../core/route_search_ranking.dart';
 import '../widgets/background_image_wrapper.dart';
+import '../widgets/cat_state_card.dart';
 import 'route_detail_navigation.dart';
 
 class SearchScreen extends StatefulWidget {
@@ -948,6 +950,7 @@ class _SearchScreenState extends State<SearchScreen> {
     bool saveHistory = false,
     String source = 'search_result',
   }) async {
+    unawaited(HapticFeedback.selectionClick());
     final busController = AppControllerScope.read(context);
     if (saveHistory && route != null) {
       await busController.addHistoryEntry(route, provider: provider);
@@ -1041,29 +1044,24 @@ class _SearchScreenState extends State<SearchScreen> {
                 child: Center(child: CircularProgressIndicator()),
               )
             else if (_error != null)
-              Card(
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Text('搜尋失敗：$_error'),
-                ),
+              CatStateCard(
+                mood: CatStateMood.cry,
+                title: '搜尋撞到貓貓了',
+                message: _error,
               )
             else if (_isResolvingStopDistances && _results.isEmpty)
-              const Card(
-                child: Padding(
-                  padding: EdgeInsets.all(16),
-                  child: Text('正在搜尋站牌…'),
-                ),
+              const CatStateCard(
+                mood: CatStateMood.laugh,
+                title: '貓貓正在翻站牌',
+                message: '正在搜尋附近可搭的站牌...',
               )
             else if (_results.isEmpty)
-              Card(
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Text(
-                    missingProviders.isEmpty
-                        ? '找不到符合的路線或站牌。'
-                        : '找不到符合的路線或站牌。部分站牌搜尋需要本機資料庫。',
-                  ),
-                ),
+              CatStateCard(
+                mood: CatStateMood.sad,
+                title: '沒有找到這台貓公車',
+                message: missingProviders.isEmpty
+                    ? '試試看少打一點，或換成站牌名稱搜尋。'
+                    : '部分站牌搜尋需要本機資料庫，先更新資料庫後再試一次。',
               )
             else
               ..._results.map(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -910,25 +910,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             style: theme.textTheme.bodyMedium,
                             children: [
                               const TextSpan(text: '貢獻者清單：\nAvianJay\n'),
-                              TextSpan(
-                                text: 'Axoled',
-                                style: theme.textTheme.bodyMedium?.copyWith(
-                                  color: theme.colorScheme.primary,
-                                  fontWeight: FontWeight.w700,
-                                  shadows: [
-                                    Shadow(
-                                      color: theme.colorScheme.primary
-                                          .withValues(alpha: 0.85),
-                                      blurRadius: 12,
-                                    ),
-                                    Shadow(
-                                      color: theme.colorScheme.tertiary
-                                          .withValues(alpha: 0.65),
-                                      blurRadius: 24,
-                                    ),
-                                  ],
-                                ),
-                              ),
+                              const TextSpan(text: 'Axoled'),
                             ],
                           ),
                         ),

--- a/lib/widgets/cat_state_card.dart
+++ b/lib/widgets/cat_state_card.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+enum CatStateMood { sad, cry, laugh }
+
+class CatStateCard extends StatelessWidget {
+  const CatStateCard({
+    required this.title,
+    this.message,
+    this.mood = CatStateMood.sad,
+    this.actionLabel,
+    this.onAction,
+    this.padding = const EdgeInsets.all(20),
+    super.key,
+  });
+
+  final String title;
+  final String? message;
+  final CatStateMood mood;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+  final EdgeInsetsGeometry padding;
+
+  String get _assetPath => switch (mood) {
+    CatStateMood.sad => 'assets/cat_sad.png',
+    CatStateMood.cry => 'assets/cat_cry.png',
+    CatStateMood.laugh => 'assets/cat_laugh.png',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final actionLabel = this.actionLabel;
+    final onAction = this.onAction;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: padding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 112,
+              height: 112,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primaryContainer.withValues(
+                  alpha: 0.45,
+                ),
+                shape: BoxShape.circle,
+              ),
+              child: Image.asset(_assetPath, fit: BoxFit.contain),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            if (message != null && message!.trim().isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(
+                message!,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            if (actionLabel != null && onAction != null) ...[
+              const SizedBox(height: 16),
+              FilledButton.tonal(
+                onPressed: onAction,
+                child: Text(actionLabel),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -952,6 +952,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.3"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.1"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.9"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   google_sign_in: ^7.2.0
   google_mobile_ads: ^5.3.0
   share_plus: ^12.0.0
+  permission_handler: ^12.0.3
 
 dev_dependencies:
   flutter_test:

--- a/test/live_activity_service_test.dart
+++ b/test/live_activity_service_test.dart
@@ -21,7 +21,7 @@ void main() {
           case 'startLiveActivity':
             return 'mock-activity-id';
           case 'updateLiveActivity':
-            return null;
+            return true;
           case 'endLiveActivity':
             return null;
           case 'isLiveActivityActive':
@@ -103,7 +103,7 @@ void main() {
 
     log.clear();
 
-    await LiveActivityService.updateLiveActivity(
+    final updated = await LiveActivityService.updateLiveActivity(
       const LiveActivityDisplayState(
         stopId: 102,
         stopName: '龍山寺',
@@ -118,6 +118,7 @@ void main() {
       ),
     );
 
+    expect(updated, isTrue);
     expect(log, hasLength(1));
     expect(log.single.method, 'updateLiveActivity');
     final args = log.single.arguments as Map<dynamic, dynamic>;
@@ -138,10 +139,81 @@ void main() {
     await LiveActivityService.endLiveActivity();
     log.clear();
 
-    await LiveActivityService.updateLiveActivity(
+    final updated = await LiveActivityService.updateLiveActivity(
       const LiveActivityDisplayState(stopId: 101, stopName: '西門町'),
     );
 
+    expect(updated, isFalse);
+    expect(log, isEmpty);
+  });
+
+  test('updateLiveActivity skips updates from a non-owner', () async {
+    await LiveActivityService.startLiveActivity(
+      routeName: '307',
+      pathName: '往板橋',
+      routeKey: 307,
+      provider: 'twn',
+      pathId: 0,
+      state: const LiveActivityDisplayState(stopId: 100, stopName: '臺北車站'),
+    );
+    log.clear();
+
+    final updated = await LiveActivityService.updateLiveActivity(
+      const LiveActivityDisplayState(stopId: 999, stopName: '別條路線'),
+      ownerActivityId: 'stale-activity-id',
+    );
+
+    expect(updated, isFalse);
+    expect(log, isEmpty);
+    expect(LiveActivityService.isActive, isTrue);
+  });
+
+  test('updateLiveActivity clears active id when native reports a missing '
+      'activity', () async {
+    await LiveActivityService.startLiveActivity(
+      routeName: '307',
+      pathName: '往板橋',
+      routeKey: 307,
+      provider: 'twn',
+      pathId: 0,
+      state: const LiveActivityDisplayState(stopId: 100, stopName: '臺北車站'),
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        log.add(methodCall);
+        return methodCall.method == 'updateLiveActivity' ? false : null;
+      },
+    );
+    log.clear();
+
+    final updated = await LiveActivityService.updateLiveActivity(
+      const LiveActivityDisplayState(stopId: 101, stopName: '西門町'),
+      ownerActivityId: LiveActivityService.activeActivityId,
+    );
+
+    expect(updated, isFalse);
+    expect(LiveActivityService.isActive, isFalse);
+  });
+
+  test('endLiveActivity skips when another owner holds the activity',
+      () async {
+    await LiveActivityService.startLiveActivity(
+      routeName: '307',
+      pathName: '往板橋',
+      routeKey: 307,
+      provider: 'twn',
+      pathId: 0,
+      state: const LiveActivityDisplayState(stopId: 100, stopName: '臺北車站'),
+    );
+    log.clear();
+
+    await LiveActivityService.endLiveActivity(
+      ownerActivityId: 'stale-activity-id',
+    );
+
+    expect(LiveActivityService.isActive, isTrue);
     expect(log, isEmpty);
   });
 

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -71,6 +71,48 @@ void main() {
     expect(effectiveStopEtaSeconds(stop, now: now), 90);
   });
 
+  test('vehicle eta lookup normalizes plate ids', () {
+    final stop = StopInfo(
+      routeKey: 1,
+      pathId: 0,
+      stopId: 10,
+      stopName: 'Main Station',
+      sequence: 1,
+      lon: 121.5,
+      lat: 25.0,
+      etas: const [
+        StopEta(sec: 60, vehicleId: 'EAL-5959'),
+        StopEta(sec: 180, vehicleId: 'abc 1234'),
+      ],
+    );
+
+    expect(stopEtaForVehicle(stop, ' eal-5959 ')?.sec, 60);
+    expect(stopEtaForVehicle(stop, 'ABC1234')?.sec, 180);
+  });
+
+  test('vehicle eta uses matching bus instead of stop summary', () {
+    final now = DateTime(2026, 6, 9, 8, 0);
+    final stop = StopInfo(
+      routeKey: 1,
+      pathId: 0,
+      stopId: 10,
+      stopName: 'Destination',
+      sequence: 1,
+      lon: 121.5,
+      lat: 25.0,
+      sec: 90,
+      t: now.subtract(const Duration(seconds: 30)).toIso8601String(),
+      etas: const [
+        StopEta(sec: 45, msg: '即將進站', vehicleId: 'wrong-bus'),
+        StopEta(sec: 300, vehicleId: 'EAL-5959'),
+      ],
+    );
+
+    expect(effectiveStopEtaSecondsForVehicle(stop, 'EAL-5959', now: now), 270);
+    expect(effectiveStopEtaMessageForVehicle(stop, 'EAL-5959'), isNull);
+    expect(effectiveStopEtaMessageForVehicle(stop, 'wrong-bus'), '即將進站');
+  });
+
   test('formatEtaBadgeText wraps text by length', () {
     expect(formatEtaBadgeText(''), '');
     expect(formatEtaBadgeText('12:34'), '12:34');

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -20,6 +20,57 @@ void main() {
     expect(eta.text, '2分\n5秒');
   });
 
+  test('eta presentation keeps floor minutes when seconds are hidden', () {
+    final stop = StopInfo(
+      routeKey: 1,
+      pathId: 0,
+      stopId: 10,
+      stopName: 'Main Station',
+      sequence: 1,
+      lon: 121.5,
+      lat: 25.0,
+      sec: 61,
+    );
+
+    final eta = buildEtaPresentation(stop, alwaysShowSeconds: false);
+
+    expect(eta.text, '1分');
+  });
+
+  test('effective stop eta subtracts elapsed time from realtime timestamp', () {
+    final now = DateTime(2026, 6, 9, 8, 0);
+    final stop = StopInfo(
+      routeKey: 1,
+      pathId: 0,
+      stopId: 10,
+      stopName: 'Main Station',
+      sequence: 1,
+      lon: 121.5,
+      lat: 25.0,
+      sec: 90,
+      t: now.subtract(const Duration(seconds: 35)).toIso8601String(),
+    );
+
+    expect(effectiveStopEtaSeconds(stop, now: now), 55);
+  });
+
+  test('effective stop eta ignores stale timestamps', () {
+    final now = DateTime(2026, 6, 9, 8, 0);
+    final stop = StopInfo(
+      routeKey: 1,
+      pathId: 0,
+      stopId: 10,
+      stopName: 'Main Station',
+      sequence: 1,
+      lon: 121.5,
+      lat: 25.0,
+      sec: 90,
+      t: now.subtract(const Duration(minutes: 20)).toIso8601String(),
+    );
+
+    expect(effectiveStopEtaSeconds(stop, now: now), 90);
+  });
+
   test('formatEtaBadgeText wraps text by length', () {
     expect(formatEtaBadgeText(''), '');
     expect(formatEtaBadgeText('12:34'), '12:34');

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -84,65 +84,6 @@ void main() {
     expect(formatDistance(1530), '1.5km');
   });
 
-  test('favorite stop ignores a destination that points at itself', () {
-    const favorite = FavoriteStop(
-      provider: BusProvider.txg,
-      routeKey: 3,
-      pathId: 1,
-      stopId: 100,
-      stopName: '臺中市議會',
-      destinationPathId: 1,
-      destinationStopId: 100,
-      destinationStopName: '臺中市議會',
-    );
-
-    expect(favorite.hasDestination, isFalse);
-    expect(favorite.effectiveDestinationPathId, isNull);
-    expect(favorite.effectiveDestinationStopId, isNull);
-    expect(favorite.effectiveDestinationStopName, isNull);
-    expect(favorite.toJson().containsKey('destinationStopId'), isFalse);
-  });
-
-  test('favorite stop keeps a distinct destination', () {
-    const favorite = FavoriteStop(
-      provider: BusProvider.txg,
-      routeKey: 3,
-      pathId: 1,
-      stopId: 100,
-      stopName: '臺中市議會',
-      destinationPathId: 1,
-      destinationStopId: 120,
-      destinationStopName: '臺中高工',
-    );
-
-    final json = favorite.toJson();
-
-    expect(favorite.hasDestination, isTrue);
-    expect(favorite.effectiveDestinationPathId, 1);
-    expect(favorite.effectiveDestinationStopId, 120);
-    expect(favorite.effectiveDestinationStopName, '臺中高工');
-    expect(json['destinationPathId'], 1);
-    expect(json['destinationStopId'], 120);
-    expect(json['destinationStopName'], '臺中高工');
-  });
-
-  test('favorite stop drops stale self-destination when restored', () {
-    final restored = FavoriteStop.fromJson({
-      'provider': 'txg',
-      'routeKey': 3,
-      'pathId': 1,
-      'stopId': 100,
-      'stopName': '臺中市議會',
-      'destinationPathId': 1,
-      'destinationStopId': 100,
-      'destinationStopName': '臺中市議會',
-    });
-
-    expect(restored.hasDestination, isFalse);
-    expect(restored.destinationStopId, isNull);
-    expect(restored.destinationStopName, isNull);
-  });
-
   test('app settings persist mobile map provider', () {
     final settings = AppSettings.defaults().copyWith(
       mobileMapProvider: MobileMapProvider.osm,

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -84,6 +84,65 @@ void main() {
     expect(formatDistance(1530), '1.5km');
   });
 
+  test('favorite stop ignores a destination that points at itself', () {
+    const favorite = FavoriteStop(
+      provider: BusProvider.txg,
+      routeKey: 3,
+      pathId: 1,
+      stopId: 100,
+      stopName: '臺中市議會',
+      destinationPathId: 1,
+      destinationStopId: 100,
+      destinationStopName: '臺中市議會',
+    );
+
+    expect(favorite.hasDestination, isFalse);
+    expect(favorite.effectiveDestinationPathId, isNull);
+    expect(favorite.effectiveDestinationStopId, isNull);
+    expect(favorite.effectiveDestinationStopName, isNull);
+    expect(favorite.toJson().containsKey('destinationStopId'), isFalse);
+  });
+
+  test('favorite stop keeps a distinct destination', () {
+    const favorite = FavoriteStop(
+      provider: BusProvider.txg,
+      routeKey: 3,
+      pathId: 1,
+      stopId: 100,
+      stopName: '臺中市議會',
+      destinationPathId: 1,
+      destinationStopId: 120,
+      destinationStopName: '臺中高工',
+    );
+
+    final json = favorite.toJson();
+
+    expect(favorite.hasDestination, isTrue);
+    expect(favorite.effectiveDestinationPathId, 1);
+    expect(favorite.effectiveDestinationStopId, 120);
+    expect(favorite.effectiveDestinationStopName, '臺中高工');
+    expect(json['destinationPathId'], 1);
+    expect(json['destinationStopId'], 120);
+    expect(json['destinationStopName'], '臺中高工');
+  });
+
+  test('favorite stop drops stale self-destination when restored', () {
+    final restored = FavoriteStop.fromJson({
+      'provider': 'txg',
+      'routeKey': 3,
+      'pathId': 1,
+      'stopId': 100,
+      'stopName': '臺中市議會',
+      'destinationPathId': 1,
+      'destinationStopId': 100,
+      'destinationStopName': '臺中市議會',
+    });
+
+    expect(restored.hasDestination, isFalse);
+    expect(restored.destinationStopId, isNull);
+    expect(restored.destinationStopName, isNull);
+  });
+
   test('app settings persist mobile map provider', () {
     final settings = AppSettings.defaults().copyWith(
       mobileMapProvider: MobileMapProvider.osm,

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -30,7 +30,11 @@ set(CMAKE_C_FLAGS_PROFILE "${CMAKE_C_FLAGS_RELEASE}")
 set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 
 # Use Unicode for all projects.
-add_definitions(-DUNICODE -D_UNICODE)
+add_definitions(
+  -DUNICODE
+  -D_UNICODE
+  -D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS
+)
 
 # Compilation settings that should be applied to most targets.
 #

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <geolocator_windows/geolocator_windows.h>
 #include <local_notifier/local_notifier_plugin.h>
+#include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -28,6 +29,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   LocalNotifierPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("LocalNotifierPlugin"));
+  PermissionHandlerWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_core
   geolocator_windows
   local_notifier
+  permission_handler_windows
   share_plus
   url_launcher_windows
 )


### PR DESCRIPTION
## Latest update

Commit `99670cc` adds startup permission prompting:

- Requests iOS photo-library and notification permissions after the first rendered frame when the app has not already attempted those startup prompts.
- Uses `permission_handler` for runtime photo/notification permission checks and requests.
- Enables the iOS CocoaPods macros for photos and notifications, and registers the permission handler plugin in the active `YABus` iOS target.
- Restores fun Chinese purpose strings, including `沒有相簿存取權限要怎麼選擇背景圖片呢 o(*￣▽￣*)ブ` for the gallery prompt.

Commit `78ad581` also removed the special glow/color styling from the Axoled contributor name.

Commit `2db1b22` fixes the Windows CI regression from Visual Studio 2026's `<experimental/coroutine>` deprecation assertion.

## Local validation

- `dart format lib/app/bus_app.dart lib/core/startup_permission_service.dart`
- `flutter analyze`
- `flutter test`
- Parsed `ios/YABus/Info.plist` as XML with UTF-8
- Local `flutter build windows --release` passed the coroutine-deprecation point but stopped because this machine lacks ATL (`atlbase.h`)

## CI

- GitHub Actions Build for commit `2db1b22` is in progress: https://github.com/AvianJay/yetanotherbusapp/actions/runs/27217083069
- Previous run for `99670cc` passed iOS unsigned IPA but failed Windows before `2db1b22`.

## Scope note

This update was pushed to the existing PR for `feature/ui-personality-haptics`; the PR also contains earlier branch work outside these latest commits.