### PR TITLE
fix: replace raw error dumps with friendly user-facing messages

### DIFF
--- a/lib/app/bus_app.dart
+++ b/lib/app/bus_app.dart
@@ -14,6 +14,7 @@ import '../core/app_launch_service.dart';
 import '../core/android_home_integration.dart';
 import '../core/desktop_discord_presence_service.dart';
 import '../core/desktop_discord_route_observer.dart';
+import '../core/friendly_error.dart';
 import '../core/app_route_observer.dart';
 import '../core/ios_widget_integration.dart';
 import '../core/models.dart';
@@ -544,7 +545,9 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
       if (!mounted) {
         return;
       }
-      messenger?.showSnackBar(SnackBar(content: Text('設定同步偏好失敗：$error')));
+      messenger?.showSnackBar(
+        SnackBar(content: Text('設定同步偏好失敗：${friendlyErrorMessage(error)}')),
+      );
     }
   }
 
@@ -691,7 +694,9 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
         if (!mounted) {
           return;
         }
-        messenger?.showSnackBar(SnackBar(content: Text('登入錯誤: $error')));
+        messenger?.showSnackBar(
+          SnackBar(content: Text('登入失敗：${friendlyErrorMessage(error)}')),
+        );
       }
       return;
     }
@@ -780,7 +785,7 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
               return;
             }
             messenger?.showSnackBar(
-              SnackBar(content: Text('自動更新資料庫失敗：$error')),
+              SnackBar(content: Text('自動更新資料庫失敗：${friendlyErrorMessage(error)}')),
             );
           }
         } else if (databasePlan.shouldShowPopup) {
@@ -805,7 +810,7 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
               }
               ScaffoldMessenger.maybeOf(
                 context,
-              )?.showSnackBar(SnackBar(content: Text('資料庫更新失敗：$error')));
+              )?.showSnackBar(SnackBar(content: Text('資料庫更新失敗：${friendlyErrorMessage(error)}')));
             }
           }
         } else if (databasePlan.shouldShowNotification) {
@@ -841,7 +846,7 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
                     }
                     ScaffoldMessenger.maybeOf(
                       context,
-                    )?.showSnackBar(SnackBar(content: Text('資料庫更新失敗：$error')));
+                    )?.showSnackBar(SnackBar(content: Text('資料庫更新失敗：${friendlyErrorMessage(error)}')));
                   }
                 },
               ),
@@ -857,7 +862,9 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
       if (mounted) {
         ScaffoldMessenger.maybeOf(
           context,
-        )?.showSnackBar(SnackBar(content: Text('檢查資料庫更新失敗：$error')));
+        )?.showSnackBar(
+          SnackBar(content: Text('檢查資料庫更新失敗：${friendlyErrorMessage(error)}')),
+        );
       }
     }
 

--- a/lib/core/app_controller.dart
+++ b/lib/core/app_controller.dart
@@ -22,6 +22,7 @@ import 'auth_token_store.dart';
 import 'background_image_store.dart';
 import 'bus_repository.dart';
 import 'desktop_discord_presence_service.dart';
+import 'friendly_error.dart';
 import 'haptic_feedback_service.dart';
 import 'ios_widget_integration.dart';
 import 'live_activity_service.dart';
@@ -1097,7 +1098,7 @@ class AppController extends ChangeNotifier {
       rethrow;
     } catch (error) {
       if (error is! AccountSyncConflictException) {
-        _accountSyncError = '$error';
+        _accountSyncError = friendlyErrorMessage(error);
       }
       rethrow;
     } finally {
@@ -1134,7 +1135,7 @@ class AppController extends ChangeNotifier {
       );
       _announcementsError = null;
     } catch (error) {
-      _announcementsError = '$error';
+      _announcementsError = friendlyErrorMessage(error);
     } finally {
       _announcementsLoading = false;
       notifyListeners();

--- a/lib/core/app_update_installer_io.dart
+++ b/lib/core/app_update_installer_io.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 import 'app_update_installer.dart';
+import 'friendly_error.dart';
 import 'http_error_utils.dart';
 import 'app_update_service.dart';
 
@@ -102,7 +103,7 @@ class IoAppUpdateInstaller extends AppUpdateInstaller {
     } catch (error) {
       return AppUpdateInstallResult(
         status: AppUpdateInstallStatus.failed,
-        message: '下載或安裝更新失敗：$error',
+        message: '下載或安裝更新失敗：${friendlyErrorMessage(error)}',
       );
     }
   }
@@ -279,7 +280,7 @@ class IoAppUpdateInstaller extends AppUpdateInstaller {
     } catch (error) {
       return AppUpdateInstallResult(
         status: AppUpdateInstallStatus.failed,
-        message: '下載或安裝更新失敗：$error',
+        message: '下載或安裝更新失敗：${friendlyErrorMessage(error)}',
       );
     }
   }

--- a/lib/core/app_update_service.dart
+++ b/lib/core/app_update_service.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 
 import 'api_user_agent.dart';
 import 'app_build_info.dart';
+import 'friendly_error.dart';
 import 'http_error_utils.dart';
 import 'models.dart';
 
@@ -162,7 +163,7 @@ class AppUpdateService {
     } catch (error) {
       return AppUpdateCheckResult(
         status: AppUpdateStatus.unavailable,
-        message: '檢查更新失敗：$error',
+        message: '檢查更新失敗：${friendlyErrorMessage(error)}',
       );
     }
   }

--- a/lib/core/friendly_error.dart
+++ b/lib/core/friendly_error.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'http_error_utils.dart';
+
+const genericFriendlyErrorMessage = '發生錯誤，請稍後再試。';
+const networkFriendlyErrorMessage = '網路連線異常，請確認網路後再試。';
+const timeoutFriendlyErrorMessage = '連線逾時，請稍後再試。';
+
+final _cjkPattern = RegExp(r'[぀-ヿ㐀-䶿一-鿿]');
+
+const _networkErrorMarkers = [
+  'SocketException',
+  'ClientException',
+  'HandshakeException',
+  'Failed host lookup',
+  'Connection refused',
+  'Connection reset',
+  'Connection closed',
+  'Connection terminated',
+  'Network is unreachable',
+  'XMLHttpRequest error',
+  'ERR_INTERNET_DISCONNECTED',
+  'ERR_NAME_NOT_RESOLVED',
+];
+
+const _exceptionPrefixes = [
+  'Exception: ',
+  'HttpException: ',
+  'FormatException: ',
+  'Bad state: ',
+];
+
+/// Converts a caught [error] into a message that is safe to show to users.
+///
+/// Messages that were already written for users (they contain CJK text, e.g.
+/// the ones thrown by the repository layer) pass through with their exception
+/// prefix stripped. Raw network / timeout exceptions are translated, and
+/// anything else falls back to [fallback] so English stack-dump text never
+/// reaches the UI.
+String friendlyErrorMessage(
+  Object? error, {
+  String fallback = genericFriendlyErrorMessage,
+}) {
+  if (error == null) {
+    return fallback;
+  }
+  final raw = error.toString().trim();
+  if (raw.isEmpty || raw.startsWith('Instance of ')) {
+    return fallback;
+  }
+  if (isRateLimitedError(error)) {
+    return rateLimitedErrorMessage;
+  }
+  if (error is TimeoutException ||
+      raw.contains('TimeoutException') ||
+      raw.contains('Connection timed out')) {
+    return timeoutFriendlyErrorMessage;
+  }
+  for (final marker in _networkErrorMarkers) {
+    if (raw.contains(marker)) {
+      return networkFriendlyErrorMessage;
+    }
+  }
+  final message = _stripExceptionPrefixes(raw);
+  if (_cjkPattern.hasMatch(message)) {
+    return message;
+  }
+  return fallback;
+}
+
+String _stripExceptionPrefixes(String message) {
+  var result = message.trim();
+  var stripped = true;
+  while (stripped) {
+    stripped = false;
+    for (final prefix in _exceptionPrefixes) {
+      if (result.startsWith(prefix)) {
+        result = result.substring(prefix.length).trim();
+        stripped = true;
+      }
+    }
+  }
+  return result;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'core/api_user_agent.dart';
 import 'core/auth_service.dart';
 import 'core/bus_repository.dart';
 import 'core/database_factory.dart';
+import 'core/friendly_error.dart';
 import 'core/storage_service.dart';
 import 'core/ad_service.dart';
 
@@ -46,16 +47,25 @@ Future<void> main(List<String> args) async {
     runApp(BusApp(controller: controller, analytics: analytics));
     unawaited(AnnouncementPushService.instance.initialize());
   } catch (error) {
-    runApp(_StartupErrorApp(error: '$error'));
+    runApp(
+      _StartupErrorApp(
+        message: friendlyErrorMessage(
+          error,
+          fallback: '啟動時發生未預期的錯誤，請稍後再試。',
+        ),
+        detail: '$error',
+      ),
+    );
   } finally {
     FlutterNativeSplash.remove();
   }
 }
 
 class _StartupErrorApp extends StatelessWidget {
-  const _StartupErrorApp({required this.error});
+  const _StartupErrorApp({required this.message, required this.detail});
 
-  final String error;
+  final String message;
+  final String detail;
 
   @override
   Widget build(BuildContext context) {
@@ -74,7 +84,15 @@ class _StartupErrorApp extends StatelessWidget {
                     style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
                   ),
                   const SizedBox(height: 12),
-                  Text(error, textAlign: TextAlign.center),
+                  Text(message, textAlign: TextAlign.center),
+                  if (detail != message) ...[
+                    const SizedBox(height: 16),
+                    Text(
+                      detail,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(fontSize: 12, color: Colors.grey),
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/lib/screens/account_screen.dart
+++ b/lib/screens/account_screen.dart
@@ -5,6 +5,7 @@ import '../app/bus_app.dart';
 import '../core/account_sync_models.dart';
 import '../core/app_controller.dart';
 import '../core/auth_service.dart';
+import '../core/friendly_error.dart';
 
 class AccountScreen extends StatefulWidget {
   const AccountScreen({super.key});
@@ -58,7 +59,9 @@ class _AccountScreenState extends State<AccountScreen> {
         );
         return;
       }
-      messenger.showSnackBar(SnackBar(content: Text('登入失敗：$error')));
+      messenger.showSnackBar(
+        SnackBar(content: Text('登入失敗：${friendlyErrorMessage(error)}')),
+      );
     }
   }
 
@@ -80,7 +83,9 @@ class _AccountScreenState extends State<AccountScreen> {
         );
         return;
       }
-      messenger.showSnackBar(SnackBar(content: Text('重新整理帳號失敗：$error')));
+      messenger.showSnackBar(
+        SnackBar(content: Text('重新整理帳號失敗：${friendlyErrorMessage(error)}')),
+      );
     }
   }
 
@@ -105,7 +110,9 @@ class _AccountScreenState extends State<AccountScreen> {
         );
         return;
       }
-      messenger.showSnackBar(SnackBar(content: Text('更新同步設定失敗：$error')));
+      messenger.showSnackBar(
+        SnackBar(content: Text('更新同步設定失敗：${friendlyErrorMessage(error)}')),
+      );
     }
   }
 
@@ -132,7 +139,9 @@ class _AccountScreenState extends State<AccountScreen> {
         );
         return;
       }
-      messenger.showSnackBar(SnackBar(content: Text('同步失敗：$error')));
+      messenger.showSnackBar(
+        SnackBar(content: Text('同步失敗：${friendlyErrorMessage(error)}')),
+      );
     }
   }
 
@@ -210,7 +219,9 @@ class _AccountScreenState extends State<AccountScreen> {
       if (!mounted) {
         return;
       }
-      messenger.showSnackBar(SnackBar(content: Text('處理同步衝突失敗：$error')));
+      messenger.showSnackBar(
+        SnackBar(content: Text('處理同步衝突失敗：${friendlyErrorMessage(error)}')),
+      );
     }
   }
 

--- a/lib/screens/database_settings_screen.dart
+++ b/lib/screens/database_settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../app/bus_app.dart';
 import '../core/app_controller.dart';
+import '../core/friendly_error.dart';
 import '../core/models.dart';
 
 class DatabaseSettingsScreen extends StatelessWidget {
@@ -35,7 +36,9 @@ class DatabaseSettingsScreen extends StatelessWidget {
       if (!context.mounted) {
         return;
       }
-      messenger.showSnackBar(SnackBar(content: Text('檢查資料庫更新失敗：$error')));
+      messenger.showSnackBar(
+        SnackBar(content: Text('檢查資料庫更新失敗：${friendlyErrorMessage(error)}')),
+      );
     }
   }
 
@@ -62,7 +65,9 @@ class DatabaseSettingsScreen extends StatelessWidget {
       if (!context.mounted) {
         return;
       }
-      messenger.showSnackBar(SnackBar(content: Text('下載資料庫失敗：$error')));
+      messenger.showSnackBar(
+        SnackBar(content: Text('下載資料庫失敗：${friendlyErrorMessage(error)}')),
+      );
     }
   }
 
@@ -454,7 +459,9 @@ class DatabaseSettingsScreen extends StatelessWidget {
                                       }
                                       messenger.showSnackBar(
                                         SnackBar(
-                                          content: Text('刪除資料庫失敗：$error'),
+                                          content: Text(
+                                            '刪除資料庫失敗：${friendlyErrorMessage(error)}',
+                                          ),
                                         ),
                                       );
                                     }

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -7,6 +7,7 @@ import '../core/app_controller.dart';
 import '../core/haptic_feedback_service.dart';
 import '../core/app_route_observer.dart';
 import '../core/bus_repository.dart';
+import '../core/friendly_error.dart';
 import '../core/models.dart';
 import '../widgets/eta_badge.dart';
 import 'favorite_groups_screen.dart';
@@ -443,7 +444,7 @@ class _FavoritesScreenState extends State<FavoritesScreen>
 
       setState(() {
         _isLoading = false;
-        _error = '$error';
+        _error = friendlyErrorMessage(error);
         _refreshingGroupName = null;
         _refreshingSignature = '';
         _statusMessage = _items.isEmpty ? '載入失敗' : '更新失敗，保留上一筆資料';

--- a/lib/screens/feedback_screen.dart
+++ b/lib/screens/feedback_screen.dart
@@ -5,6 +5,7 @@ import '../core/app_controller.dart';
 import '../core/app_routes.dart';
 import '../core/auth_token_store.dart';
 import '../core/feedback_service.dart';
+import '../core/friendly_error.dart';
 import '../widgets/background_image_wrapper.dart';
 
 class FeedbackScreen extends StatefulWidget {
@@ -237,11 +238,8 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
 
 String _friendlyError(Object error) {
   final raw = '$error';
-  if (raw.startsWith('Exception: ')) {
-    return raw.substring('Exception: '.length);
-  }
   if (raw.startsWith('Invalid argument')) {
     return '送出資料格式不正確。';
   }
-  return raw;
+  return friendlyErrorMessage(error, fallback: '意見回饋送出失敗，請稍後再試。');
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:geolocator/geolocator.dart';
 import '../app/bus_app.dart';
 import '../core/app_routes.dart';
 import '../core/app_controller.dart';
+import '../core/friendly_error.dart';
 import '../core/models.dart';
 import '../core/pwa_install_service.dart';
 import '../widgets/eta_badge.dart';
@@ -1184,7 +1185,7 @@ class _DesktopNearbyMapPanelState extends State<_DesktopNearbyMapPanel> {
       setState(() {
         _results = const [];
         _selectedPointId = null;
-        _error = '$error';
+        _error = friendlyErrorMessage(error);
       });
     } finally {
       if (mounted) {

--- a/lib/screens/legal_markdown_page.dart
+++ b/lib/screens/legal_markdown_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../core/friendly_error.dart';
 import '../widgets/markdown_content_view.dart';
 
 class LegalMarkdownPage extends StatefulWidget {
@@ -45,7 +46,7 @@ class _LegalMarkdownPageState extends State<LegalMarkdownPage> {
         return;
       }
       setState(() {
-        _error = '$error';
+        _error = friendlyErrorMessage(error);
       });
     } finally {
       if (mounted) {

--- a/lib/screens/metro_dashboard_screen.dart
+++ b/lib/screens/metro_dashboard_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../core/friendly_error.dart';
 import '../core/transit_repository.dart';
 import '../widgets/eta_badge.dart';
 import '../widgets/transit_drawer.dart';
@@ -79,7 +80,7 @@ class _MetroScreenState extends State<MetroScreen> {
       if (!mounted) {
         return;
       }
-      setState(() => _pageError = '$error');
+      setState(() => _pageError = friendlyErrorMessage(error));
     } finally {
       if (mounted) {
         setState(() => _loading = false);
@@ -133,7 +134,7 @@ class _MetroScreenState extends State<MetroScreen> {
       if (!mounted) {
         return;
       }
-      setState(() => _pageError = '$error');
+      setState(() => _pageError = friendlyErrorMessage(error));
     } finally {
       if (mounted) {
         setState(() => _loadingSystem = false);
@@ -183,7 +184,7 @@ class _MetroScreenState extends State<MetroScreen> {
       if (!mounted) {
         return;
       }
-      setState(() => _lineError = '$error');
+      setState(() => _lineError = friendlyErrorMessage(error));
     } finally {
       if (mounted) {
         setState(() => _loadingEta = false);

--- a/lib/screens/nearby_screen.dart
+++ b/lib/screens/nearby_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 
 import '../app/bus_app.dart';
+import '../core/friendly_error.dart';
 import '../core/models.dart';
 import 'adaptive_settings_presenter.dart';
 import '../widgets/background_image_wrapper.dart';
@@ -66,7 +67,7 @@ class _NearbyScreenState extends State<NearbyScreen> {
         return;
       }
       setState(() {
-        _error = '$error';
+        _error = friendlyErrorMessage(error);
       });
     } finally {
       if (mounted) {

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -5,6 +5,7 @@ import 'package:geolocator/geolocator.dart';
 import '../app/bus_app.dart';
 import '../core/app_controller.dart';
 import '../core/app_routes.dart';
+import '../core/friendly_error.dart';
 import '../core/models.dart';
 
 class OnboardingScreen extends StatefulWidget {
@@ -138,7 +139,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       }
     } catch (error) {
       setState(() {
-        _permissionMessage = '定位設定失敗（$error）。請改為手動選擇資料庫。';
+        _permissionMessage =
+            '定位設定失敗（${friendlyErrorMessage(error)}）。請改為手動選擇資料庫。';
       });
     } finally {
       if (mounted) {
@@ -557,7 +559,9 @@ class _DatabaseStep extends StatelessWidget {
                       }
                       final messenger = ScaffoldMessenger.of(context);
                       messenger.showSnackBar(
-                        SnackBar(content: Text('下載失敗：$error')),
+                        SnackBar(
+                          content: Text('下載失敗：${friendlyErrorMessage(error)}'),
+                        ),
                       );
                     }
                   },

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -18,6 +18,7 @@ import '../core/app_launch_service.dart';
 import '../core/app_route_observer.dart';
 import '../core/app_routes.dart';
 import '../core/bus_repository.dart';
+import '../core/friendly_error.dart';
 import '../core/desktop_discord_presence_service.dart';
 import '../core/live_activity_service.dart';
 import '../core/models.dart';
@@ -335,7 +336,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       }
       setState(() {
         _isLoading = false;
-        _error = '$error';
+        _error = friendlyErrorMessage(error);
         _statusMessage = previousDetail == null ? '讀取失敗' : '更新失敗，保留上一筆資料';
       });
       _startCountdown(controller.settings.busErrorUpdateTime);
@@ -5533,7 +5534,7 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
       if (!mounted) return;
       setState(() {
         _loading = false;
-        _error = e.toString();
+        _error = friendlyErrorMessage(e);
       });
     }
   }
@@ -6049,7 +6050,7 @@ class _StopScheduleSheetState extends State<_StopScheduleSheet> {
       if (!mounted) return;
       setState(() {
         _loading = false;
-        _error = e.toString();
+        _error = friendlyErrorMessage(e);
       });
     }
   }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -6,6 +6,7 @@ import 'package:geolocator/geolocator.dart';
 
 import '../app/bus_app.dart';
 import '../core/app_controller.dart';
+import '../core/friendly_error.dart';
 import '../core/haptic_feedback_service.dart';
 import '../core/models.dart';
 import '../core/route_search_ranking.dart';
@@ -475,7 +476,7 @@ class _SearchScreenState extends State<SearchScreen> {
         return;
       }
       setState(() {
-        _error = '$error';
+        _error = friendlyErrorMessage(error);
         _isResolvingStopDistances = false;
       });
       unawaited(

--- a/lib/screens/thsr_dashboard_screen.dart
+++ b/lib/screens/thsr_dashboard_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../core/friendly_error.dart';
 import '../core/transit_repository.dart';
 import '../widgets/transit_drawer.dart';
 import '../widgets/transit_station_map.dart';
@@ -91,7 +92,7 @@ class _ThsrScreenState extends State<ThsrScreen> {
       if (!mounted) {
         return;
       }
-      setState(() => _pageError = '$error');
+      setState(() => _pageError = friendlyErrorMessage(error));
     } finally {
       if (mounted) {
         setState(() => _loadingStations = false);
@@ -146,7 +147,7 @@ class _ThsrScreenState extends State<ThsrScreen> {
       setState(() {
         _selectedStation = activeStation;
         _seatInfos = const [];
-        _seatError = '$error';
+        _seatError = friendlyErrorMessage(error);
       });
     } finally {
       if (mounted) {
@@ -179,7 +180,7 @@ class _ThsrScreenState extends State<ThsrScreen> {
       if (!mounted) {
         return;
       }
-      setState(() => _queryError = '$error');
+      setState(() => _queryError = friendlyErrorMessage(error));
     } finally {
       if (mounted) {
         setState(() => _searching = false);

--- a/lib/screens/tra_screen.dart
+++ b/lib/screens/tra_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../core/friendly_error.dart';
 import '../core/transit_repository.dart';
 import '../widgets/transit_drawer.dart';
 import '../widgets/transit_station_map.dart';
@@ -87,7 +88,7 @@ class _TraScreenState extends State<TraScreen> {
       }
     } catch (error) {
       if (!mounted) return;
-      setState(() => _pageError = '$error');
+      setState(() => _pageError = friendlyErrorMessage(error));
     } finally {
       if (mounted) {
         setState(() => _loadingStations = false);
@@ -184,7 +185,7 @@ class _TraScreenState extends State<TraScreen> {
       setState(() => _results = results);
     } catch (error) {
       if (!mounted) return;
-      setState(() => _queryError = '$error');
+      setState(() => _queryError = friendlyErrorMessage(error));
     } finally {
       if (mounted) {
         setState(() => _searching = false);

--- a/lib/widgets/route_bus_map_sheet.dart
+++ b/lib/widgets/route_bus_map_sheet.dart
@@ -10,6 +10,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart' as gmaps;
 import 'package:latlong2/latlong.dart';
 
 import '../app/bus_app.dart';
+import '../core/friendly_error.dart';
 import '../core/models.dart';
 import 'eta_badge.dart';
 import 'platform_map_provider.dart';
@@ -448,7 +449,7 @@ class _RouteBusMapSheetState extends State<RouteBusMapSheet>
       }
       setState(() {
         _isRefreshing = false;
-        _error = '$error';
+        _error = friendlyErrorMessage(error);
       });
       _scheduleNextRefresh();
     }

--- a/test/friendly_error_test.dart
+++ b/test/friendly_error_test.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:taiwanbus_flutter/core/bus_repository.dart';
+import 'package:taiwanbus_flutter/core/friendly_error.dart';
+import 'package:taiwanbus_flutter/core/http_error_utils.dart';
+
+void main() {
+  group('friendlyErrorMessage', () {
+    test('keeps user-facing messages written in Chinese', () {
+      expect(
+        friendlyErrorMessage(DatabaseNotReadyException('尚未下載路線資料庫。')),
+        '尚未下載路線資料庫。',
+      );
+      expect(
+        friendlyErrorMessage(const HttpException('無法查詢全部路線 (500)。')),
+        '無法查詢全部路線 (500)。',
+      );
+    });
+
+    test('strips Exception prefixes from user-facing messages', () {
+      expect(
+        friendlyErrorMessage(Exception('資料庫版本格式錯誤。')),
+        '資料庫版本格式錯誤。',
+      );
+    });
+
+    test('translates rate-limit errors', () {
+      expect(
+        friendlyErrorMessage(const HttpException(rateLimitedErrorMessage)),
+        rateLimitedErrorMessage,
+      );
+      expect(
+        friendlyErrorMessage(Exception('429 Too Many Requests')),
+        rateLimitedErrorMessage,
+      );
+    });
+
+    test('translates network errors', () {
+      expect(
+        friendlyErrorMessage(
+          const SocketException('Failed host lookup: api.example.com'),
+        ),
+        networkFriendlyErrorMessage,
+      );
+      expect(
+        friendlyErrorMessage(Exception('XMLHttpRequest error.')),
+        networkFriendlyErrorMessage,
+      );
+    });
+
+    test('translates timeouts', () {
+      expect(
+        friendlyErrorMessage(TimeoutException('future not completed')),
+        timeoutFriendlyErrorMessage,
+      );
+    });
+
+    test('falls back for raw English exception text', () {
+      expect(
+        friendlyErrorMessage(
+          StateError('Null check operator used on a null value'),
+        ),
+        genericFriendlyErrorMessage,
+      );
+      expect(
+        friendlyErrorMessage(const FormatException('Unexpected character')),
+        genericFriendlyErrorMessage,
+      );
+    });
+
+    test('uses the provided fallback', () {
+      expect(
+        friendlyErrorMessage(StateError('boom'), fallback: '載入失敗，請稍後再試。'),
+        '載入失敗，請稍後再試。',
+      );
+    });
+
+    test('handles null and empty errors', () {
+      expect(friendlyErrorMessage(null), genericFriendlyErrorMessage);
+      expect(friendlyErrorMessage(''), genericFriendlyErrorMessage);
+    });
+  });
+}


### PR DESCRIPTION
把 catch 到的原始例外訊息（SocketException、429、Instance of …、英文 stack dump 等）一律經過 friendlyErrorMessage 過濾後再顯示，避免用戶看到看不懂
的錯誤內容。

- 新增 lib/core/friendly_error.dart：集中轉譯速率限制、網路、逾時例外， 並 strip Exception 前綴；只有含中文字元的訊息才直接顯示，其餘退回預設 友善訊息。
- 套用到所有 SnackBar 與頁面錯誤狀態顯示點（bus_app、各 dashboard、 account、database_settings、onboarding、favorites、home、nearby、 search、route_detail、route_bus_map_sheet、legal_markdown、 feedback、app_controller、app_update_*、main）。
- main.dart 啟動失敗頁改為顯示友善訊息 + 灰色原始詳情，方便回報但不再 直接把例外丟給用戶。
- 新增 test/friendly_error_test.dart 涵蓋各分支。