### PR TITLE
feat: 支援路線、站牌與乘車點多類型收藏

### DIFF
--- a/android/app/src/main/kotlin/tw/avianjay/taiwanbus/flutter/AppLaunchConstants.kt
+++ b/android/app/src/main/kotlin/tw/avianjay/taiwanbus/flutter/AppLaunchConstants.kt
@@ -5,24 +5,28 @@ import android.content.Intent
 
 object AppLaunchConstants {
     const val TARGET_ROUTE_DETAIL = "route_detail"
+    const val TARGET_STATION_DETAIL = "station_detail"
     const val TARGET_FAVORITES_GROUP = "favorites_group"
     const val TARGET_AUTH_CALLBACK = "auth_callback"
 
     private const val EXTRA_TARGET = "launch_target"
     private const val EXTRA_PROVIDER = "provider"
     private const val EXTRA_ROUTE_KEY = "route_key"
+    private const val EXTRA_ROUTE_ID = "route_id"
     private const val EXTRA_PATH_ID = "path_id"
     private const val EXTRA_STOP_ID = "stop_id"
     private const val EXTRA_DESTINATION_PATH_ID = "destination_path_id"
     private const val EXTRA_DESTINATION_STOP_ID = "destination_stop_id"
     private const val EXTRA_GROUP_NAME = "group_name"
+    private const val EXTRA_STATION_ID = "station_id"
 
     fun createRouteDetailIntent(
         context: Context,
         provider: String,
         routeKey: Int,
-        pathId: Int,
-        stopId: Int,
+        routeId: String? = null,
+        pathId: Int? = null,
+        stopId: Int? = null,
         destinationPathId: Int? = null,
         destinationStopId: Int? = null,
     ): Intent {
@@ -30,14 +34,29 @@ object AppLaunchConstants {
             putExtra(EXTRA_TARGET, TARGET_ROUTE_DETAIL)
             putExtra(EXTRA_PROVIDER, provider)
             putExtra(EXTRA_ROUTE_KEY, routeKey)
-            putExtra(EXTRA_PATH_ID, pathId)
-            putExtra(EXTRA_STOP_ID, stopId)
+            routeId?.takeIf { it.isNotBlank() }?.let { putExtra(EXTRA_ROUTE_ID, it) }
+            pathId?.let { putExtra(EXTRA_PATH_ID, it) }
+            stopId?.let { putExtra(EXTRA_STOP_ID, it) }
             if (destinationPathId != null) {
                 putExtra(EXTRA_DESTINATION_PATH_ID, destinationPathId)
             }
             if (destinationStopId != null) {
                 putExtra(EXTRA_DESTINATION_STOP_ID, destinationStopId)
             }
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        }
+    }
+
+    fun createStationDetailIntent(
+        context: Context,
+        provider: String,
+        stationId: String,
+    ): Intent {
+        return Intent(context, MainActivity::class.java).apply {
+            putExtra(EXTRA_TARGET, TARGET_STATION_DETAIL)
+            putExtra(EXTRA_PROVIDER, provider)
+            putExtra(EXTRA_STATION_ID, stationId)
             addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         }
@@ -75,9 +94,15 @@ object AppLaunchConstants {
                     "target" to TARGET_ROUTE_DETAIL,
                     "provider" to provider,
                     "routeKey" to routeKey,
-                    "pathId" to intent.getIntExtra(EXTRA_PATH_ID, 0),
-                    "stopId" to intent.getIntExtra(EXTRA_STOP_ID, 0),
                 )
+                intent.getStringExtra(EXTRA_ROUTE_ID)?.takeIf { it.isNotBlank() }
+                    ?.let { payload["routeId"] = it }
+                if (intent.hasExtra(EXTRA_PATH_ID)) {
+                    payload["pathId"] = intent.getIntExtra(EXTRA_PATH_ID, 0)
+                }
+                if (intent.hasExtra(EXTRA_STOP_ID)) {
+                    payload["stopId"] = intent.getIntExtra(EXTRA_STOP_ID, 0)
+                }
                 val destinationPathId = intent.getIntExtra(
                     EXTRA_DESTINATION_PATH_ID,
                     Int.MIN_VALUE,
@@ -93,6 +118,19 @@ object AppLaunchConstants {
                     payload["destinationStopId"] = destinationStopId
                 }
                 payload
+            }
+
+            TARGET_STATION_DETAIL -> {
+                val provider = intent.getStringExtra(EXTRA_PROVIDER) ?: return null
+                val stationId = intent.getStringExtra(EXTRA_STATION_ID)
+                    ?.trim()
+                    ?.takeIf { it.isNotEmpty() }
+                    ?: return null
+                mapOf(
+                    "target" to TARGET_STATION_DETAIL,
+                    "provider" to provider,
+                    "stationId" to stationId,
+                )
             }
 
             TARGET_FAVORITES_GROUP -> {

--- a/android/app/src/main/kotlin/tw/avianjay/taiwanbus/flutter/FavoriteGroupWidgetProvider.kt
+++ b/android/app/src/main/kotlin/tw/avianjay/taiwanbus/flutter/FavoriteGroupWidgetProvider.kt
@@ -261,23 +261,35 @@ object FavoriteGroupWidgetSupport {
         val views = buildBaseRemoteViews(context, appWidgetId, groupName)
         if (items.isEmpty()) {
             views.setViewVisibility(R.id.favorite_widget_empty, View.VISIBLE)
-            views.setTextViewText(R.id.favorite_widget_empty, "這個群組目前還沒有儲存站牌。")
+            views.setTextViewText(R.id.favorite_widget_empty, "這個群組目前還沒有收藏。")
             return WidgetRenderResult(views, updateTimestamp = true)
         }
 
+        val boardingItems = items.filter { it.type == "boarding" }
         val liveStopsByRoute = linkedMapOf<String, Map<String, WidgetLiveStop>>()
-        var successfulRouteFetches = 0
-        items.associateBy(::routeRequestKey).forEach { (requestKey, item) ->
+        var successfulFetches = 0
+        boardingItems.associateBy(::routeRequestKey).forEach { (requestKey, item) ->
             val fetchResult = fetchLiveStopMap(context, item)
             if (fetchResult.success) {
-                successfulRouteFetches += 1
+                successfulFetches += 1
             }
             liveStopsByRoute[requestKey] = fetchResult.liveStops
+        }
+        val stationArrivals = linkedMapOf<String, WidgetStationArrival?>()
+        items.filter { it.type == "station" }.forEach { item ->
+            val fetchResult = fetchStationArrival(item)
+            if (fetchResult.success) successfulFetches += 1
+            stationArrivals[stationRequestKey(item)] = fetchResult.arrival
         }
 
         views.removeAllViews(R.id.favorite_widget_items_container)
         items.take(MAX_WIDGET_ITEMS).forEach { item ->
-            val liveStop = liveStopsByRoute[routeRequestKey(item)]?.get("${item.pathId}:${item.stopId}")
+            val liveStop = if (item.type == "boarding") {
+                liveStopsByRoute[routeRequestKey(item)]?.get("${item.pathId}:${item.stopId}")
+            } else {
+                stationArrivals[stationRequestKey(item)]?.stop
+            }
+            val stationArrival = stationArrivals[stationRequestKey(item)]
             val itemViews = RemoteViews(context.packageName, R.layout.favorite_group_widget_item)
             itemViews.setTextViewText(
                 R.id.favorite_widget_item_eta,
@@ -285,26 +297,39 @@ object FavoriteGroupWidgetSupport {
             )
             itemViews.setTextViewText(
                 R.id.favorite_widget_item_route,
-                item.routeName.ifBlank { "路線 ${item.routeKey}" },
+                when (item.type) {
+                    "route" -> item.routeName.ifBlank { item.routeId ?: "路線" }
+                    "station" -> item.stationName.ifBlank { item.stationId }
+                    else -> item.routeName.ifBlank { "路線 ${item.routeKey}" }
+                },
             )
             itemViews.setTextViewText(
                 R.id.favorite_widget_item_stop,
-                item.stopName.ifBlank { "站牌 ${item.stopId}" },
+                when (item.type) {
+                    "route" -> item.routeDescription.orEmpty().ifBlank { item.provider.uppercase() }
+                    "station" -> stationArrival?.let { "${it.routeName} · ${it.sideLabel} 側" }
+                        ?: "目前沒有即將抵達班次"
+                    else -> item.stopName.ifBlank { "站牌 ${item.stopId}" }
+                },
             )
             itemViews.setTextViewText(
                 R.id.favorite_widget_item_note,
-                liveStop?.vehicleId ?: "",
+                when (item.type) {
+                    "route" -> "路線收藏"
+                    "station" -> liveStop?.vehicleId ?: "整站"
+                    else -> liveStop?.vehicleId ?: ""
+                },
             )
             itemViews.setOnClickPendingIntent(
                 R.id.favorite_widget_item_root,
-                createRoutePendingIntent(context, item),
+                createItemPendingIntent(context, item),
             )
             views.addView(R.id.favorite_widget_items_container, itemViews)
         }
 
         return WidgetRenderResult(
             views = views,
-            updateTimestamp = successfulRouteFetches > 0,
+            updateTimestamp = successfulFetches > 0,
         )
     }
 
@@ -365,28 +390,33 @@ object FavoriteGroupWidgetSupport {
         )
     }
 
-    private fun createRoutePendingIntent(
+    private fun createItemPendingIntent(
         context: Context,
         item: FavoriteWidgetItem,
     ): PendingIntent {
-        val requestCode = (item.routeKey * 31) + item.stopId
-        val intent = AppLaunchConstants.createRouteDetailIntent(
-            context = context,
-            provider = item.provider,
-            routeKey = item.routeKey,
-            pathId = item.pathId,
-            stopId = item.stopId,
-            destinationPathId = item.destinationPathId,
-            destinationStopId = item.destinationStopId,
-        ).apply {
-            data = Uri.parse(
-                "yabus://route/${item.provider}/${item.routeKey}/${item.pathId}/${item.stopId}",
-            ).buildUpon()
-                .apply {
-                    item.destinationPathId?.let { appendQueryParameter("destinationPathId", it.toString()) }
-                    item.destinationStopId?.let { appendQueryParameter("destinationStopId", it.toString()) }
-                }
-                .build()
+        val requestCode = item.identity.hashCode()
+        val intent = when (item.type) {
+            "station" -> AppLaunchConstants.createStationDetailIntent(
+                context = context,
+                provider = item.provider,
+                stationId = item.stationId,
+            ).apply {
+                data = Uri.parse("yabus://station/${item.provider}/${Uri.encode(item.stationId)}")
+            }
+            else -> AppLaunchConstants.createRouteDetailIntent(
+                context = context,
+                provider = item.provider,
+                routeKey = item.routeKey,
+                routeId = item.routeId,
+                pathId = item.pathId.takeIf { item.type == "boarding" },
+                stopId = item.stopId.takeIf { item.type == "boarding" },
+                destinationPathId = item.destinationPathId,
+                destinationStopId = item.destinationStopId,
+            ).apply {
+                data = Uri.parse(
+                    "yabus://route/${item.provider}/${item.routeKey}/${Uri.encode(item.routeId.orEmpty())}",
+                )
+            }
         }
         return PendingIntent.getActivity(
             context,
@@ -417,9 +447,18 @@ object FavoriteGroupWidgetSupport {
             val groupArray = root.optJSONArray(groupName) ?: JSONArray()
             for (index in 0 until groupArray.length()) {
                 val item = groupArray.optJSONObject(index) ?: continue
+                val type = item.optString("type", "boarding").trim().ifEmpty { "boarding" }
                 val routeKey = item.optInt("routeKey", 0)
                 val stopId = item.optInt("stopId", 0)
-                if (routeKey <= 0 || stopId <= 0) {
+                val routeId = item.optString("routeId", "").trim().takeIf { it.isNotEmpty() }
+                val stationId = item.optString("stationId", "").trim()
+                val valid = when (type) {
+                    "route" -> routeKey > 0 && routeId != null
+                    "station" -> stationId.isNotEmpty()
+                    "boarding" -> routeKey > 0 && stopId > 0
+                    else -> false
+                }
+                if (!valid) {
                     continue
                 }
                 val destinationStopId = item.optInt("destinationStopId", 0)
@@ -430,15 +469,19 @@ object FavoriteGroupWidgetSupport {
                     item.optInt("destinationPathId", item.optInt("pathId", 0))
                 }
                 groupItems += FavoriteWidgetItem(
+                    type = type,
                     provider = item.optString("provider", "twn"),
                     routeKey = routeKey,
                     pathId = item.optInt("pathId", 0),
                     stopId = stopId,
-                    routeId = item.optString("routeId", "")
+                    routeId = routeId,
+                    routeName = item.optString("routeName", ""),
+                    routeDescription = item.optString("routeDescription", "")
                         .trim()
                         .takeIf { it.isNotEmpty() },
-                    routeName = item.optString("routeName", ""),
                     stopName = item.optString("stopName", ""),
+                    stationId = stationId,
+                    stationName = item.optString("stationName", ""),
                     destinationPathId = destinationPathId,
                     destinationStopId = destinationStopId,
                     destinationStopName = item.optString("destinationStopName", "")
@@ -449,6 +492,65 @@ object FavoriteGroupWidgetSupport {
             result[groupName] = groupItems
         }
         return result
+    }
+
+    private fun fetchStationArrival(item: FavoriteWidgetItem): WidgetStationFetchResult {
+        if (item.stationId.isBlank() || item.provider.isBlank()) {
+            return WidgetStationFetchResult(success = false, arrival = null)
+        }
+        var connection: HttpURLConnection? = null
+        return try {
+            val encodedStationId = URLEncoder.encode(item.stationId, Charsets.UTF_8.name())
+            val encodedCity = URLEncoder.encode(item.provider.uppercase(), Charsets.UTF_8.name())
+            connection = URL(
+                "$API_BASE_URL/api/v1/stations/$encodedStationId/passby?city=$encodedCity",
+            ).openConnection() as HttpURLConnection
+            connection.connectTimeout = 10_000
+            connection.readTimeout = 10_000
+            connection.requestMethod = "GET"
+            connection.setRequestProperty("Accept", "application/json")
+            connection.setRequestProperty("User-Agent", NativeApiUserAgent.value())
+            connection.doInput = true
+            connection.useCaches = false
+            if (connection.responseCode !in 200..299) {
+                return WidgetStationFetchResult(success = false, arrival = null)
+            }
+            val root = JSONObject(
+                connection.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() },
+            )
+            val sides = root.optJSONArray("sides") ?: JSONArray()
+            var bestEta: Int? = null
+            var best: WidgetStationArrival? = null
+            for (sideIndex in 0 until sides.length()) {
+                val side = sides.optJSONObject(sideIndex) ?: continue
+                val sideLabel = side.optString("label", "?").trim().ifEmpty { "?" }
+                val routes = side.optJSONArray("routes") ?: continue
+                for (routeIndex in 0 until routes.length()) {
+                    val route = routes.optJSONObject(routeIndex) ?: continue
+                    val eta = toIntOrNull(route.opt("eta")) ?: continue
+                    if (eta < 0 || (bestEta != null && eta >= bestEta)) continue
+                    val message = route.optString("message", "")
+                        .trim()
+                        .takeIf { it.isNotEmpty() }
+                    bestEta = eta
+                    best = WidgetStationArrival(
+                        routeName = route.optString("route_name", "路線").trim()
+                            .ifEmpty { "路線" },
+                        sideLabel = sideLabel,
+                        stop = WidgetLiveStop(
+                            sec = eta,
+                            msg = message,
+                            vehicleId = firstVehicleId(route.optJSONArray("buses")),
+                        ),
+                    )
+                }
+            }
+            WidgetStationFetchResult(success = true, arrival = best)
+        } catch (_: Exception) {
+            WidgetStationFetchResult(success = false, arrival = null)
+        } finally {
+            connection?.disconnect()
+        }
     }
 
     private fun fetchLiveStopMap(
@@ -664,8 +766,12 @@ object FavoriteGroupWidgetSupport {
     }
 
     private fun routeRequestKey(item: FavoriteWidgetItem): String {
-        return item.routeId?.takeIf { it.isNotBlank() }
+        return item.routeId?.takeIf { it.isNotBlank() }?.let { "${item.provider}:$it" }
             ?: "${item.provider}:${item.routeKey}"
+    }
+
+    private fun stationRequestKey(item: FavoriteWidgetItem): String {
+        return "${item.provider}:${item.stationId}"
     }
 
     private fun saveLastUpdated(context: Context, appWidgetId: Int, timestamp: Long) {
@@ -697,16 +803,38 @@ object FavoriteGroupWidgetSupport {
 }
 
 data class FavoriteWidgetItem(
+    val type: String,
     val provider: String,
     val routeKey: Int,
     val pathId: Int,
     val stopId: Int,
     val routeId: String?,
     val routeName: String,
+    val routeDescription: String?,
     val stopName: String,
+    val stationId: String,
+    val stationName: String,
     val destinationPathId: Int?,
     val destinationStopId: Int?,
     val destinationStopName: String?,
+) {
+    val identity: String
+        get() = when (type) {
+            "route" -> "route:$provider:${routeId.orEmpty()}"
+            "station" -> "station:$provider:$stationId"
+            else -> "boarding:$provider:$routeKey:$pathId:$stopId"
+        }
+}
+
+data class WidgetStationArrival(
+    val routeName: String,
+    val sideLabel: String,
+    val stop: WidgetLiveStop,
+)
+
+data class WidgetStationFetchResult(
+    val success: Boolean,
+    val arrival: WidgetStationArrival?,
 )
 
 data class WidgetLiveStop(

--- a/android/app/src/main/kotlin/tw/avianjay/taiwanbus/flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/tw/avianjay/taiwanbus/flutter/MainActivity.kt
@@ -73,8 +73,8 @@ class MainActivity : FlutterActivity() {
             HOME_INTEGRATION_CHANNEL,
         ).setMethodCallHandler { call, result ->
             when (call.method) {
-                "pinStopShortcut" -> {
-                    result.success(requestPinnedStopShortcut(call))
+                "pinFavoriteShortcut", "pinStopShortcut" -> {
+                    result.success(requestPinnedFavoriteShortcut(call))
                 }
 
                 "refreshFavoriteWidgets" -> {
@@ -296,37 +296,75 @@ class MainActivity : FlutterActivity() {
         result.success(null)
     }
 
-    private fun requestPinnedStopShortcut(call: MethodCall): Boolean {
+    private fun requestPinnedFavoriteShortcut(call: MethodCall): Boolean {
+        val type = call.argument<String>("type")?.trim().orEmpty().ifBlank { "boarding" }
         val provider = call.argument<String>("provider")?.trim().orEmpty()
-        val routeKey = call.argument<Int>("routeKey")
-        val pathId = call.argument<Int>("pathId")
-        val stopId = call.argument<Int>("stopId")
-        if (provider.isEmpty() || routeKey == null || pathId == null || stopId == null) {
+        if (provider.isEmpty()) {
             return false
         }
 
+        val routeKey = call.argument<Int>("routeKey")
+        val routeId = call.argument<String>("routeId")?.trim().orEmpty()
+        val pathId = call.argument<Int>("pathId")
+        val stopId = call.argument<Int>("stopId")
         val routeName = call.argument<String>("routeName")?.trim().orEmpty()
         val stopName = call.argument<String>("stopName")?.trim().orEmpty()
-        val shortcutId = "stop_${provider}_${routeKey}_${pathId}_${stopId}"
-        val shortLabel = when {
-            stopName.isNotBlank() -> stopName
-            routeName.isNotBlank() -> routeName
-            else -> "YABus"
-        }
-        val longLabel = buildString {
-            append(if (routeName.isNotBlank()) routeName else "Route $routeKey")
-            if (stopName.isNotBlank()) {
-                append(" - ")
-                append(stopName)
+        val stationId = call.argument<String>("stationId")?.trim().orEmpty()
+        val stationName = call.argument<String>("stationName")?.trim().orEmpty()
+        val shortcutId: String
+        val shortLabel: String
+        val longLabel: String
+        val intent: Intent
+        when (type) {
+            "route" -> {
+                if (routeKey == null || routeId.isEmpty()) return false
+                shortcutId = "route_${provider}_${routeId}"
+                shortLabel = routeName.ifBlank { routeId }
+                longLabel = "${shortLabel} 路線"
+                intent = AppLaunchConstants.createRouteDetailIntent(
+                    context = this,
+                    provider = provider,
+                    routeKey = routeKey,
+                    routeId = routeId,
+                )
+            }
+            "station" -> {
+                if (stationId.isEmpty()) return false
+                shortcutId = "station_${provider}_${stationId}"
+                shortLabel = stationName.ifBlank { stationId }
+                longLabel = "${shortLabel} 站牌"
+                intent = AppLaunchConstants.createStationDetailIntent(
+                    context = this,
+                    provider = provider,
+                    stationId = stationId,
+                )
+            }
+            else -> {
+                if (routeKey == null || pathId == null || stopId == null) return false
+                shortcutId = "boarding_${provider}_${routeKey}_${pathId}_${stopId}"
+                shortLabel = when {
+                    stopName.isNotBlank() -> stopName
+                    routeName.isNotBlank() -> routeName
+                    else -> "YABus"
+                }
+                longLabel = buildString {
+                    append(if (routeName.isNotBlank()) routeName else "Route $routeKey")
+                    if (stopName.isNotBlank()) {
+                        append(" - ")
+                        append(stopName)
+                    }
+                }
+                intent = AppLaunchConstants.createRouteDetailIntent(
+                    context = this,
+                    provider = provider,
+                    routeKey = routeKey,
+                    routeId = routeId.takeIf { it.isNotEmpty() },
+                    pathId = pathId,
+                    stopId = stopId,
+                )
             }
         }
-        val intent = AppLaunchConstants.createRouteDetailIntent(
-            context = this,
-            provider = provider,
-            routeKey = routeKey,
-            pathId = pathId,
-            stopId = stopId,
-        ).apply {
+        intent.apply {
             action = Intent.ACTION_VIEW
         }
         val shortcut = ShortcutInfoCompat.Builder(this, shortcutId)

--- a/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/complication/NextBusComplicationService.kt
+++ b/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/complication/NextBusComplicationService.kt
@@ -39,7 +39,7 @@ class NextBusComplicationService : SuspendingComplicationDataSourceService() {
 
     override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData? {
         val snapshot = TileSnapshotBuilder.read(this)
-        val (primary, secondary, longText, minutes, routeId, provider) = pickFromSnapshot(snapshot)
+        val slots = pickFromSnapshot(snapshot)
             ?: return getPreviewData(request.complicationType)
                 ?.let { fallback ->
                     when (fallback) {
@@ -54,13 +54,13 @@ class NextBusComplicationService : SuspendingComplicationDataSourceService() {
                     }
                 }
 
-        val tapIntent = buildTapPendingIntent(routeId, provider)
+        val tapIntent = buildTapPendingIntent(slots.routeId, slots.stationId, slots.provider)
         return buildData(
             type = request.complicationType,
-            primaryText = primary,
-            secondaryText = secondary,
-            longText = longText,
-            rangedValueMinutes = minutes,
+            primaryText = slots.primary,
+            secondaryText = slots.secondary,
+            longText = slots.longText,
+            rangedValueMinutes = slots.minutes,
             tapIntent = tapIntent,
         )
     }
@@ -71,6 +71,7 @@ class NextBusComplicationService : SuspendingComplicationDataSourceService() {
         val longText: String,
         val minutes: Float,
         val routeId: String?,
+        val stationId: String?,
         val provider: String?,
     )
 
@@ -93,6 +94,7 @@ class NextBusComplicationService : SuspendingComplicationDataSourceService() {
             longText = "${routeName.ifBlank { routeId }} · $stop",
             minutes = minutes,
             routeId = routeId.takeIf { it.isNotBlank() },
+            stationId = null,
             provider = provider.takeIf { it.isNotBlank() },
         )
     }
@@ -106,6 +108,7 @@ class NextBusComplicationService : SuspendingComplicationDataSourceService() {
             longText = "$routeName · $stopName",
             minutes = minutes,
             routeId = routeId.takeIf { it.isNotBlank() },
+            stationId = stationId.takeIf { it.isNotBlank() },
             provider = provider.takeIf { it.isNotBlank() },
         )
     }
@@ -162,9 +165,12 @@ class NextBusComplicationService : SuspendingComplicationDataSourceService() {
 
     private fun buildTapPendingIntent(
         routeId: String?,
+        stationId: String?,
         provider: String?,
     ): PendingIntent {
-        val uri = if (routeId.isNullOrBlank()) {
+        val uri = if (!stationId.isNullOrBlank()) {
+            Uri.parse("yabus-wear://station/$stationId?provider=${provider.orEmpty()}")
+        } else if (routeId.isNullOrBlank()) {
             Uri.parse("yabus-wear://search")
         } else {
             Uri.parse("yabus-wear://route/$routeId?provider=${provider.orEmpty()}")

--- a/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/data/BusApiService.kt
+++ b/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/data/BusApiService.kt
@@ -39,8 +39,13 @@ object BusApiService {
     ): List<BusArrival> =
         withContext(Dispatchers.IO) {
             ensureSecurityProvider(context)
-            val routableFavorites = favorites.filter { it.realtimeRouteId != null }
-            if (routableFavorites.isEmpty()) {
+            val routableFavorites = favorites.filter {
+                it.type == "boarding" && it.realtimeRouteId != null
+            }
+            val stationFavorites = favorites.filter {
+                it.type == "station" && !it.stationId.isNullOrBlank()
+            }
+            if (routableFavorites.isEmpty() && stationFavorites.isEmpty()) {
                 return@withContext emptyList()
             }
 
@@ -62,7 +67,7 @@ object BusApiService {
                 }
             }
 
-            return@withContext routableFavorites.map { favorite ->
+            val boardingArrivals = routableFavorites.map { favorite ->
                 val route = favorite.realtimeRouteId?.let(routes::get)
                 val stop = route
                     ?.paths()
@@ -85,7 +90,61 @@ object BusApiService {
                     updatedAtMs = requestedAtMs,
                 )
             }
+            val stationArrivals = stationFavorites.map { favorite ->
+                runCatching {
+                    fetchStationArrival(favorite, requestedAtMs)
+                }.getOrElse {
+                    BusArrival(
+                        favoriteId = favorite.id,
+                        etaText = "No data",
+                        statusText = "Realtime unavailable",
+                        updatedAtMs = requestedAtMs,
+                    )
+                }
+            }
+            return@withContext boardingArrivals + stationArrivals
         }
+
+    private fun fetchStationArrival(
+        favorite: FavoriteStop,
+        requestedAtMs: Long,
+    ): BusArrival {
+        val stationId = favorite.stationId?.trim().orEmpty()
+        val payload = requestJson(
+            "${BuildConfig.WEAR_API_BASE_URL}/api/v1/stations/${encodePathSegment(stationId)}/passby" +
+                "?city=${encodeQueryValue(favorite.provider.uppercase())}",
+        ).jsonObject
+        var bestRoute: JsonObject? = null
+        var bestSideLabel = "?"
+        var bestEta: Int? = null
+        val sides = (payload["sides"] as? JsonArray).orEmpty()
+        for (sideElement in sides) {
+            val side = sideElement as? JsonObject ?: continue
+            val sideLabel = side.string("label").ifBlank { "?" }
+            val sideRoutes = (side["routes"] as? JsonArray).orEmpty()
+            for (routeElement in sideRoutes) {
+                val route = routeElement as? JsonObject ?: continue
+                val eta = route.int("eta") ?: continue
+                if (eta < 0 || (bestEta != null && eta >= bestEta)) continue
+                bestEta = eta
+                bestRoute = route
+                bestSideLabel = sideLabel
+            }
+        }
+        val route = bestRoute ?: return BusArrival(
+            favoriteId = favorite.id,
+            etaText = "--",
+            statusText = "目前沒有即將抵達班次",
+            updatedAtMs = requestedAtMs,
+        )
+        return route.toArrival(
+            favoriteId = favorite.id,
+            requestedAtMs = requestedAtMs,
+            fallbackStatus = favorite.provider,
+        ).copy(
+            statusText = "${route.string("route_name").ifBlank { "路線" }} · $bestSideLabel 側",
+        )
+    }
 
     suspend fun searchRoutes(
         context: Context?,
@@ -229,6 +288,54 @@ object BusApiService {
             routeName = routeName,
             provider = provider,
             paths = paths,
+        )
+    }
+
+    suspend fun fetchStationDetail(
+        context: Context?,
+        stationId: String,
+        provider: String,
+    ): WearStationDetail = withContext(Dispatchers.IO) {
+        ensureSecurityProvider(context)
+        val payload = requestJson(
+            "${BuildConfig.WEAR_API_BASE_URL}/api/v1/stations/${encodePathSegment(stationId)}/passby" +
+                "?city=${encodeQueryValue(provider.uppercase())}",
+        ).jsonObject
+        val sides = (payload["sides"] as? JsonArray).orEmpty().mapNotNull sideLoop@ { sideElement ->
+            val side = sideElement as? JsonObject ?: return@sideLoop null
+            val routes = (side["routes"] as? JsonArray).orEmpty().mapNotNull routeLoop@ { routeElement ->
+                val route = routeElement as? JsonObject ?: return@routeLoop null
+                val routeId = route.string("routeid")
+                if (routeId.isBlank()) return@routeLoop null
+                val etaSeconds = route.int("eta")
+                val message = route.string("message")
+                WearStationRoute(
+                    routeId = routeId,
+                    routeName = route.string("route_name").ifBlank { routeId },
+                    pathId = route.int("pathid") ?: 0,
+                    etaText = when {
+                        message.isNotBlank() -> message
+                        etaSeconds == null -> "--"
+                        etaSeconds <= 0 -> "即將到站"
+                        etaSeconds < 60 -> "${etaSeconds}秒"
+                        else -> "${etaSeconds / 60}分"
+                    },
+                    etaSeconds = etaSeconds,
+                    statusText = route.string("path_name"),
+                )
+            }
+            WearStationSide(
+                sideId = side.string("side_id"),
+                label = side.string("label").ifBlank { "?" },
+                direction = side.string("direction"),
+                routes = routes,
+            )
+        }
+        WearStationDetail(
+            stationId = payload.string("station_id").ifBlank { stationId },
+            stationName = payload.string("station_name").ifBlank { stationId },
+            provider = provider,
+            sides = sides,
         )
     }
 

--- a/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/data/WearDataRepository.kt
+++ b/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/data/WearDataRepository.kt
@@ -299,6 +299,14 @@ object WearDataRepository {
         return BusApiService.fetchRouteDetail(context, routeId, provider)
     }
 
+    suspend fun fetchStationDetail(
+        context: Context,
+        stationId: String,
+        provider: String,
+    ): WearStationDetail {
+        return BusApiService.fetchStationDetail(context, stationId, provider)
+    }
+
     private fun preferences(context: Context) =
         context.applicationContext.getSharedPreferences(
             preferencesName,
@@ -316,10 +324,13 @@ object WearDataRepository {
     }
 
     private fun persistTileSnapshot(context: Context, nextState: WearHomeState) {
-        val cards = nextState.favorites.map { favorite ->
+        val cards = nextState.favorites
+            .filter { favorite -> favorite.type != "route" }
+            .map { favorite ->
             val arrival = nextState.arrivalFor(favorite.id)
             WearArrivalCard(
                 favoriteId = favorite.id,
+                type = favorite.type,
                 routeName = favorite.displayRouteName,
                 stopName = favorite.displayStopName,
                 etaText = arrival?.etaText ?: "--",
@@ -329,6 +340,7 @@ object WearDataRepository {
                 statusText = arrival?.statusText
                     ?: favorite.groupName.ifBlank { favorite.provider },
                 routeId = favorite.realtimeRouteId.orEmpty(),
+                stationId = favorite.stationId.orEmpty(),
                 provider = favorite.provider,
                 pathId = favorite.pathId,
                 stopId = favorite.stopId,

--- a/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/data/WearModels.kt
+++ b/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/data/WearModels.kt
@@ -12,6 +12,7 @@ data class WearSettings(
 @Serializable
 data class FavoriteStop(
     val id: String,
+    val type: String = "boarding",
     val groupName: String = "",
     val provider: String = "",
     val routeKey: Int = 0,
@@ -19,19 +20,37 @@ data class FavoriteStop(
     val stopId: Int = 0,
     val routeId: String? = null,
     val routeName: String? = null,
+    val routeDescription: String? = null,
     val stopName: String? = null,
+    val stationId: String? = null,
+    val stationName: String? = null,
     val destinationPathId: Int? = null,
     val destinationStopId: Int? = null,
     val destinationStopName: String? = null,
 ) {
     val displayRouteName: String
-        get() = routeName?.takeIf { it.isNotBlank() } ?: routeKey.toString()
+        get() = when (type) {
+            "station" -> stationName?.takeIf { it.isNotBlank() }
+                ?: stationId?.takeIf { it.isNotBlank() }
+                ?: "站牌"
+            else -> routeName?.takeIf { it.isNotBlank() }
+                ?: routeId?.takeIf { it.isNotBlank() }
+                ?: routeKey.toString()
+        }
 
     val displayStopName: String
-        get() = stopName?.takeIf { it.isNotBlank() } ?: "Stop $stopId"
+        get() = when (type) {
+            "route" -> routeDescription?.takeIf { it.isNotBlank() } ?: provider.uppercase()
+            "station" -> "整站所有路線"
+            else -> stopName?.takeIf { it.isNotBlank() } ?: "Stop $stopId"
+        }
 
     val realtimeRouteId: String?
-        get() = routeId?.trim()?.takeIf { it.isNotEmpty() }
+        get() = if (type == "boarding") {
+            routeId?.trim()?.takeIf { it.isNotEmpty() }
+        } else {
+            null
+        }
 }
 
 @Serializable
@@ -98,6 +117,32 @@ data class WearRouteStop(
     val statusText: String,
 )
 
+@Serializable
+data class WearStationDetail(
+    val stationId: String,
+    val stationName: String,
+    val provider: String,
+    val sides: List<WearStationSide> = emptyList(),
+)
+
+@Serializable
+data class WearStationSide(
+    val sideId: String,
+    val label: String,
+    val direction: String = "",
+    val routes: List<WearStationRoute> = emptyList(),
+)
+
+@Serializable
+data class WearStationRoute(
+    val routeId: String,
+    val routeName: String,
+    val pathId: Int = 0,
+    val etaText: String = "--",
+    val etaSeconds: Int? = null,
+    val statusText: String = "",
+)
+
 /**
  * Smart route suggestion pushed from the phone. The watch may also synthesize
  * a fallback suggestion locally when [WearSmartRouteService] is used.
@@ -157,12 +202,14 @@ data class WearTileSnapshot(
 @Serializable
 data class WearArrivalCard(
     val favoriteId: String,
+    val type: String = "boarding",
     val routeName: String,
     val stopName: String,
     val etaText: String,
     val etaSeconds: Int? = null,
     val statusText: String = "",
     val routeId: String = "",
+    val stationId: String = "",
     val provider: String = "",
     val pathId: Int = 0,
     val stopId: Int = 0,

--- a/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/presentation/MainActivity.kt
+++ b/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/presentation/MainActivity.kt
@@ -72,6 +72,8 @@ import tw.avianjay.taiwanbus.wearos.data.WearRefreshScheduler
 import tw.avianjay.taiwanbus.wearos.data.WearRouteDetail
 import tw.avianjay.taiwanbus.wearos.data.WearRoutePath
 import tw.avianjay.taiwanbus.wearos.data.WearRouteStop
+import tw.avianjay.taiwanbus.wearos.data.WearStationDetail
+import tw.avianjay.taiwanbus.wearos.data.WearStationRoute
 import tw.avianjay.taiwanbus.wearos.data.WearSmartSuggestionPayload
 import tw.avianjay.taiwanbus.wearos.presentation.theme.AndroidTheme
 import java.text.SimpleDateFormat
@@ -124,6 +126,7 @@ internal enum class WearScreen {
     Favorites,
     Search,
     RouteDetail,
+    StationDetail,
     Nearby,
 }
 
@@ -132,6 +135,11 @@ internal sealed class DeepLinkTarget {
         val routeId: String,
         val routeName: String,
         val description: String,
+        val provider: String,
+    ) : DeepLinkTarget()
+    data class Station(
+        val stationId: String,
+        val stationName: String,
         val provider: String,
     ) : DeepLinkTarget()
     object Search : DeepLinkTarget()
@@ -148,6 +156,14 @@ internal sealed class DeepLinkTarget {
                     val description = uri.getQueryParameter("description").orEmpty()
                     val provider = uri.getQueryParameter("provider").orEmpty()
                     if (routeId.isEmpty()) null else Route(routeId, routeName, description, provider)
+                }
+
+                "station" -> {
+                    val stationId = uri.lastPathSegment.orEmpty()
+                    val stationName = uri.getQueryParameter("stationName").orEmpty()
+                        .ifBlank { stationId }
+                    val provider = uri.getQueryParameter("provider").orEmpty()
+                    if (stationId.isEmpty()) null else Station(stationId, stationName, provider)
                 }
 
                 "search" -> Search
@@ -178,6 +194,11 @@ private fun WearApp(
     var routeDetailLoading by remember { mutableStateOf(false) }
     var routeDetailError by remember { mutableStateOf<String?>(null) }
     var activePathIndex by remember { mutableStateOf(0) }
+    var selectedStation by remember { mutableStateOf<FavoriteStop?>(null) }
+    var stationDetail by remember { mutableStateOf<WearStationDetail?>(null) }
+    var stationDetailLoading by remember { mutableStateOf(false) }
+    var stationDetailError by remember { mutableStateOf<String?>(null) }
+    var stationDetailRefreshTrigger by remember { mutableStateOf(0) }
 
     var nearbyStops by remember { mutableStateOf<List<WearNearbyStop>>(emptyList()) }
     var nearbyLoading by remember { mutableStateOf(false) }
@@ -235,6 +256,17 @@ private fun WearApp(
                     provider = target.provider,
                 )
                 screen = WearScreen.RouteDetail
+            }
+
+            is DeepLinkTarget.Station -> {
+                selectedStation = FavoriteStop(
+                    id = "station:${target.provider}:${target.stationId}",
+                    type = "station",
+                    provider = target.provider,
+                    stationId = target.stationId,
+                    stationName = target.stationName,
+                )
+                screen = WearScreen.StationDetail
             }
         }
         onConsumeDeepLink()
@@ -317,6 +349,29 @@ private fun WearApp(
         }
     }
 
+    LaunchedEffect(selectedStation, stationDetailRefreshTrigger) {
+        val station = selectedStation
+        val stationId = station?.stationId
+        if (station == null || stationId.isNullOrBlank()) {
+            stationDetail = null
+            stationDetailLoading = false
+            stationDetailError = null
+            return@LaunchedEffect
+        }
+        stationDetailLoading = true
+        stationDetailError = null
+        runCatching {
+            WearDataRepository.fetchStationDetail(context, stationId, station.provider)
+        }.onSuccess { detail ->
+            stationDetail = detail
+            stationDetailLoading = false
+        }.onFailure { error ->
+            stationDetail = null
+            stationDetailLoading = false
+            stationDetailError = error.message ?: "載入站牌資料失敗"
+        }
+    }
+
     AppScaffold {
         val listState = rememberTransformingLazyColumnState()
         val transformationSpec = rememberTransformationSpec()
@@ -325,13 +380,15 @@ private fun WearApp(
         val focusManager = LocalFocusManager.current
 
         // 返回鍵處理：搜尋/附近畫面時返回我的最愛
-        if (screen == WearScreen.Search || screen == WearScreen.Nearby) {
+        if (screen != WearScreen.Favorites) {
             BackHandler {
                 keyboardController?.hide()
                 focusManager.clearFocus()
                 screen = WearScreen.Favorites
                 query = ""
                 searchResults = emptyList()
+                selectedRoute = null
+                selectedStation = null
             }
         }
 
@@ -344,6 +401,10 @@ private fun WearApp(
                             WearScreen.RouteDetail -> {
                                 screen = WearScreen.Search
                                 selectedRoute = null
+                            }
+                            WearScreen.StationDetail -> {
+                                screen = WearScreen.Favorites
+                                selectedStation = null
                             }
                             WearScreen.Search -> {
                                 // 移除焦點並關閉鍵盤後返回
@@ -368,7 +429,10 @@ private fun WearApp(
                 ) {
                     Text(
                         when (screen) {
-                            WearScreen.Search, WearScreen.RouteDetail, WearScreen.Nearby -> "返回"
+                            WearScreen.Search,
+                            WearScreen.RouteDetail,
+                            WearScreen.StationDetail,
+                            WearScreen.Nearby -> "返回"
                             WearScreen.Favorites -> "整理"
                         }
                     )
@@ -395,6 +459,10 @@ private fun WearApp(
                                     WearScreen.Search -> "搜尋公車"
                                     WearScreen.Nearby -> "附近站牌"
                                     WearScreen.RouteDetail -> selectedRoute?.routeName ?: "公車資料"
+                                    WearScreen.StationDetail ->
+                                        stationDetail?.stationName
+                                            ?: selectedStation?.stationName
+                                            ?: "站牌"
                                 },
                             )
                             Text(
@@ -407,6 +475,8 @@ private fun WearApp(
 
                                     WearScreen.RouteDetail ->
                                         selectedRoute?.description ?: ""
+
+                                    WearScreen.StationDetail -> "各側全部路線與即時到站"
 
                                     else -> when {
                                         state.settings.syncEnabled && state.hasSyncedFavorites ->
@@ -438,6 +508,23 @@ private fun WearApp(
                                     provider = suggestion.provider,
                                 )
                                 screen = WearScreen.RouteDetail
+                            },
+                            onSelectFavorite = { favorite ->
+                                if (favorite.type == "station") {
+                                    selectedStation = favorite
+                                    screen = WearScreen.StationDetail
+                                } else {
+                                    val routeId = favorite.routeId.orEmpty()
+                                    if (routeId.isNotBlank()) {
+                                        selectedRoute = RouteSearchResult(
+                                            routeId = routeId,
+                                            routeName = favorite.displayRouteName,
+                                            description = favorite.displayStopName,
+                                            provider = favorite.provider,
+                                        )
+                                        screen = WearScreen.RouteDetail
+                                    }
+                                }
                             },
                         )
                     }
@@ -507,6 +594,24 @@ private fun WearApp(
                             },
                         )
                     }
+
+                    WearScreen.StationDetail -> {
+                        stationDetailContent(
+                            detail = stationDetail,
+                            loading = stationDetailLoading,
+                            error = stationDetailError,
+                            onRefresh = { stationDetailRefreshTrigger++ },
+                            onSelectRoute = { route ->
+                                selectedRoute = RouteSearchResult(
+                                    routeId = route.routeId,
+                                    routeName = route.routeName,
+                                    description = route.statusText,
+                                    provider = selectedStation?.provider.orEmpty(),
+                                )
+                                screen = WearScreen.RouteDetail
+                            },
+                        )
+                    }
                 }
             }
         }
@@ -518,6 +623,7 @@ private fun TransformingLazyColumnScope.favoritesContent(
     onOpenSearch: () -> Unit,
     onOpenNearby: () -> Unit,
     onSelectSuggestion: (WearSmartSuggestionPayload) -> Unit,
+    onSelectFavorite: (FavoriteStop) -> Unit,
 ) {
     state.smartSuggestion?.let { suggestion ->
         item {
@@ -569,6 +675,7 @@ private fun TransformingLazyColumnScope.favoritesContent(
             FavoriteArrivalCard(
                 favorite = favorite,
                 state = state,
+                onClick = { onSelectFavorite(favorite) },
             )
         }
     }
@@ -807,10 +914,11 @@ private fun TransformingLazyColumnScope.nearbyContent(
 private fun FavoriteArrivalCard(
     favorite: FavoriteStop,
     state: WearHomeState,
+    onClick: () -> Unit,
 ) {
     val arrival = state.arrivalFor(favorite.id)
     Card(
-        onClick = {},
+        onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.secondaryContainer,
@@ -819,11 +927,61 @@ private fun FavoriteArrivalCard(
     ) {
         Text(favorite.displayRouteName)
         Text(favorite.displayStopName)
-        Text(arrival?.etaText ?: "--")
+        Text(if (favorite.type == "route") "路線" else arrival?.etaText ?: "--")
         arrival?.arrivalEpochMs?.let { arrivalAtMs ->
             Text(formatClockTime(arrivalAtMs))
         }
         Text(arrival?.statusText ?: favorite.groupName.ifBlank { favorite.provider })
+    }
+}
+
+private fun TransformingLazyColumnScope.stationDetailContent(
+    detail: WearStationDetail?,
+    loading: Boolean,
+    error: String?,
+    onRefresh: () -> Unit,
+    onSelectRoute: (WearStationRoute) -> Unit,
+) {
+    if (loading) {
+        item { WearInfoCard(title = "載入中", subtitle = "查詢整站即時路線...") }
+        return
+    }
+    if (error != null) {
+        item { WearInfoCard(title = "載入失敗", subtitle = error) }
+        item {
+            Button(onClick = onRefresh, modifier = Modifier.fillMaxWidth()) {
+                Text("重試")
+            }
+        }
+        return
+    }
+    if (detail == null || detail.sides.isEmpty()) {
+        item { WearInfoCard(title = "無資料", subtitle = "這個站牌目前沒有可顯示側別") }
+        return
+    }
+    detail.sides.forEach { side ->
+        item {
+            WearInfoCard(
+                title = "${side.label} 側",
+                subtitle = side.direction.ifBlank { "經過路線" },
+            )
+        }
+        if (side.routes.isEmpty()) {
+            item { WearInfoCard(title = "暫無路線", subtitle = "${side.label} 側目前沒有班次") }
+        } else {
+            side.routes.forEach { route ->
+                item {
+                    Card(
+                        onClick = { onSelectRoute(route) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(route.routeName)
+                        Text(route.etaText, color = MaterialTheme.colorScheme.primary)
+                        if (route.statusText.isNotBlank()) Text(route.statusText)
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/tile/YaBusTileService.kt
+++ b/android/wearos/src/main/java/tw/avianjay/taiwanbus/wearos/tile/YaBusTileService.kt
@@ -204,7 +204,14 @@ class YaBusTileService : TileService() {
             .addContent(text(favorite.stopName, 11, color = COLOR_ON_SURFACE_DIM))
             .addContent(text(favorite.etaText, 13, color = COLOR_ACCENT, weight = FONT_WEIGHT_BOLD))
 
-        val clickable = if (favorite.routeId.isNotBlank()) {
+        val clickable = if (favorite.type == "station" && favorite.stationId.isNotBlank()) {
+            openStationAction(
+                context = context,
+                stationId = favorite.stationId,
+                stationName = favorite.routeName,
+                provider = favorite.provider,
+            )
+        } else if (favorite.routeId.isNotBlank()) {
             openRouteAction(
                 context,
                 routeId = favorite.routeId,
@@ -356,6 +363,28 @@ class YaBusTileService : TileService() {
             .build()
         return ModifiersBuilders.Clickable.Builder()
             .setId("route_$routeId")
+            .setOnClick(launchAction)
+            .build()
+    }
+
+    private fun openStationAction(
+        context: Context,
+        stationId: String,
+        stationName: String,
+        provider: String,
+    ): ModifiersBuilders.Clickable {
+        val deeplinkUri =
+            "yabus-wear://station/$stationId?stationName=${Uri.encode(stationName)}&provider=$provider"
+        val androidActivity = ActionBuilders.AndroidActivity.Builder()
+            .setPackageName(context.packageName)
+            .setClassName(MainActivity::class.java.name)
+            .addKeyToExtraMapping("deeplink", ActionBuilders.stringExtra(deeplinkUri))
+            .build()
+        val launchAction = ActionBuilders.LaunchAction.Builder()
+            .setAndroidActivity(androidActivity)
+            .build()
+        return ModifiersBuilders.Clickable.Builder()
+            .setId("station_$stationId")
             .setOnClick(launchAction)
             .build()
     }

--- a/android/wearos/src/test/java/tw/avianjay/taiwanbus/wearos/data/WearModelsTest.kt
+++ b/android/wearos/src/test/java/tw/avianjay/taiwanbus/wearos/data/WearModelsTest.kt
@@ -1,0 +1,42 @@
+package tw.avianjay.taiwanbus.wearos.data
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class WearModelsTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun favoritePayloadDecodesAllThreeFavoriteTypes() {
+        val payload = json.decodeFromString<FavoritePayload>(
+            """
+            {
+              "favorites": [
+                {"id":"route:tpe:R1","type":"route","provider":"tpe","routeKey":1,"routeId":"R1","routeName":"307","routeDescription":"往板橋"},
+                {"id":"station:tpe:S1","type":"station","provider":"tpe","stationId":"S1","stationName":"臺北車站"},
+                {"id":"tpe:1:0:10","type":"boarding","provider":"tpe","routeKey":1,"pathId":0,"stopId":10,"routeId":"R1","routeName":"307","stopName":"臺北車站"}
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals(listOf("route", "station", "boarding"), payload.favorites.map { it.type })
+        assertEquals("往板橋", payload.favorites[0].displayStopName)
+        assertEquals("臺北車站", payload.favorites[1].displayRouteName)
+        assertNull(payload.favorites[0].realtimeRouteId)
+        assertNull(payload.favorites[1].realtimeRouteId)
+        assertEquals("R1", payload.favorites[2].realtimeRouteId)
+    }
+
+    @Test
+    fun legacyFavoriteDefaultsToBoarding() {
+        val favorite = json.decodeFromString<FavoriteStop>(
+            """{"id":"tpe:1:0:10","provider":"tpe","routeKey":1,"pathId":0,"stopId":10,"routeId":"R1"}""",
+        )
+
+        assertEquals("boarding", favorite.type)
+        assertEquals("R1", favorite.realtimeRouteId)
+    }
+}

--- a/ios/YABus/AppLaunchBridge.swift
+++ b/ios/YABus/AppLaunchBridge.swift
@@ -78,6 +78,10 @@ final class AppLaunchBridge {
     return handle(url: url)
   }
 
+  func payloadForTesting(url: URL) -> [String: Any]? {
+    payload(for: url)
+  }
+
   private func payload(for url: URL) -> [String: Any]? {
     guard let scheme = url.scheme?.lowercased() else {
       return nil
@@ -118,6 +122,14 @@ final class AppLaunchBridge {
       return routePayload(from: components, pathSegments: pathSegments)
     }
 
+    if host == "station" {
+      return stationPayload(
+        provider: queryValue("provider", from: components) ?? pathSegments.first,
+        stationId: queryValue("stationId", from: components)
+          ?? stringValue(at: 1, in: pathSegments)
+      )
+    }
+
     if host == "auth-callback" {
       return authPayload(from: components)
     }
@@ -139,6 +151,12 @@ final class AppLaunchBridge {
         stopId: queryInt("stopId", from: components) ?? intValue(at: 4, in: pathSegments),
         destinationPathId: queryInt("destinationPathId", from: components),
         destinationStopId: queryInt("destinationStopId", from: components)
+      )
+    }
+    if pathSegments.count >= 3 && pathSegments.first == "station" {
+      return stationPayload(
+        provider: pathSegments[1],
+        stationId: pathSegments[2]
       )
     }
 
@@ -229,6 +247,25 @@ final class AppLaunchBridge {
     return payload
   }
 
+  private func stationPayload(
+    provider: String?,
+    stationId: String?
+  ) -> [String: Any]? {
+    guard
+      let provider = provider?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !provider.isEmpty,
+      let stationId = stationId?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !stationId.isEmpty
+    else {
+      return nil
+    }
+    return [
+      "target": "station_detail",
+      "provider": provider,
+      "stationId": stationId,
+    ]
+  }
+
   private func internalLocationPayload(
     from components: URLComponents?,
     path: String
@@ -286,5 +323,11 @@ final class AppLaunchBridge {
       return nil
     }
     return Int(values[index])
+  }
+
+  private func stringValue(at index: Int, in values: [String]) -> String? {
+    guard values.indices.contains(index) else { return nil }
+    let value = values[index].trimmingCharacters(in: .whitespacesAndNewlines)
+    return value.isEmpty ? nil : value
   }
 }

--- a/ios/YABusTests/YABusTests.swift
+++ b/ios/YABusTests/YABusTests.swift
@@ -235,4 +235,26 @@ class YABusTests: XCTestCase {
     let bridge2 = LiveActivityBridge.shared
     XCTAssertTrue(bridge1 === bridge2)
   }
+
+  func testStationWidgetDeepLinkCreatesStationLaunchTarget() throws {
+    let url = try XCTUnwrap(
+      URL(string: "yabus://station?provider=tpe&stationId=TPE-STATION-1")
+    )
+    let payload = try XCTUnwrap(AppLaunchBridge.shared.payloadForTesting(url: url))
+
+    XCTAssertEqual(payload["target"] as? String, "station_detail")
+    XCTAssertEqual(payload["provider"] as? String, "tpe")
+    XCTAssertEqual(payload["stationId"] as? String, "TPE-STATION-1")
+  }
+
+  func testStationUniversalLinkCreatesStationLaunchTarget() throws {
+    let url = try XCTUnwrap(
+      URL(string: "https://busapp.avianjay.sbs/station/tpe/TPE-STATION-1")
+    )
+    let payload = try XCTUnwrap(AppLaunchBridge.shared.payloadForTesting(url: url))
+
+    XCTAssertEqual(payload["target"] as? String, "station_detail")
+    XCTAssertEqual(payload["provider"] as? String, "tpe")
+    XCTAssertEqual(payload["stationId"] as? String, "TPE-STATION-1")
+  }
 }

--- a/ios/YABusWidgets/FavoriteGroupWidgets.swift
+++ b/ios/YABusWidgets/FavoriteGroupWidgets.swift
@@ -57,6 +57,8 @@ enum FavoriteWidgetSharedStore {
 
         let provider = (stopMap["provider"] as? String ?? "")
           .trimmingCharacters(in: .whitespacesAndNewlines)
+        let type = (stopMap["type"] as? String ?? "boarding")
+          .trimmingCharacters(in: .whitespacesAndNewlines)
         let routeKey = integerValue(from: stopMap["routeKey"])
         let pathId = integerValue(from: stopMap["pathId"])
         let stopId = integerValue(from: stopMap["stopId"])
@@ -64,18 +66,32 @@ enum FavoriteWidgetSharedStore {
         let destinationPathId = destinationStopId == nil
           ? nil
           : (optionalIntegerValue(from: stopMap["destinationPathId"]) ?? pathId)
-        guard !provider.isEmpty, routeKey > 0, pathId >= 0, stopId >= 0 else {
+        let routeId = (stopMap["routeId"] as? String)?.nilIfBlank
+        let stationId = (stopMap["stationId"] as? String)?.nilIfBlank
+        let hasRequiredFields: Bool
+        switch type {
+        case "route": hasRequiredFields = routeKey > 0 && routeId != nil
+        case "station": hasRequiredFields = stationId != nil
+        case "boarding": hasRequiredFields = routeKey > 0 && pathId >= 0 && stopId >= 0
+        default: hasRequiredFields = false
+        }
+        let isValid = !provider.isEmpty && hasRequiredFields
+        guard isValid else {
           return nil
         }
 
         return FavoriteWidgetStop(
+          type: type,
           provider: provider,
           routeKey: routeKey,
           pathId: pathId,
           stopId: stopId,
-          routeId: (stopMap["routeId"] as? String)?.nilIfBlank,
+          routeId: routeId,
           routeName: (stopMap["routeName"] as? String)?.nilIfBlank,
+          routeDescription: (stopMap["routeDescription"] as? String)?.nilIfBlank,
           stopName: (stopMap["stopName"] as? String)?.nilIfBlank,
+          stationId: stationId,
+          stationName: (stopMap["stationName"] as? String)?.nilIfBlank,
           destinationPathId: destinationPathId,
           destinationStopId: destinationStopId,
           destinationStopName: (stopMap["destinationStopName"] as? String)?.nilIfBlank
@@ -351,13 +367,17 @@ private enum FavoriteWidgetAppGroupResolver {
 }
 
 struct FavoriteWidgetStop: Decodable, Hashable {
+  let type: String
   let provider: String
   let routeKey: Int
   let pathId: Int
   let stopId: Int
   let routeId: String?
   let routeName: String?
+  let routeDescription: String?
   let stopName: String?
+  let stationId: String?
+  let stationName: String?
   let destinationPathId: Int?
   let destinationStopId: Int?
   let destinationStopName: String?
@@ -392,6 +412,12 @@ private struct FavoriteWidgetRouteLiveData: Hashable {
   let fallbackStops: [Int: FavoriteWidgetLiveStop]
 }
 
+private struct FavoriteWidgetStationArrival: Hashable {
+  let routeName: String
+  let sideLabel: String
+  let liveStop: FavoriteWidgetLiveStop
+}
+
 struct FavoriteGroupOptionsProvider: DynamicOptionsProvider {
   func results() async throws -> [String] {
     let names = FavoriteWidgetSharedStore.loadFavoriteGroupNames()
@@ -404,7 +430,7 @@ struct FavoriteGroupConfigurationIntent: WidgetConfigurationIntent {
   static var title: LocalizedStringResource =
     "\u{6211}\u{7684}\u{6700}\u{611b}\u{7fa4}\u{7d44}"
   static var description = IntentDescription(
-    "\u{986f}\u{793a}\u{55ae}\u{4e00}\u{6700}\u{611b}\u{7fa4}\u{7d44}\u{7684}\u{5230}\u{7ad9}\u{6642}\u{9593}\u{3002}"
+    "顯示單一最愛群組的收藏內容與即時資訊。"
   )
 
   @Parameter(
@@ -514,9 +540,12 @@ private enum FavoriteWidgetRouteFetcher {
     for favorites: [FavoriteWidgetStop]
   ) async -> (items: [FavoriteWidgetItem], didFetchLiveData: Bool) {
     var liveDataByRoute = [String: FavoriteWidgetRouteLiveData]()
+    var stationArrivals = [String: FavoriteWidgetStationArrival?]()
     var successfulFetchCount = 0
     // A single realtime payload can cover multiple directions for the same route.
-    let uniqueRoutes = uniqueRouteRequests(from: favorites)
+    let uniqueRoutes = uniqueRouteRequests(
+      from: favorites.filter { $0.type == "boarding" }
+    )
 
     await withTaskGroup(of: (String, FavoriteWidgetRouteLiveData, Bool).self) { group in
       for (requestKey, favorite) in uniqueRoutes {
@@ -534,7 +563,53 @@ private enum FavoriteWidgetRouteFetcher {
       }
     }
 
+    await withTaskGroup(of: (String, FavoriteWidgetStationArrival?, Bool).self) { group in
+      for favorite in favorites where favorite.type == "station" {
+        group.addTask {
+          let result = await fetchStationArrival(favorite: favorite)
+          return (stationRequestKey(for: favorite), result.arrival, result.success)
+        }
+      }
+      for await (requestKey, arrival, success) in group {
+        stationArrivals[requestKey] = arrival
+        if success { successfulFetchCount += 1 }
+      }
+    }
+
     let items = favorites.map { favorite in
+      if favorite.type == "route" {
+        return FavoriteWidgetItem(
+          id: "route:\(favorite.provider):\(favorite.routeId ?? "")",
+          routeName: favorite.routeName?.nilIfBlank ?? favorite.routeId ?? "路線",
+          stopName: favorite.routeDescription?.nilIfBlank ?? favorite.provider.uppercased(),
+          etaText: "路線",
+          noteText: favorite.provider.uppercased(),
+          routeURL: FavoriteWidgetDeepLink.route(
+            provider: favorite.provider,
+            routeKey: favorite.routeKey,
+            routeId: favorite.routeId,
+            pathId: nil,
+            stopId: nil,
+            destinationPathId: nil,
+            destinationStopId: nil
+          )
+        )
+      }
+      if favorite.type == "station" {
+        let arrival = stationArrivals[stationRequestKey(for: favorite)] ?? nil
+        return FavoriteWidgetItem(
+          id: "station:\(favorite.provider):\(favorite.stationId ?? "")",
+          routeName: favorite.stationName?.nilIfBlank ?? favorite.stationId ?? "站牌",
+          stopName: arrival.map { "\($0.routeName) · \($0.sideLabel) 側" }
+            ?? "目前沒有即將抵達班次",
+          etaText: formatETA(arrival?.liveStop),
+          noteText: arrival?.liveStop.vehicleId?.nilIfBlank ?? "整站",
+          routeURL: FavoriteWidgetDeepLink.station(
+            provider: favorite.provider,
+            stationId: favorite.stationId ?? ""
+          )
+        )
+      }
       let liveStop = resolveLiveStop(
         for: favorite,
         in: liveDataByRoute[routeRequestKey(for: favorite)]
@@ -548,6 +623,7 @@ private enum FavoriteWidgetRouteFetcher {
         routeURL: FavoriteWidgetDeepLink.route(
           provider: favorite.provider,
           routeKey: favorite.routeKey,
+          routeId: favorite.routeId,
           pathId: favorite.pathId,
           stopId: favorite.stopId,
           destinationPathId: favorite.destinationPathId,
@@ -556,7 +632,72 @@ private enum FavoriteWidgetRouteFetcher {
       )
     }
 
-    return (items, successfulFetchCount > 0)
+    return (
+      items,
+      successfulFetchCount > 0 || favorites.allSatisfy { $0.type == "route" }
+    )
+  }
+
+  private static func fetchStationArrival(
+    favorite: FavoriteWidgetStop
+  ) async -> (success: Bool, arrival: FavoriteWidgetStationArrival?) {
+    guard
+      let stationId = favorite.stationId?.nilIfBlank,
+      let encodedStationId = stationId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+      var components = URLComponents(
+        string: "https://bus.avianjay.sbs/api/v1/stations/\(encodedStationId)/passby"
+      )
+    else {
+      return (false, nil)
+    }
+    components.queryItems = [
+      URLQueryItem(name: "city", value: favorite.provider.uppercased())
+    ]
+    guard let url = components.url else { return (false, nil) }
+    var request = URLRequest(url: url)
+    request.timeoutInterval = 10
+    request.cachePolicy = .reloadIgnoringLocalCacheData
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue(FavoriteWidgetApiUserAgent.current(), forHTTPHeaderField: "User-Agent")
+    do {
+      let (data, response) = try await URLSession.shared.data(for: request)
+      guard
+        let httpResponse = response as? HTTPURLResponse,
+        (200...299).contains(httpResponse.statusCode),
+        let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let sides = root["sides"] as? [Any]
+      else {
+        return (false, nil)
+      }
+      var bestETA: Int?
+      var bestArrival: FavoriteWidgetStationArrival?
+      for rawSide in sides {
+        guard let side = rawSide as? [String: Any] else { continue }
+        let label = (side["label"] as? String)?.nilIfBlank ?? "?"
+        let routes = side["routes"] as? [Any] ?? []
+        for rawRoute in routes {
+          guard
+            let route = rawRoute as? [String: Any],
+            let eta = intValue(from: route["eta"]),
+            eta >= 0,
+            bestETA == nil || eta < bestETA!
+          else { continue }
+          bestETA = eta
+          bestArrival = FavoriteWidgetStationArrival(
+            routeName: (route["route_name"] as? String)?.nilIfBlank ?? "路線",
+            sideLabel: label,
+            liveStop: FavoriteWidgetLiveStop(
+              sec: eta,
+              msg: (route["message"] as? String)?.nilIfBlank,
+              vehicleId: firstVehicleID(from: route["buses"] as? [Any])
+            )
+          )
+        }
+      }
+      return (true, bestArrival)
+    } catch {
+      return (false, nil)
+    }
   }
 
   private static func fetchLiveStops(
@@ -714,6 +855,10 @@ private enum FavoriteWidgetRouteFetcher {
     "\(favorite.provider):\(favorite.routeKey)"
   }
 
+  private static func stationRequestKey(for favorite: FavoriteWidgetStop) -> String {
+    "\(favorite.provider):\(favorite.stationId ?? "")"
+  }
+
   private static func uniqueRouteRequests(
     from favorites: [FavoriteWidgetStop]
   ) -> [String: FavoriteWidgetStop] {
@@ -781,8 +926,9 @@ private enum FavoriteWidgetDeepLink {
   static func route(
     provider: String,
     routeKey: Int,
-    pathId: Int,
-    stopId: Int,
+    routeId: String?,
+    pathId: Int?,
+    stopId: Int?,
     destinationPathId: Int?,
     destinationStopId: Int?
   ) -> URL? {
@@ -792,9 +938,10 @@ private enum FavoriteWidgetDeepLink {
     var queryItems = [
       URLQueryItem(name: "provider", value: provider),
       URLQueryItem(name: "routeKey", value: String(routeKey)),
-      URLQueryItem(name: "pathId", value: String(pathId)),
-      URLQueryItem(name: "stopId", value: String(stopId)),
     ]
+    if let routeId { queryItems.append(URLQueryItem(name: "routeId", value: routeId)) }
+    if let pathId { queryItems.append(URLQueryItem(name: "pathId", value: String(pathId))) }
+    if let stopId { queryItems.append(URLQueryItem(name: "stopId", value: String(stopId))) }
     if let destinationPathId {
       queryItems.append(
         URLQueryItem(name: "destinationPathId", value: String(destinationPathId))
@@ -807,6 +954,40 @@ private enum FavoriteWidgetDeepLink {
     }
     components.queryItems = queryItems
     return components.url
+  }
+
+  static func station(provider: String, stationId: String) -> URL? {
+    guard !provider.isEmpty, !stationId.isEmpty else { return nil }
+    var components = URLComponents()
+    components.scheme = "yabus"
+    components.host = "station"
+    components.queryItems = [
+      URLQueryItem(name: "provider", value: provider),
+      URLQueryItem(name: "stationId", value: stationId),
+    ]
+    return components.url
+  }
+}
+
+private struct OpenFavoriteWidgetItemIntent: AppIntent {
+  static var title: LocalizedStringResource = "開啟收藏項目"
+  static var description = IntentDescription("在 YABus 開啟路線、站牌或乘車點。")
+  static var openAppWhenRun = true
+  static var isDiscoverable = false
+
+  @Parameter(title: "收藏連結")
+  var url: URL
+
+  init() {
+    url = FavoriteWidgetDeepLink.group(named: "收藏")!
+  }
+
+  init(url: URL) {
+    self.url = url
+  }
+
+  func perform() async throws -> some IntentResult & OpensIntent {
+    .result(opensIntent: OpenURLIntent(url))
   }
 }
 
@@ -821,8 +1002,8 @@ struct FavoriteGroupWidget: Widget {
     ) { entry in
       FavoriteGroupWidgetView(entry: entry)
     }
-    .configurationDisplayName("我的最愛站牌")
-    .description("在主畫面或鎖定畫面查看最愛站牌的到站時間。")
+    .configurationDisplayName("我的最愛")
+    .description("在主畫面或鎖定畫面查看最愛路線、站牌與乘車點。")
     .supportedFamilies([
       .systemSmall,
       .systemMedium,
@@ -885,7 +1066,7 @@ private struct FavoriteGroupWidgetView: View {
         VStack(alignment: .leading, spacing: 8) {
           ForEach(Array(entry.items.prefix(maxVisibleItems))) { item in
             if let routeURL = item.routeURL {
-              Link(destination: routeURL) {
+              Button(intent: OpenFavoriteWidgetItemIntent(url: routeURL)) {
                 rowView(for: item)
               }
               .buttonStyle(.plain)

--- a/ios/YABusWidgets/FavoriteGroupWidgets.swift
+++ b/ios/YABusWidgets/FavoriteGroupWidgets.swift
@@ -969,6 +969,7 @@ private enum FavoriteWidgetDeepLink {
   }
 }
 
+@available(iOS 18.0, *)
 private struct OpenFavoriteWidgetItemIntent: AppIntent {
   static var title: LocalizedStringResource = "開啟收藏項目"
   static var description = IntentDescription("在 YABus 開啟路線、站牌或乘車點。")
@@ -1066,10 +1067,16 @@ private struct FavoriteGroupWidgetView: View {
         VStack(alignment: .leading, spacing: 8) {
           ForEach(Array(entry.items.prefix(maxVisibleItems))) { item in
             if let routeURL = item.routeURL {
-              Button(intent: OpenFavoriteWidgetItemIntent(url: routeURL)) {
-                rowView(for: item)
+              if #available(iOS 18.0, *) {
+                Button(intent: OpenFavoriteWidgetItemIntent(url: routeURL)) {
+                  rowView(for: item)
+                }
+                .buttonStyle(.plain)
+              } else {
+                Link(destination: routeURL) {
+                  rowView(for: item)
+                }
               }
-              .buttonStyle(.plain)
             } else {
               rowView(for: item)
             }

--- a/lib/app/bus_app.dart
+++ b/lib/app/bus_app.dart
@@ -36,6 +36,7 @@ import '../screens/nearby_screen.dart';
 import '../screens/onboarding_screen.dart';
 import '../screens/privacy_policy_page.dart';
 import '../screens/route_detail_navigation.dart';
+import '../screens/station_detail_screen.dart';
 import '../screens/search_screen.dart';
 import '../screens/settings_screen.dart';
 import '../screens/terms_of_service_page.dart';
@@ -310,6 +311,19 @@ Route<dynamic>? _buildAppRoute(
         initialStopId: intent.stopId,
         initialDestinationPathId: intent.destinationPathId,
         initialDestinationStopId: intent.destinationStopId,
+      );
+    case AppRouteKind.stationDetail:
+      final provider = intent.provider;
+      final stationId = intent.stationId;
+      if (provider == null || stationId == null) {
+        return null;
+      }
+      return MaterialPageRoute<void>(
+        settings: RouteSettings(name: intent.location),
+        builder: (_) => StationDetailScreen(
+          provider: provider,
+          stationId: stationId,
+        ),
       );
     case AppRouteKind.stopDetail:
     case AppRouteKind.unknown:
@@ -733,6 +747,19 @@ class _AppHomeState extends State<_AppHome> with WidgetsBindingObserver {
             initialStopId: action.stopId,
             initialDestinationPathId: action.destinationPathId,
             initialDestinationStopId: action.destinationStopId,
+          ),
+        );
+        return;
+      case AppLaunchTarget.stationDetail:
+        final provider = action.provider;
+        final stationId = action.stationId;
+        if (provider == null || stationId == null || stationId.isEmpty) {
+          return;
+        }
+        await navigator.pushNamed(
+          AppRoutes.stationDetailPath(
+            provider: provider,
+            stationId: stationId,
           ),
         );
         return;

--- a/lib/core/account_sync_models.dart
+++ b/lib/core/account_sync_models.dart
@@ -16,7 +16,10 @@ enum AccountSyncNamespace {
     AccountSyncNamespace.preferences => '設定',
   };
 
-  int get schemaVersion => 1;
+  int get schemaVersion => switch (this) {
+    AccountSyncNamespace.favorites => 2,
+    AccountSyncNamespace.preferences => 1,
+  };
 }
 
 enum AccountSyncConflictPolicy {

--- a/lib/core/android_home_integration.dart
+++ b/lib/core/android_home_integration.dart
@@ -13,21 +13,22 @@ class AndroidHomeIntegration {
   static bool get _isAndroid =>
       !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
 
-  static Future<bool> pinStopShortcut({required FavoriteStop favorite}) async {
+  static Future<bool> pinFavoriteShortcut({
+    required FavoriteItem favorite,
+  }) async {
     if (!_isAndroid) {
       return false;
     }
 
-    final result = await _channel.invokeMethod<bool>('pinStopShortcut', {
-      'provider': favorite.provider.name,
-      'routeKey': favorite.routeKey,
-      'pathId': favorite.pathId,
-      'stopId': favorite.stopId,
-      'routeName': favorite.routeName ?? '',
-      'stopName': favorite.stopName ?? '',
-    });
+    final result = await _channel.invokeMethod<bool>(
+      'pinFavoriteShortcut',
+      favorite.toJson(),
+    );
     return result ?? false;
   }
+
+  static Future<bool> pinStopShortcut({required FavoriteStop favorite}) =>
+      pinFavoriteShortcut(favorite: favorite);
 
   static Future<void> refreshFavoriteWidgets() async {
     if (!_isAndroid) {

--- a/lib/core/app_controller.dart
+++ b/lib/core/app_controller.dart
@@ -33,7 +33,7 @@ import 'smart_route_service.dart';
 import 'storage_service.dart';
 import 'wear_os_integration.dart';
 
-/// Thrown when the total number of favorite stops across all groups
+/// Thrown when the total number of favorite items across all groups
 /// has reached the maximum allowed limit.
 class FavoriteGroupFullException implements Exception {
   final String groupName;
@@ -42,7 +42,17 @@ class FavoriteGroupFullException implements Exception {
 
   @override
   String toString() =>
-      'FavoriteGroupFullException: already have $maxStops favorite stops total';
+      'FavoriteGroupFullException: already have $maxStops favorite items total';
+}
+
+class FavoriteGroupTypeMismatchException implements Exception {
+  const FavoriteGroupTypeMismatchException(this.groupName, this.itemType);
+
+  final String groupName;
+  final FavoriteItemType itemType;
+
+  @override
+  String toString() => '群組「$groupName」不接受 ${itemType.name} 收藏。';
 }
 
 class AppController extends ChangeNotifier {
@@ -88,7 +98,8 @@ class AppController extends ChangeNotifier {
       AnnouncementLocalState.empty();
   List<AppAnnouncement> _announcements = const [];
   List<SearchHistoryEntry> _history = const [];
-  Map<String, List<FavoriteStop>> _favoriteGroups = const {};
+  Map<String, List<FavoriteItem>> _favoriteGroups = const {};
+  Map<String, FavoriteGroupKind> _favoriteGroupKinds = const {};
   List<RouteUsageProfile> _routeUsageProfiles = const [];
   List<FavoriteUsageProfile> _favoriteUsageProfiles = const [];
   List<FavoriteUsageProfile> _stopVisitProfiles = const [];
@@ -124,8 +135,12 @@ class AppController extends ChangeNotifier {
   bool get isAuthenticated => _authSession?.isAuthenticated ?? false;
   List<AppAnnouncement> get announcements => List.unmodifiable(_announcements);
   List<SearchHistoryEntry> get history => List.unmodifiable(_history);
-  Map<String, List<FavoriteStop>> get favoriteGroups =>
+  Map<String, List<FavoriteItem>> get favoriteGroups =>
       Map.unmodifiable(_favoriteGroups);
+  Map<String, FavoriteGroupKind> get favoriteGroupKinds =>
+      Map.unmodifiable(_favoriteGroupKinds);
+  FavoriteGroupKind favoriteGroupKind(String groupName) =>
+      _favoriteGroupKinds[groupName] ?? FavoriteGroupKind.boarding;
   List<String> get favoriteGroupNames => _favoriteGroups.keys.toList();
   List<RouteUsageProfile> get routeUsageProfiles =>
       List.unmodifiable(_routeUsageProfiles);
@@ -157,16 +172,7 @@ class AppController extends ChangeNotifier {
       .followedBy(
         _favoriteGroups.entries.expand(
           (entry) => entry.value.map(
-            (favorite) =>
-                '${entry.key}:'
-                '${favorite.provider.name}:'
-                '${favorite.routeKey}:'
-                '${favorite.pathId}:'
-                '${favorite.stopId}:'
-                '${favorite.stopName ?? ''}:'
-                '${favorite.destinationPathId ?? 0}:'
-                '${favorite.destinationStopId ?? 0}:'
-                '${favorite.destinationStopName ?? ''}',
+            (favorite) => '${entry.key}:${jsonEncode(favorite.toJson())}',
           ),
         ),
       )
@@ -286,6 +292,9 @@ class AppController extends ChangeNotifier {
     _announcementLocalState = await storage.loadAnnouncementLocalState();
     _history = await storage.loadHistory();
     _favoriteGroups = await storage.loadFavoriteGroups();
+    _favoriteGroupKinds = await storage.loadFavoriteGroupKinds(
+      _favoriteGroups.keys,
+    );
     _favoriteGroupsLastModifiedAtMs = await storage
         .loadFavoriteGroupsLastModifiedAtMs();
     _routeUsageProfiles = await storage.loadRouteUsageProfiles();
@@ -460,8 +469,7 @@ class AppController extends ChangeNotifier {
         if (mergeToken.isEmpty) {
           throw Exception('連結回調缺少合併憑證。');
         }
-        final preview =
-            await authService.fetchPendingAccountMerge(mergeToken);
+        final preview = await authService.fetchPendingAccountMerge(mergeToken);
         return AuthLinkCallbackResult(
           outcome: AuthLinkOutcome.mergeRequired,
           provider: provider,
@@ -553,6 +561,7 @@ class AppController extends ChangeNotifier {
       _favoriteGroups,
       modifiedAtMs: effectiveModifiedAtMs,
     );
+    await storage.saveFavoriteGroupKinds(_favoriteGroupKinds);
     _favoriteGroupsLastModifiedAtMs = effectiveModifiedAtMs;
     if (scheduleSync) {
       _scheduleChangeDrivenAccountSync();
@@ -844,6 +853,10 @@ class AppController extends ChangeNotifier {
     switch (namespace) {
       case AccountSyncNamespace.favorites:
         _favoriteGroups = _favoriteGroupsFromSyncPayload(document.payload);
+        _favoriteGroupKinds = _favoriteGroupKindsFromSyncPayload(
+          document.payload,
+          _favoriteGroups.keys,
+        );
         await _persistFavoriteGroups(
           modifiedAtMs: updatedAtMs,
           scheduleSync: false,
@@ -961,6 +974,7 @@ class AppController extends ChangeNotifier {
 
     final needsMetadata = selectedFavorites
         .map((entry) => entry.favorite)
+        .whereType<FavoriteStop>()
         .where(
           (favorite) =>
               favorite.routeId?.trim().isNotEmpty != true ||
@@ -986,6 +1000,17 @@ class AppController extends ChangeNotifier {
     final payload = <Map<String, dynamic>>[];
     for (final selection in selectedFavorites) {
       final favorite = selection.favorite;
+      if (favorite is FavoriteRoute || favorite is FavoriteStation) {
+        payload.add({
+          'id': favorite.stableKey,
+          'groupName': selection.groupName,
+          ...favorite.toJson(),
+        });
+        continue;
+      }
+      if (favorite is! FavoriteStop) {
+        continue;
+      }
       final resolved = resolvedByKey[favorite.stableKey];
       final routeId = favorite.routeId?.trim().isNotEmpty == true
           ? favorite.routeId!.trim()
@@ -1296,7 +1321,10 @@ class AppController extends ChangeNotifier {
     }
   }
 
-  AppAnnouncement _optimisticToggle(AppAnnouncement announcement, String emoji) {
+  AppAnnouncement _optimisticToggle(
+    AppAnnouncement announcement,
+    String emoji,
+  ) {
     final myReactions = Set<String>.from(announcement.myReactions);
     final reactions = List<AnnouncementReaction>.from(announcement.reactions);
     final existingIndex = reactions.indexWhere(
@@ -1327,7 +1355,10 @@ class AppController extends ChangeNotifier {
       }
     }
 
-    return announcement.copyWith(reactions: reactions, myReactions: myReactions);
+    return announcement.copyWith(
+      reactions: reactions,
+      myReactions: myReactions,
+    );
   }
 
   void _replaceAnnouncement(int index, AppAnnouncement announcement) {
@@ -2386,6 +2417,7 @@ class AppController extends ChangeNotifier {
     final alreadyFavorited = _favoriteGroups.values.any(
       (group) => group.any(
         (item) =>
+            item is FavoriteStop &&
             item.provider == provider &&
             item.routeKey == routeKey &&
             item.pathId == pathId &&
@@ -2413,13 +2445,15 @@ class AppController extends ChangeNotifier {
     } on FavoriteGroupFullException {
       return null;
     }
-    return _favoriteGroups[autoFavoriteGroupName]?.firstWhere(
-      (item) =>
-          item.provider == provider &&
-          item.routeKey == routeKey &&
-          item.pathId == pathId &&
-          item.stopId == stopId,
-    );
+    return _favoriteGroups[autoFavoriteGroupName]
+        ?.whereType<FavoriteStop>()
+        .firstWhere(
+          (item) =>
+              item.provider == provider &&
+              item.routeKey == routeKey &&
+              item.pathId == pathId &&
+              item.stopId == stopId,
+        );
   }
 
   Future<void> recordRouteVisit(
@@ -2599,6 +2633,7 @@ class AppController extends ChangeNotifier {
       ),
       favorites: _favoriteGroups.values
           .expand((group) => group)
+          .whereType<FavoriteStop>()
           .where((favorite) => favorite.provider == _settings.provider),
       now: now ?? DateTime.now(),
       position: position,
@@ -2626,6 +2661,7 @@ class AppController extends ChangeNotifier {
       ),
       favorites: _favoriteGroups.values
           .expand((group) => group)
+          .whereType<FavoriteStop>()
           .where((favorite) => favorite.provider == _settings.provider),
       now: now ?? DateTime.now(),
       position: position,
@@ -2633,13 +2669,17 @@ class AppController extends ChangeNotifier {
     );
   }
 
-  Future<void> addFavoriteGroup(String name) async {
+  Future<void> addFavoriteGroup(
+    String name, {
+    FavoriteGroupKind kind = FavoriteGroupKind.boarding,
+  }) async {
     final trimmed = name.trim();
     if (trimmed.isEmpty || _favoriteGroups.containsKey(trimmed)) {
       return;
     }
 
-    _favoriteGroups = {..._favoriteGroups, trimmed: <FavoriteStop>[]};
+    _favoriteGroups = {..._favoriteGroups, trimmed: <FavoriteItem>[]};
+    _favoriteGroupKinds = {..._favoriteGroupKinds, trimmed: kind};
     await _persistFavoriteGroups();
     await IOSWidgetIntegration.syncFavoriteGroups(_favoriteGroups);
     await AndroidHomeIntegration.refreshFavoriteWidgets();
@@ -2652,6 +2692,8 @@ class AppController extends ChangeNotifier {
     final next = {..._favoriteGroups};
     next.remove(name);
     _favoriteGroups = next;
+    final nextKinds = {..._favoriteGroupKinds}..remove(name);
+    _favoriteGroupKinds = nextKinds;
     await _persistFavoriteGroups();
     await IOSWidgetIntegration.syncFavoriteGroups(_favoriteGroups);
     await AndroidHomeIntegration.refreshFavoriteWidgets();
@@ -2660,17 +2702,45 @@ class AppController extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<String> addFavoriteStop(
-    FavoriteStop favorite, {
+  Future<String> addFavoriteStop(FavoriteStop favorite, {String? groupName}) =>
+      addFavoriteItem(favorite, groupName: groupName);
+
+  List<String> compatibleFavoriteGroupNames(FavoriteItemType itemType) {
+    return _favoriteGroups.keys
+        .where((name) => favoriteGroupKind(name).acceptsType(itemType))
+        .toList(growable: false);
+  }
+
+  Future<String> addFavoriteItem(
+    FavoriteItem favorite, {
     String? groupName,
   }) async {
-    final targetGroup = groupName?.trim().isNotEmpty == true
-        ? groupName!.trim()
-        : (_favoriteGroups.isEmpty
-              ? defaultFavoriteGroupName
-              : _favoriteGroups.keys.first);
+    var targetGroup = groupName?.trim() ?? '';
+    if (targetGroup.isEmpty) {
+      final compatible = _favoriteGroups.keys.where(
+        (name) => favoriteGroupKind(name).accepts(favorite),
+      );
+      if (compatible.isNotEmpty) {
+        targetGroup = compatible.first;
+      } else if (favorite is FavoriteStop) {
+        targetGroup = defaultFavoriteGroupName;
+      } else {
+        throw StateError('沒有相容的${favorite.type.name}收藏群組。');
+      }
+    }
 
-    // Enforce maximum 25 stops across all groups (matches batch API limit
+    if (!_favoriteGroups.containsKey(targetGroup)) {
+      _favoriteGroups = {..._favoriteGroups, targetGroup: <FavoriteItem>[]};
+      _favoriteGroupKinds = {
+        ..._favoriteGroupKinds,
+        targetGroup: _groupKindForItemType(favorite.type),
+      };
+    }
+    if (!favoriteGroupKind(targetGroup).accepts(favorite)) {
+      throw FavoriteGroupTypeMismatchException(targetGroup, favorite.type);
+    }
+
+    // Enforce maximum 25 items across all groups (matches account sync limit
     // and account-sync server setting).
     const maxFavoritesTotal = 25;
     final currentTotal = _favoriteGroups.values.fold<int>(
@@ -2684,11 +2754,11 @@ class AppController extends ChangeNotifier {
       throw FavoriteGroupFullException(targetGroup, maxFavoritesTotal);
     }
 
-    final next = <String, List<FavoriteStop>>{
+    final next = <String, List<FavoriteItem>>{
       for (final entry in _favoriteGroups.entries)
-        entry.key: List<FavoriteStop>.from(entry.value),
+        entry.key: List<FavoriteItem>.from(entry.value),
     };
-    next.putIfAbsent(targetGroup, () => <FavoriteStop>[]);
+    next.putIfAbsent(targetGroup, () => <FavoriteItem>[]);
     final existingIndex = next[targetGroup]!.indexWhere(
       (item) => item.sameAs(favorite),
     );
@@ -2697,38 +2767,9 @@ class AppController extends ChangeNotifier {
       next[targetGroup]!.add(favorite);
     } else {
       final existing = next[targetGroup]![existingIndex];
-      final routeId = favorite.routeId?.trim().isNotEmpty == true
-          ? favorite.routeId
-          : existing.routeId;
-      final routeName = favorite.routeName?.trim().isNotEmpty == true
-          ? favorite.routeName
-          : existing.routeName;
-      final stopName = favorite.stopName?.trim().isNotEmpty == true
-          ? favorite.stopName
-          : existing.stopName;
-      final destinationStopId = favorite.destinationStopId;
-      final mergedDestinationStopId =
-          destinationStopId ?? existing.destinationStopId;
-      final mergedDestinationPathId = mergedDestinationStopId == null
-          ? null
-          : (destinationStopId == null
-                ? existing.destinationPathId
-                : (favorite.destinationPathId ?? favorite.pathId));
-      final mergedDestinationStopName = destinationStopId == null
-          ? existing.destinationStopName
-          : favorite.destinationStopName;
-
-      next[targetGroup]![existingIndex] = FavoriteStop(
-        provider: favorite.provider,
-        routeKey: favorite.routeKey,
-        pathId: favorite.pathId,
-        stopId: favorite.stopId,
-        routeId: routeId,
-        routeName: routeName,
-        stopName: stopName,
-        destinationPathId: mergedDestinationPathId,
-        destinationStopId: mergedDestinationStopId,
-        destinationStopName: mergedDestinationStopName,
+      next[targetGroup]![existingIndex] = _mergeFavoriteItem(
+        existing,
+        favorite,
       );
     }
 
@@ -2741,12 +2782,14 @@ class AppController extends ChangeNotifier {
       (item) => item.sameAs(favorite),
       orElse: () => favorite,
     );
-    await analytics.logFavoriteStopSaved(
-      provider: favorite.provider,
-      routeKey: favorite.routeKey,
-      replacedExisting: replacedExisting,
-      hasDestination: savedFavorite.destinationStopId != null,
-    );
+    if (favorite is FavoriteStop && savedFavorite is FavoriteStop) {
+      await analytics.logFavoriteStopSaved(
+        provider: favorite.provider,
+        routeKey: favorite.routeKey,
+        replacedExisting: replacedExisting,
+        hasDestination: savedFavorite.destinationStopId != null,
+      );
+    }
     notifyListeners();
     return targetGroup;
   }
@@ -2779,7 +2822,7 @@ class AppController extends ChangeNotifier {
     var found = false;
     var didChange = false;
     final updatedGroup = currentGroup.map((item) {
-      if (!item.sameAs(favorite)) {
+      if (item is! FavoriteStop || !item.sameAs(favorite)) {
         return item;
       }
 
@@ -2799,6 +2842,7 @@ class AppController extends ChangeNotifier {
         routeId: item.routeId,
         routeName: item.routeName,
         stopName: item.stopName,
+        rawStopId: item.rawStopId,
         destinationPathId: normalizedDestinationPathId,
         destinationStopId: normalizedDestinationStopId,
         destinationStopName: normalizedDestinationStopName,
@@ -2818,13 +2862,16 @@ class AppController extends ChangeNotifier {
     return true;
   }
 
-  Future<void> removeFavoriteStop(
+  Future<void> removeFavoriteStop(String groupName, FavoriteStop favorite) =>
+      removeFavoriteItem(groupName, favorite);
+
+  Future<void> removeFavoriteItem(
     String groupName,
-    FavoriteStop favorite,
+    FavoriteItem favorite,
   ) async {
-    final next = <String, List<FavoriteStop>>{
+    final next = <String, List<FavoriteItem>>{
       for (final entry in _favoriteGroups.entries)
-        entry.key: List<FavoriteStop>.from(entry.value),
+        entry.key: List<FavoriteItem>.from(entry.value),
     };
     next[groupName]?.removeWhere((item) => item.sameAs(favorite));
     _favoriteGroups = next;
@@ -2832,15 +2879,17 @@ class AppController extends ChangeNotifier {
     await IOSWidgetIntegration.syncFavoriteGroups(_favoriteGroups);
     await AndroidHomeIntegration.refreshFavoriteWidgets();
     await _syncWearOsSnapshot(requestRefresh: false);
-    await analytics.logFavoriteStopRemoved(
-      provider: favorite.provider,
-      routeKey: favorite.routeKey,
-      hadDestination: favorite.destinationStopId != null,
-    );
+    if (favorite is FavoriteStop) {
+      await analytics.logFavoriteStopRemoved(
+        provider: favorite.provider,
+        routeKey: favorite.routeKey,
+        hadDestination: favorite.destinationStopId != null,
+      );
+    }
     notifyListeners();
   }
 
-  List<FavoriteStop> favoritesInGroup(String groupName) {
+  List<FavoriteItem> favoritesInGroup(String groupName) {
     return List.unmodifiable(_favoriteGroups[groupName] ?? const []);
   }
 
@@ -2848,7 +2897,7 @@ class AppController extends ChangeNotifier {
     String groupName,
   ) async {
     final items = await repository.resolveFavoriteGroup(
-      favoritesInGroup(groupName),
+      favoritesInGroup(groupName).whereType<FavoriteStop>().toList(),
     );
     await _persistFavoriteMetadata(groupName, items);
     return items;
@@ -2874,6 +2923,9 @@ class AppController extends ChangeNotifier {
 
     var didChange = false;
     final updatedGroup = current.map((favorite) {
+      if (favorite is! FavoriteStop) {
+        return favorite;
+      }
       final resolved =
           resolvedByKey['${favorite.provider.name}:'
               '${favorite.routeKey}:'
@@ -2910,6 +2962,7 @@ class AppController extends ChangeNotifier {
         routeId: nextRouteId,
         routeName: nextRouteName,
         stopName: nextStopName,
+        rawStopId: favorite.rawStopId,
         destinationPathId: favorite.destinationPathId,
         destinationStopId: favorite.destinationStopId,
         destinationStopName: favorite.destinationStopName,
@@ -2937,6 +2990,9 @@ class AppController extends ChangeNotifier {
   Map<String, dynamic> _buildSyncPayload(AccountSyncNamespace namespace) {
     return switch (namespace) {
       AccountSyncNamespace.favorites => {
+        'groupKinds': _favoriteGroups.map(
+          (key, _) => MapEntry(key, favoriteGroupKind(key).name),
+        ),
         'groups': _favoriteGroups.map(
           (key, value) => MapEntry(
             key,
@@ -3004,7 +3060,7 @@ class AppController extends ChangeNotifier {
     return AppSettings.fromJson(merged);
   }
 
-  Map<String, List<FavoriteStop>> _favoriteGroupsFromSyncPayload(
+  Map<String, List<FavoriteItem>> _favoriteGroupsFromSyncPayload(
     Map<String, dynamic>? payload,
   ) {
     final rawGroups = _stringMap(payload?['groups']);
@@ -3012,7 +3068,7 @@ class AppController extends ChangeNotifier {
       return {};
     }
 
-    final groups = <String, List<FavoriteStop>>{};
+    final groups = <String, List<FavoriteItem>>{};
     for (final entry in rawGroups.entries) {
       final groupName = entry.key.trim();
       final value = entry.value;
@@ -3022,15 +3078,26 @@ class AppController extends ChangeNotifier {
       final favorites = value
           .whereType<Map>()
           .map(
-            (item) => FavoriteStop.fromJson(
+            (item) => FavoriteItem.fromJson(
               item.map((key, value) => MapEntry(key.toString(), value)),
             ),
           )
-          .where((favorite) => favorite.routeKey > 0 && favorite.stopId > 0)
+          .where(_isValidFavoriteItemForController)
           .toList(growable: false);
       groups[groupName] = favorites;
     }
     return groups;
+  }
+
+  Map<String, FavoriteGroupKind> _favoriteGroupKindsFromSyncPayload(
+    Map<String, dynamic>? payload,
+    Iterable<String> groupNames,
+  ) {
+    final rawKinds = _stringMap(payload?['groupKinds']);
+    return {
+      for (final groupName in groupNames)
+        groupName: FavoriteGroupKind.fromJson(rawKinds?[groupName]),
+    };
   }
 
   Future<DatabaseConnectionKind> _resolveDatabaseConnectionKind() async {
@@ -3069,7 +3136,81 @@ class _WearFavoriteSelection {
   });
 
   final String groupName;
-  final FavoriteStop favorite;
+  final FavoriteItem favorite;
+}
+
+FavoriteGroupKind _groupKindForItemType(FavoriteItemType itemType) =>
+    switch (itemType) {
+      FavoriteItemType.route => FavoriteGroupKind.route,
+      FavoriteItemType.station => FavoriteGroupKind.station,
+      FavoriteItemType.boarding => FavoriteGroupKind.boarding,
+    };
+
+bool _isValidFavoriteItemForController(FavoriteItem item) => switch (item) {
+  FavoriteRoute(:final routeKey, :final routeId, :final routeName) =>
+    routeKey > 0 && routeId.isNotEmpty && routeName.isNotEmpty,
+  FavoriteStation(:final stationId, :final stationName) =>
+    stationId.isNotEmpty && stationName.isNotEmpty,
+  FavoriteStop(:final routeKey, :final stopId) => routeKey > 0 && stopId > 0,
+  _ => false,
+};
+
+FavoriteItem _mergeFavoriteItem(FavoriteItem existing, FavoriteItem incoming) {
+  if (existing is FavoriteStop && incoming is FavoriteStop) {
+    final destinationStopId = incoming.destinationStopId;
+    final mergedDestinationStopId =
+        destinationStopId ?? existing.destinationStopId;
+    return FavoriteStop(
+      provider: incoming.provider,
+      routeKey: incoming.routeKey,
+      pathId: incoming.pathId,
+      stopId: incoming.stopId,
+      routeId: incoming.routeId?.trim().isNotEmpty == true
+          ? incoming.routeId
+          : existing.routeId,
+      routeName: incoming.routeName?.trim().isNotEmpty == true
+          ? incoming.routeName
+          : existing.routeName,
+      stopName: incoming.stopName?.trim().isNotEmpty == true
+          ? incoming.stopName
+          : existing.stopName,
+      rawStopId: incoming.rawStopId?.trim().isNotEmpty == true
+          ? incoming.rawStopId
+          : existing.rawStopId,
+      destinationPathId: mergedDestinationStopId == null
+          ? null
+          : (destinationStopId == null
+                ? existing.destinationPathId
+                : (incoming.destinationPathId ?? incoming.pathId)),
+      destinationStopId: mergedDestinationStopId,
+      destinationStopName: destinationStopId == null
+          ? existing.destinationStopName
+          : incoming.destinationStopName,
+    );
+  }
+  if (existing is FavoriteRoute && incoming is FavoriteRoute) {
+    return FavoriteRoute(
+      provider: incoming.provider,
+      routeKey: incoming.routeKey,
+      routeId: incoming.routeId,
+      routeName: incoming.routeName.isNotEmpty
+          ? incoming.routeName
+          : existing.routeName,
+      routeDescription: incoming.routeDescription?.isNotEmpty == true
+          ? incoming.routeDescription
+          : existing.routeDescription,
+    );
+  }
+  if (existing is FavoriteStation && incoming is FavoriteStation) {
+    return FavoriteStation(
+      provider: incoming.provider,
+      stationId: incoming.stationId,
+      stationName: incoming.stationName.isNotEmpty
+          ? incoming.stationName
+          : existing.stationName,
+    );
+  }
+  return incoming;
 }
 
 Map<String, dynamic> _preferencesSyncPayloadFromSettings(AppSettings settings) {

--- a/lib/core/app_launch_service.dart
+++ b/lib/core/app_launch_service.dart
@@ -9,6 +9,7 @@ import 'web_auth_callback_stub.dart'
 
 enum AppLaunchTarget {
   routeDetail,
+  stationDetail,
   favoritesGroup,
   internalLocation,
   authCallback,
@@ -25,6 +26,7 @@ class AppLaunchAction {
     this.destinationPathId,
     this.destinationStopId,
     this.groupName,
+    this.stationId,
     this.location,
     this.authToken,
     this.authAccountId,
@@ -62,9 +64,11 @@ class AppLaunchAction {
     }
 
     return AppLaunchAction(
-      target: targetName == 'favorites_group'
-          ? AppLaunchTarget.favoritesGroup
-          : AppLaunchTarget.routeDetail,
+      target: switch (targetName) {
+        'favorites_group' => AppLaunchTarget.favoritesGroup,
+        'station_detail' => AppLaunchTarget.stationDetail,
+        _ => AppLaunchTarget.routeDetail,
+      },
       provider: map['provider'] == null
           ? null
           : busProviderFromString(map['provider'] as String),
@@ -75,6 +79,7 @@ class AppLaunchAction {
       destinationPathId: (map['destinationPathId'] as num?)?.toInt(),
       destinationStopId: (map['destinationStopId'] as num?)?.toInt(),
       groupName: map['groupName'] as String?,
+      stationId: map['stationId']?.toString(),
     );
   }
 
@@ -87,6 +92,7 @@ class AppLaunchAction {
   final int? destinationPathId;
   final int? destinationStopId;
   final String? groupName;
+  final String? stationId;
   final String? location;
   final String? authToken;
   final String? authAccountId;

--- a/lib/core/app_link_handler.dart
+++ b/lib/core/app_link_handler.dart
@@ -59,6 +59,7 @@ String? _internalLocationForUri(Uri uri) {
     case AppRouteKind.announcements:
     case AppRouteKind.announcementDetail:
     case AppRouteKind.routeDetail:
+    case AppRouteKind.stationDetail:
       return intent.location;
     case AppRouteKind.stopDetail:
     case AppRouteKind.unknown:

--- a/lib/core/app_routes.dart
+++ b/lib/core/app_routes.dart
@@ -112,6 +112,15 @@ class AppRoutes {
   static String announcementDetailPath(String announcementId) {
     return Uri(pathSegments: ['announcement', announcementId]).toString();
   }
+
+  static String stationDetailPath({
+    required BusProvider provider,
+    required String stationId,
+  }) {
+    return Uri(
+      pathSegments: ['station', provider.name, stationId.trim()],
+    ).toString();
+  }
 }
 
 enum AppRouteKind {
@@ -128,6 +137,7 @@ enum AppRouteKind {
   announcements,
   announcementDetail,
   routeDetail,
+  stationDetail,
   stopDetail,
   unknown,
 }
@@ -145,6 +155,7 @@ class AppRouteIntent {
     this.destinationStopId,
     this.announcementId,
     this.stopIdentifier,
+    this.stationId,
   });
 
   final AppRouteKind kind;
@@ -158,6 +169,7 @@ class AppRouteIntent {
   final int? destinationStopId;
   final String? announcementId;
   final String? stopIdentifier;
+  final String? stationId;
 }
 
 AppRouteIntent parseAppRoute(String? rawLocation) {
@@ -271,6 +283,19 @@ AppRouteIntent parseAppRoute(String? rawLocation) {
         destinationStopId: _tryParseInt(
           uri.queryParameters['destinationStopId'],
         ),
+      );
+    }
+  }
+
+  if (segments.first == 'station' && segments.length >= 3) {
+    final provider = _providerFromName(segments[1]);
+    final stationId = Uri.decodeComponent(segments[2]).trim();
+    if (provider != null && stationId.isNotEmpty) {
+      return AppRouteIntent(
+        kind: AppRouteKind.stationDetail,
+        location: location,
+        provider: provider,
+        stationId: stationId,
       );
     }
   }

--- a/lib/core/bus_repository.dart
+++ b/lib/core/bus_repository.dart
@@ -1993,6 +1993,154 @@ class BusRepository {
   /// response whose stop name doesn't match the tapped stop is discarded so
   /// callers fall back to the local lookup instead of showing another city's
   /// routes.
+  Future<StationPassbyData?> resolveStation(
+    String stopId, {
+    required BusProvider provider,
+  }) async {
+    final trimmed = stopId.trim();
+    if (trimmed.isEmpty) {
+      return null;
+    }
+    final uri = Uri.parse('$_apiBaseUrl/api/v1/stations/resolve').replace(
+      queryParameters: {'city': provider.prefix, 'stopid': trimmed},
+    );
+    return _loadStationPassby(uri, expectedProvider: provider);
+  }
+
+  Future<StationPassbyData?> getStationPassby(
+    String stationId, {
+    required BusProvider provider,
+  }) async {
+    final trimmed = stationId.trim();
+    if (trimmed.isEmpty) {
+      return null;
+    }
+    final uri = Uri.parse(
+      '$_apiBaseUrl/api/v1/stations/${Uri.encodeComponent(trimmed)}/passby',
+    ).replace(queryParameters: {'city': provider.prefix});
+    final station = await _loadStationPassby(uri, expectedProvider: provider);
+    if (station != null && station.stationId != trimmed) {
+      return null;
+    }
+    return station;
+  }
+
+  Future<StationPassbyData?> _loadStationPassby(
+    Uri uri, {
+    required BusProvider expectedProvider,
+  }) async {
+    final response = await _client.get(uri, headers: _apiJsonHeaders);
+    if (response.statusCode == 429) {
+      throw const HttpException(rateLimitedErrorMessage);
+    }
+    if (response.statusCode == 404) {
+      return null;
+    }
+    if (response.statusCode != 200) {
+      throw HttpException('整站路線暫時無法取得 (${response.statusCode})。');
+    }
+    final decoded = jsonDecode(apiResponseText(response));
+    if (decoded is! Map) {
+      throw const FormatException('Invalid station passby response.');
+    }
+    final json = decoded.map(
+      (key, value) => MapEntry(key.toString(), value),
+    );
+    if (json['city']?.toString().toUpperCase() != expectedProvider.prefix) {
+      return null;
+    }
+    final stationId = json['station_id']?.toString().trim() ?? '';
+    final stationName = json['station_name']?.toString().trim() ?? '';
+    if (stationId.isEmpty || stationName.isEmpty) {
+      throw const FormatException('Invalid station identity.');
+    }
+
+    final sides = <StationSideData>[];
+    for (final rawSide in (json['sides'] as List? ?? const []).whereType<Map>()) {
+      final side = rawSide.map(
+        (key, value) => MapEntry(key.toString(), value),
+      );
+      final sideId = side['side_id']?.toString().trim() ?? '';
+      final label = side['label']?.toString().trim() ?? '';
+      final rawStopId = side['stopid']?.toString().trim() ?? '';
+      if (sideId.isEmpty || label.isEmpty || rawStopId.isEmpty) {
+        continue;
+      }
+      final arrivals = <StationRouteArrival>[];
+      for (final rawRoute
+          in (side['routes'] as List? ?? const []).whereType<Map>()) {
+        final routeId = rawRoute['routeid']?.toString().trim() ?? '';
+        if (routeId.isEmpty || !routeId.startsWith(expectedProvider.prefix)) {
+          continue;
+        }
+        final pathId = _toInt(rawRoute['pathid']);
+        final routeProvider = busProviderFromString(routeId.substring(0, 3));
+        final route = _routeSummaryFromPathRow(
+          provider: routeProvider,
+          routeId: routeId,
+          routeName: rawRoute['route_name']?.toString() ?? routeId,
+          routeNameEn: rawRoute['route_name_en']?.toString() ?? '',
+          pathId: pathId,
+          pathName: rawRoute['path_name']?.toString() ?? '',
+        );
+        final matchedStop = StopInfo(
+          routeKey: _routeKeyForRouteId(routeId),
+          pathId: pathId,
+          stopId: _parseStopId(rawStopId),
+          rawStopId: rawStopId,
+          stopName: stationName,
+          sequence: _toInt(rawRoute['seq']),
+          lon: _toDouble(side['lon']),
+          lat: _toDouble(side['lat']),
+          sec: _nullableInt(rawRoute['eta']),
+          msg: rawRoute['message']?.toString(),
+          t: rawRoute['updated_at']?.toString(),
+          buses: (rawRoute['buses'] as List? ?? const [])
+              .whereType<Map>()
+              .map(_parseBusVehicle)
+              .toList(growable: false),
+          etas: _parseStopEtas(rawRoute['etas']),
+        );
+        arrivals.add(
+          StationRouteArrival(
+            sideLabel: label,
+            result: StopRouteSearchResult(
+              route: route,
+              matchedStop: matchedStop,
+            ),
+          ),
+        );
+      }
+      sides.add(
+        StationSideData(
+          sideId: sideId,
+          label: label,
+          direction: side['direction']?.toString().trim().isNotEmpty == true
+              ? side['direction'].toString().trim()
+              : null,
+          stopUid: side['stop_uid']?.toString().trim() ?? '',
+          rawStopId: rawStopId,
+          lat: _toDouble(side['lat']),
+          lon: _toDouble(side['lon']),
+          routes: arrivals,
+        ),
+      );
+    }
+
+    return StationPassbyData(
+      provider: expectedProvider,
+      stationId: stationId,
+      stationName: stationName,
+      stationNameEn:
+          json['station_name_en']?.toString().trim().isNotEmpty == true
+          ? json['station_name_en'].toString().trim()
+          : null,
+      lat: _toDouble(json['lat']),
+      lon: _toDouble(json['lon']),
+      sides: sides,
+    );
+  }
+
   Future<List<StopRouteSearchResult>> getStopPassby(
     String stopId, {
     required BusProvider provider,

--- a/lib/core/ios_widget_integration.dart
+++ b/lib/core/ios_widget_integration.dart
@@ -20,7 +20,7 @@ class IOSWidgetIntegration {
       !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
 
   static Future<void> syncFavoriteGroups(
-    Map<String, List<FavoriteStop>> favoriteGroups, {
+    Map<String, List<FavoriteItem>> favoriteGroups, {
     bool waitForBridge = false,
   }) async {
     if (!_isIOS) {

--- a/lib/core/models.dart
+++ b/lib/core/models.dart
@@ -782,9 +782,12 @@ enum FavoriteGroupKind {
       this == FavoriteGroupKind.mixed || name == itemType.name;
 
   String get label => switch (this) {
+    // Display text only. The enum *names* are persisted and synced to the
+    // server (see _FAVORITE_GROUP_KINDS server-side), so they must not follow
+    // any relabelling here.
     FavoriteGroupKind.route => '路線',
-    FavoriteGroupKind.station => '站牌',
-    FavoriteGroupKind.boarding => '乘車點',
+    FavoriteGroupKind.station => '整站',
+    FavoriteGroupKind.boarding => '站牌',
     FavoriteGroupKind.mixed => '綜合',
   };
 }

--- a/lib/core/models.dart
+++ b/lib/core/models.dart
@@ -761,7 +761,146 @@ class SearchHistoryEntry {
   }
 }
 
-class FavoriteStop {
+enum FavoriteItemType { route, station, boarding }
+
+enum FavoriteGroupKind {
+  route,
+  station,
+  boarding,
+  mixed;
+
+  factory FavoriteGroupKind.fromJson(Object? value) {
+    return FavoriteGroupKind.values.firstWhere(
+      (kind) => kind.name == value?.toString(),
+      orElse: () => FavoriteGroupKind.boarding,
+    );
+  }
+
+  bool accepts(FavoriteItem item) => acceptsType(item.type);
+
+  bool acceptsType(FavoriteItemType itemType) =>
+      this == FavoriteGroupKind.mixed || name == itemType.name;
+
+  String get label => switch (this) {
+    FavoriteGroupKind.route => '路線',
+    FavoriteGroupKind.station => '站牌',
+    FavoriteGroupKind.boarding => '乘車點',
+    FavoriteGroupKind.mixed => '綜合',
+  };
+}
+
+abstract class FavoriteItem {
+  const FavoriteItem();
+
+  factory FavoriteItem.fromJson(Map<String, dynamic> json) {
+    return switch (json['type']?.toString()) {
+      'route' => FavoriteRoute.fromJson(json),
+      'station' => FavoriteStation.fromJson(json),
+      _ => FavoriteStop.fromJson(json),
+    };
+  }
+
+  FavoriteItemType get type;
+  BusProvider get provider;
+  String get stableKey;
+  Map<String, dynamic> toJson();
+  bool sameAs(FavoriteItem other);
+}
+
+class FavoriteRoute extends FavoriteItem {
+  const FavoriteRoute({
+    required this.provider,
+    required this.routeKey,
+    required this.routeId,
+    required this.routeName,
+    this.routeDescription,
+  });
+
+  factory FavoriteRoute.fromJson(Map<String, dynamic> json) {
+    return FavoriteRoute(
+      provider: busProviderFromString(json['provider'] as String? ?? 'tpe'),
+      routeKey: (json['routeKey'] as num?)?.toInt() ?? 0,
+      routeId: (json['routeId'] as String? ?? '').trim(),
+      routeName: (json['routeName'] as String? ?? '').trim(),
+      routeDescription:
+          (json['routeDescription'] as String?)?.trim().isNotEmpty == true
+          ? (json['routeDescription'] as String).trim()
+          : null,
+    );
+  }
+
+  @override
+  final BusProvider provider;
+  final int routeKey;
+  final String routeId;
+  final String routeName;
+  final String? routeDescription;
+
+  @override
+  FavoriteItemType get type => FavoriteItemType.route;
+
+  @override
+  String get stableKey => 'route:${provider.name}:$routeId';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type.name,
+    'provider': provider.name,
+    'routeKey': routeKey,
+    'routeId': routeId,
+    'routeName': routeName,
+    if (routeDescription != null) 'routeDescription': routeDescription,
+  };
+
+  @override
+  bool sameAs(FavoriteItem other) =>
+      other is FavoriteRoute &&
+      provider == other.provider &&
+      routeId == other.routeId;
+}
+
+class FavoriteStation extends FavoriteItem {
+  const FavoriteStation({
+    required this.provider,
+    required this.stationId,
+    required this.stationName,
+  });
+
+  factory FavoriteStation.fromJson(Map<String, dynamic> json) {
+    return FavoriteStation(
+      provider: busProviderFromString(json['provider'] as String? ?? 'tpe'),
+      stationId: (json['stationId'] as String? ?? '').trim(),
+      stationName: (json['stationName'] as String? ?? '').trim(),
+    );
+  }
+
+  @override
+  final BusProvider provider;
+  final String stationId;
+  final String stationName;
+
+  @override
+  FavoriteItemType get type => FavoriteItemType.station;
+
+  @override
+  String get stableKey => 'station:${provider.name}:$stationId';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type.name,
+    'provider': provider.name,
+    'stationId': stationId,
+    'stationName': stationName,
+  };
+
+  @override
+  bool sameAs(FavoriteItem other) =>
+      other is FavoriteStation &&
+      provider == other.provider &&
+      stationId == other.stationId;
+}
+
+class FavoriteStop extends FavoriteItem {
   const FavoriteStop({
     required this.provider,
     required this.routeKey,
@@ -770,6 +909,7 @@ class FavoriteStop {
     this.routeId,
     this.routeName,
     this.stopName,
+    this.rawStopId,
     this.destinationPathId,
     this.destinationStopId,
     this.destinationStopName,
@@ -786,6 +926,9 @@ class FavoriteStop {
           : null,
       routeName: json['routeName'] as String?,
       stopName: json['stopName'] as String?,
+      rawStopId: (json['rawStopId'] as String?)?.trim().isNotEmpty == true
+          ? (json['rawStopId'] as String).trim()
+          : null,
       destinationPathId: (json['destinationPathId'] as num?)?.toInt(),
       destinationStopId: (json['destinationStopId'] as num?)?.toInt(),
       destinationStopName:
@@ -795,6 +938,7 @@ class FavoriteStop {
     );
   }
 
+  @override
   final BusProvider provider;
   final int routeKey;
   final int pathId;
@@ -802,14 +946,21 @@ class FavoriteStop {
   final String? routeId;
   final String? routeName;
   final String? stopName;
+  final String? rawStopId;
   final int? destinationPathId;
   final int? destinationStopId;
   final String? destinationStopName;
 
+  @override
+  FavoriteItemType get type => FavoriteItemType.boarding;
+
+  @override
   String get stableKey => '${provider.name}:$routeKey:$pathId:$stopId';
 
+  @override
   Map<String, dynamic> toJson() {
     return {
+      'type': type.name,
       'provider': provider.name,
       'routeKey': routeKey,
       'pathId': pathId,
@@ -817,6 +968,7 @@ class FavoriteStop {
       if (routeId != null) 'routeId': routeId,
       if (routeName != null) 'routeName': routeName,
       if (stopName != null) 'stopName': stopName,
+      if (rawStopId != null) 'rawStopId': rawStopId,
       if (destinationPathId != null) 'destinationPathId': destinationPathId,
       if (destinationStopId != null) 'destinationStopId': destinationStopId,
       if (destinationStopName != null)
@@ -824,8 +976,10 @@ class FavoriteStop {
     };
   }
 
-  bool sameAs(FavoriteStop other) {
-    return provider == other.provider &&
+  @override
+  bool sameAs(FavoriteItem other) {
+    return other is FavoriteStop &&
+        provider == other.provider &&
         routeKey == other.routeKey &&
         pathId == other.pathId &&
         stopId == other.stopId;
@@ -1475,8 +1629,7 @@ class StopInfo {
   /// The original TDX stop ID string (e.g. "306232"), when available. Unlike
   /// [stopId] — which is a hashed int used for compositing/deduplication — this
   /// preserves the value the backend needs for the stop passby endpoint. Null
-  /// for stops loaded from sources that don't carry it (e.g. persisted
-  /// favorites).
+  /// for sources that do not carry it, including legacy persisted favorites.
   final String? rawStopId;
 
   final int? sec;
@@ -1554,6 +1707,73 @@ class StopRouteSearchResult {
           : (nearestDistanceMeters ?? this.nearestDistanceMeters),
     );
   }
+}
+
+class StationPassbyData {
+  const StationPassbyData({
+    required this.provider,
+    required this.stationId,
+    required this.stationName,
+    required this.lat,
+    required this.lon,
+    required this.sides,
+    this.stationNameEn,
+  });
+
+  final BusProvider provider;
+  final String stationId;
+  final String stationName;
+  final String? stationNameEn;
+  final double lat;
+  final double lon;
+  final List<StationSideData> sides;
+
+  Iterable<StationRouteArrival> get routes =>
+      sides.expand((side) => side.routes);
+
+  StationRouteArrival? get nextArrival {
+    StationRouteArrival? best;
+    for (final arrival in routes) {
+      final seconds = arrival.result.matchedStop.sec;
+      if (seconds == null || seconds < 0) {
+        continue;
+      }
+      final bestSeconds = best?.result.matchedStop.sec;
+      if (bestSeconds == null || seconds < bestSeconds) {
+        best = arrival;
+      }
+    }
+    return best;
+  }
+}
+
+class StationSideData {
+  const StationSideData({
+    required this.sideId,
+    required this.label,
+    required this.stopUid,
+    required this.rawStopId,
+    required this.lat,
+    required this.lon,
+    required this.routes,
+    this.direction,
+  });
+
+  final String sideId;
+  final String label;
+  final String? direction;
+  final String stopUid;
+  final String rawStopId;
+  final double lat;
+  final double lon;
+  final List<StationRouteArrival> routes;
+}
+
+class StationRouteArrival {
+  const StationRouteArrival({required this.sideLabel, required this.result});
+
+  final String sideLabel;
+  final StopRouteSearchResult result;
 }
 
 class NearbyStopResult {

--- a/lib/core/stop_route_merge.dart
+++ b/lib/core/stop_route_merge.dart
@@ -1,0 +1,50 @@
+import 'models.dart';
+
+/// Identity of one route+direction entry in the related-stop-routes sheet.
+///
+/// TDX publishes a *different* StopID per route and direction at the same
+/// physical stop — 捷運南屯站(文心路) is 21746 for 綠3, 21884 for 73, 24080 for
+/// 302 — so the two sources that feed the sheet disagree about stop IDs by
+/// construction:
+///
+/// * The server passby endpoint stamps every route it returns with the
+///   *requested* StopID, because it resolved them all from that one ID.
+/// * The local name-based lookup carries each route's *own* StopID.
+///
+/// `routeId` + `pathId` is therefore the only pair that names the same entry in
+/// both, and both sources emit at most one result per pair.
+String stopRouteMergeKey(StopRouteSearchResult result) =>
+    '${result.route.routeId.trim()}:${result.matchedStop.pathId}';
+
+/// Combines the server passby results with the local name-based lookup.
+///
+/// Neither source is complete on its own: passby only covers the routes sharing
+/// the queried StopID (often just the route the user is already looking at),
+/// while the local lookup finds every sibling StopID but carries no realtime
+/// data. Merging keeps the ETA *and* the full route list.
+///
+/// Passby entries win on collision — they already hold this stop's ETA.
+/// [passbyKeys] names them so callers can skip the realtime fetch for those and
+/// only request live data for the locally-sourced remainder.
+({List<StopRouteSearchResult> results, Set<String> passbyKeys})
+mergeStopRouteResults({
+  required List<StopRouteSearchResult> passby,
+  required List<StopRouteSearchResult> local,
+}) {
+  final merged = <String, StopRouteSearchResult>{};
+  final passbyKeys = <String>{};
+
+  for (final result in passby) {
+    final key = stopRouteMergeKey(result);
+    passbyKeys.add(key);
+    merged.putIfAbsent(key, () => result);
+  }
+  for (final result in local) {
+    merged.putIfAbsent(stopRouteMergeKey(result), () => result);
+  }
+
+  return (
+    results: merged.values.toList(growable: false),
+    passbyKeys: passbyKeys,
+  );
+}

--- a/lib/core/storage_service.dart
+++ b/lib/core/storage_service.dart
@@ -12,6 +12,7 @@ class StorageService {
   static const _settingsKey = 'app_settings';
   static const _historyKey = 'search_history';
   static const _favoritesKey = 'favorite_groups';
+  static const _favoriteGroupKindsKey = 'favorite_group_kinds';
   static const _routeUsageProfilesKey = 'route_usage_profiles';
   static const _favoriteUsageProfilesKey = 'favorite_usage_profiles';
   static const _stopVisitProfilesKey = 'stop_visit_profiles';
@@ -92,7 +93,7 @@ class StorageService {
     );
   }
 
-  Future<Map<String, List<FavoriteStop>>> loadFavoriteGroups() async {
+  Future<Map<String, List<FavoriteItem>>> loadFavoriteGroups() async {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getString(_favoritesKey);
     if (raw == null || raw.isEmpty) {
@@ -107,14 +108,14 @@ class StorageService {
           (value as List<dynamic>)
               .whereType<Map>()
               .map(
-                (item) => FavoriteStop.fromJson(
+                (item) => FavoriteItem.fromJson(
                   item.map(
                     (itemKey, itemValue) =>
                         MapEntry(itemKey.toString(), itemValue),
                   ),
                 ),
               )
-              .where((item) => item.routeKey > 0 && item.stopId > 0)
+              .where(_isValidFavoriteItem)
               .toList(),
         ),
       );
@@ -124,7 +125,7 @@ class StorageService {
   }
 
   Future<void> saveFavoriteGroups(
-    Map<String, List<FavoriteStop>> favoriteGroups, {
+    Map<String, List<FavoriteItem>> favoriteGroups, {
     int? modifiedAtMs,
   }) async {
     final prefs = await SharedPreferences.getInstance();
@@ -136,6 +137,36 @@ class StorageService {
     await prefs.setInt(
       _favoritesLastModifiedAtKey,
       modifiedAtMs ?? DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
+  Future<Map<String, FavoriteGroupKind>> loadFavoriteGroupKinds(
+    Iterable<String> groupNames,
+  ) async {
+    final names = groupNames.toSet();
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_favoriteGroupKindsKey);
+    Map<String, dynamic> decoded = const {};
+    if (raw != null && raw.isNotEmpty) {
+      try {
+        decoded = jsonDecode(raw) as Map<String, dynamic>;
+      } catch (_) {
+        decoded = const {};
+      }
+    }
+    return {
+      for (final name in names)
+        name: FavoriteGroupKind.fromJson(decoded[name]),
+    };
+  }
+
+  Future<void> saveFavoriteGroupKinds(
+    Map<String, FavoriteGroupKind> groupKinds,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _favoriteGroupKindsKey,
+      jsonEncode(groupKinds.map((key, value) => MapEntry(key, value.name))),
     );
   }
 
@@ -309,3 +340,12 @@ class StorageService {
     return '$_accountSyncStateKeyPrefix:${accountId.trim()}';
   }
 }
+
+bool _isValidFavoriteItem(FavoriteItem item) => switch (item) {
+  FavoriteRoute(:final routeKey, :final routeId, :final routeName) =>
+    routeKey > 0 && routeId.isNotEmpty && routeName.isNotEmpty,
+  FavoriteStation(:final stationId, :final stationName) =>
+    stationId.isNotEmpty && stationName.isNotEmpty,
+  FavoriteStop(:final routeKey, :final stopId) => routeKey > 0 && stopId > 0,
+  _ => false,
+};

--- a/lib/screens/favorite_groups_screen.dart
+++ b/lib/screens/favorite_groups_screen.dart
@@ -1,23 +1,63 @@
 import 'package:flutter/material.dart';
 
 import '../app/bus_app.dart';
+import '../core/models.dart';
 
-class FavoriteGroupsScreen extends StatelessWidget {
-  const FavoriteGroupsScreen({super.key});
+class FavoriteGroupDraft {
+  const FavoriteGroupDraft({required this.name, required this.kind});
 
-  Future<void> _showAddGroupDialog(BuildContext context) async {
-    final controller = AppControllerScope.read(context);
-    final textController = TextEditingController();
+  final String name;
+  final FavoriteGroupKind kind;
+}
 
-    final name = await showDialog<String>(
-      context: context,
-      builder: (context) {
+Future<FavoriteGroupDraft?> showFavoriteGroupDialog(
+  BuildContext context, {
+  FavoriteGroupKind initialKind = FavoriteGroupKind.boarding,
+  FavoriteItemType? compatibleItemType,
+}) async {
+  final textController = TextEditingController();
+  var selectedKind = initialKind;
+  final selectableKinds = compatibleItemType == null
+      ? FavoriteGroupKind.values
+      : FavoriteGroupKind.values
+            .where((kind) => kind.acceptsType(compatibleItemType))
+            .toList(growable: false);
+  final result = await showDialog<FavoriteGroupDraft>(
+    context: context,
+    builder: (context) => StatefulBuilder(
+      builder: (context, setState) {
         return AlertDialog(
           title: const Text('新增群組'),
-          content: TextField(
-            controller: textController,
-            autofocus: true,
-            decoration: const InputDecoration(hintText: '例如：回家'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: textController,
+                autofocus: true,
+                decoration: const InputDecoration(
+                  labelText: '群組名稱',
+                  hintText: '例如：回家',
+                ),
+              ),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<FavoriteGroupKind>(
+                initialValue: selectedKind,
+                decoration: const InputDecoration(labelText: '收藏類別'),
+                items: selectableKinds
+                    .map(
+                      (kind) => DropdownMenuItem(
+                        value: kind,
+                        child: Text(kind.label),
+                      ),
+                    )
+                    .toList(growable: false),
+                onChanged: (kind) {
+                  if (kind != null) {
+                    setState(() => selectedKind = kind);
+                  }
+                },
+              ),
+            ],
           ),
           actions: [
             TextButton(
@@ -25,20 +65,44 @@ class FavoriteGroupsScreen extends StatelessWidget {
               child: const Text('取消'),
             ),
             FilledButton(
-              onPressed: () => Navigator.of(context).pop(textController.text),
+              onPressed: () {
+                final name = textController.text.trim();
+                if (name.isEmpty) {
+                  return;
+                }
+                Navigator.of(
+                  context,
+                ).pop(FavoriteGroupDraft(name: name, kind: selectedKind));
+              },
               child: const Text('新增'),
             ),
           ],
         );
       },
-    );
+    ),
+  );
+  textController.dispose();
+  return result;
+}
 
-    textController.dispose();
-    if (name == null || name.trim().isEmpty) {
+class FavoriteGroupsScreen extends StatelessWidget {
+  const FavoriteGroupsScreen({super.key});
+
+  Future<void> _showAddGroupDialog(BuildContext context) async {
+    final controller = AppControllerScope.read(context);
+    final draft = await showFavoriteGroupDialog(context);
+    if (draft == null) {
       return;
     }
-
-    await controller.addFavoriteGroup(name);
+    if (controller.favoriteGroups.containsKey(draft.name)) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('已有相同名稱的收藏群組。')));
+      }
+      return;
+    }
+    await controller.addFavoriteGroup(draft.name, kind: draft.kind);
   }
 
   @override
@@ -65,6 +129,7 @@ class FavoriteGroupsScreen extends StatelessWidget {
               itemBuilder: (context, index) {
                 final group = groups[index];
                 final count = controller.favoriteGroups[group]?.length ?? 0;
+                final kind = controller.favoriteGroupKind(group);
                 return Dismissible(
                   key: ValueKey(group),
                   direction: DismissDirection.endToStart,
@@ -108,7 +173,7 @@ class FavoriteGroupsScreen extends StatelessWidget {
                   child: Card(
                     child: ListTile(
                       title: Text(group),
-                      subtitle: Text('$count 個站牌'),
+                      subtitle: Text('${kind.label} · $count 個收藏'),
                     ),
                   ),
                 );

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/material.dart';
 
 import '../app/bus_app.dart';
 import '../core/app_controller.dart';
+import '../core/app_routes.dart';
 import '../core/haptic_feedback_service.dart';
 import '../core/app_route_observer.dart';
 import '../core/bus_repository.dart';
@@ -31,6 +33,7 @@ class _FavoritesScreenState extends State<FavoritesScreen>
   late final AnimationController _countdownProgressController;
   ModalRoute<dynamic>? _route;
   List<FavoriteResolvedItem> _items = const [];
+  Map<String, StationPassbyData> _stationDataByKey = const {};
   bool _isLoading = false;
   bool _isRouteVisible = true;
   String? _error;
@@ -89,6 +92,7 @@ class _FavoritesScreenState extends State<FavoritesScreen>
         ..stop()
         ..value = 0;
       _items = const [];
+      _stationDataByKey = const {};
       _isLoading = false;
       _error = null;
       _statusMessage = null;
@@ -141,18 +145,8 @@ class _FavoritesScreenState extends State<FavoritesScreen>
     return groups[index];
   }
 
-  String _favoritesSignature(List<FavoriteStop> favorites) {
-    return favorites
-        .map(
-          (favorite) =>
-              '${favorite.provider.name}:'
-              '${favorite.routeKey}:'
-              '${favorite.pathId}:'
-              '${favorite.stopId}:'
-              '${favorite.destinationPathId ?? 0}:'
-              '${favorite.destinationStopId ?? 0}',
-        )
-        .join('|');
+  String _favoritesSignature(List<FavoriteItem> favorites) {
+    return favorites.map((favorite) => jsonEncode(favorite.toJson())).join('|');
   }
 
   String _favoriteItemKey(FavoriteStop favorite) {
@@ -294,6 +288,22 @@ class _FavoritesScreenState extends State<FavoritesScreen>
       final baseItems = shouldResolveStatic
           ? await controller.resolveFavoriteGroup(groupName)
           : _items;
+      final stationEntries = await Future.wait(
+        references.whereType<FavoriteStation>().map((favorite) async {
+          try {
+            final station = await controller.repository.getStationPassby(
+              favorite.stationId,
+              provider: favorite.provider,
+            );
+            return MapEntry(favorite.stableKey, station);
+          } catch (_) {
+            return MapEntry<String, StationPassbyData?>(
+              favorite.stableKey,
+              null,
+            );
+          }
+        }),
+      );
 
       if (!mounted || requestId != _refreshRequestId) {
         return;
@@ -410,21 +420,38 @@ class _FavoritesScreenState extends State<FavoritesScreen>
         return item;
       }).toList();
 
-      final allRoutesFailed =
-          uniqueRoutes.isNotEmpty && failedRouteCount == uniqueRoutes.length;
-      final hasAnyLiveData = liveRouteCount > 0;
-      final nextStatusMessage = allRoutesFailed
+      final resolvedStationData = {
+        for (final entry in stationEntries)
+          if (entry.value != null)
+            entry.key: entry.value!
+          else if (_stationDataByKey[entry.key] != null)
+            entry.key: _stationDataByKey[entry.key]!,
+      };
+      final failedStationCount =
+          stationEntries.length - resolvedStationData.length;
+      final hasStationLiveData = resolvedStationData.values.any(
+        (station) => station.nextArrival != null,
+      );
+      final refreshRequestCount = uniqueRoutes.length + stationEntries.length;
+      final failedRequestCount = failedRouteCount + failedStationCount;
+      final allRequestsFailed =
+          refreshRequestCount > 0 && failedRequestCount == refreshRequestCount;
+      final hasAnyLiveData = liveRouteCount > 0 || hasStationLiveData;
+      final nextStatusMessage = allRequestsFailed
           ? '即時資訊更新失敗'
+          : refreshRequestCount == 0
+          ? null
           : !hasAnyLiveData
           ? '目前沒有可用的即時資訊'
-          : failedRouteCount > 0
-          ? '部分路線更新失敗'
+          : failedRequestCount > 0
+          ? '部分即時資訊更新失敗'
           : null;
 
       setState(() {
         _loadedGroupName = groupName;
         _loadedSignature = signature;
         _items = enrichedItems;
+        _stationDataByKey = resolvedStationData;
         _isLoading = false;
         _error = null;
         _statusMessage = nextStatusMessage;
@@ -500,26 +527,299 @@ class _FavoritesScreenState extends State<FavoritesScreen>
     return null;
   }
 
-  Future<void> _removeFavorite(
+  Future<void> _removeFavoriteItem(
     AppController controller,
     String groupName,
-    FavoriteResolvedItem item,
+    FavoriteItem item,
+    String label,
   ) async {
     setState(() {
-      _items = _items
-          .where((entry) => !entry.reference.sameAs(item.reference))
-          .toList();
+      if (item is FavoriteStop) {
+        _items = _items
+            .where((entry) => !entry.reference.sameAs(item))
+            .toList();
+      } else if (item is FavoriteStation) {
+        _stationDataByKey = Map<String, StationPassbyData>.from(
+          _stationDataByKey,
+        )..remove(item.stableKey);
+      }
     });
 
-    await controller.removeFavoriteStop(groupName, item.reference);
+    await controller.removeFavoriteItem(groupName, item);
     if (!mounted) {
       return;
     }
     unawaited(AppHaptics.lightImpact());
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('已從 $groupName 移除 ${item.stop.stopName}')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('已從 $groupName 移除 $label')));
     _scheduleRefresh(forceResolveStatic: true);
+  }
+
+  Widget _buildDismissibleFavorite({
+    required BuildContext context,
+    required FavoriteItem favorite,
+    required VoidCallback onDismissed,
+    required Widget child,
+  }) {
+    return Dismissible(
+      key: ValueKey('favorite-${favorite.stableKey}'),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 20),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.errorContainer,
+          borderRadius: BorderRadius.circular(24),
+        ),
+        child: Icon(
+          Icons.delete_outline_rounded,
+          color: Theme.of(context).colorScheme.onErrorContainer,
+        ),
+      ),
+      onDismissed: (_) => onDismissed(),
+      child: child,
+    );
+  }
+
+  Widget _buildFavoriteTypeBadge(BuildContext context, FavoriteItemType type) {
+    final label = switch (type) {
+      FavoriteItemType.route => '路線',
+      FavoriteItemType.station => '站牌',
+      FavoriteItemType.boarding => '乘車點',
+    };
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: colorScheme.onSecondaryContainer,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRouteFavoriteCard(
+    BuildContext context,
+    AppController controller,
+    String groupName,
+    FavoriteRoute favorite,
+  ) {
+    final showTypeBadge =
+        controller.favoriteGroupKind(groupName) == FavoriteGroupKind.mixed;
+    final description = favorite.routeDescription?.trim();
+    return _buildDismissibleFavorite(
+      context: context,
+      favorite: favorite,
+      onDismissed: () => unawaited(
+        _removeFavoriteItem(
+          controller,
+          groupName,
+          favorite,
+          favorite.routeName,
+        ),
+      ),
+      child: Card(
+        child: ListTile(
+          contentPadding: const EdgeInsets.all(14),
+          leading: CircleAvatar(
+            child: Text(
+              favorite.routeName.characters.take(2).toString(),
+              style: const TextStyle(fontWeight: FontWeight.w700),
+            ),
+          ),
+          title: Text(
+            favorite.routeName,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.primary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          subtitle: Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (showTypeBadge) ...[
+                  _buildFavoriteTypeBadge(context, FavoriteItemType.route),
+                  const SizedBox(height: 5),
+                ],
+                Text(
+                  '${favorite.provider.label}${description?.isNotEmpty == true ? " · $description" : ""}',
+                ),
+              ],
+            ),
+          ),
+          trailing: const Icon(Icons.chevron_right_rounded),
+          onTap: () async {
+            unawaited(AppHaptics.selectionClick());
+            await controller.recordRouteSelection(
+              provider: favorite.provider,
+              routeKey: favorite.routeKey,
+              routeName: favorite.routeName,
+              source: 'favorite_route',
+            );
+            if (!context.mounted) return;
+            await openRouteDetailPage(
+              context,
+              routeKey: favorite.routeKey,
+              provider: favorite.provider,
+              routeIdHint: favorite.routeId,
+              routeNameHint: favorite.routeName,
+              suppressAutoDestinationSelection: true,
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStationFavoriteCard(
+    BuildContext context,
+    AppController controller,
+    String groupName,
+    FavoriteStation favorite,
+  ) {
+    final station = _stationDataByKey[favorite.stableKey];
+    final nextArrival = station?.nextArrival;
+    final route = nextArrival?.result.route;
+    final stop = nextArrival?.result.matchedStop;
+    final showTypeBadge =
+        controller.favoriteGroupKind(groupName) == FavoriteGroupKind.mixed;
+    final statusText = nextArrival == null
+        ? '${favorite.provider.label} · 目前沒有即將抵達班次'
+        : '${favorite.provider.label} · ${route!.routeName} · ${nextArrival.sideLabel} 側';
+    return _buildDismissibleFavorite(
+      context: context,
+      favorite: favorite,
+      onDismissed: () => unawaited(
+        _removeFavoriteItem(
+          controller,
+          groupName,
+          favorite,
+          favorite.stationName,
+        ),
+      ),
+      child: Card(
+        child: ListTile(
+          contentPadding: const EdgeInsets.all(14),
+          leading: stop == null
+              ? const SizedBox(
+                  width: 52,
+                  height: 52,
+                  child: Icon(Icons.directions_bus_filled_rounded, size: 30),
+                )
+              : EtaBadge(
+                  stop: stop,
+                  alwaysShowSeconds: controller.settings.alwaysShowSeconds,
+                  size: 52,
+                ),
+          title: Text(favorite.stationName),
+          subtitle: Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (showTypeBadge) ...[
+                  _buildFavoriteTypeBadge(context, FavoriteItemType.station),
+                  const SizedBox(height: 5),
+                ],
+                Text(statusText),
+              ],
+            ),
+          ),
+          trailing: const Icon(Icons.chevron_right_rounded),
+          onTap: () {
+            unawaited(AppHaptics.selectionClick());
+            Navigator.of(context).pushNamed(
+              AppRoutes.stationDetailPath(
+                provider: favorite.provider,
+                stationId: favorite.stationId,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildUnresolvedBoardingCard(
+    BuildContext context,
+    AppController controller,
+    String groupName,
+    FavoriteStop favorite,
+  ) {
+    final routeName = favorite.routeName?.trim().isNotEmpty == true
+        ? favorite.routeName!.trim()
+        : '路線 ${favorite.routeKey}';
+    final stopName = favorite.stopName?.trim().isNotEmpty == true
+        ? favorite.stopName!.trim()
+        : '站牌 ${favorite.stopId}';
+    final showTypeBadge =
+        controller.favoriteGroupKind(groupName) == FavoriteGroupKind.mixed;
+    return _buildDismissibleFavorite(
+      context: context,
+      favorite: favorite,
+      onDismissed: () => unawaited(
+        _removeFavoriteItem(controller, groupName, favorite, stopName),
+      ),
+      child: Card(
+        child: ListTile(
+          contentPadding: const EdgeInsets.all(14),
+          leading: const SizedBox(
+            width: 52,
+            height: 52,
+            child: Icon(Icons.schedule_rounded, size: 30),
+          ),
+          title: RichText(
+            text: TextSpan(
+              style: Theme.of(context).textTheme.titleMedium,
+              children: [
+                TextSpan(
+                  text: '$routeName ',
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.primary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                TextSpan(text: stopName),
+              ],
+            ),
+          ),
+          subtitle: Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (showTypeBadge) ...[
+                  _buildFavoriteTypeBadge(context, FavoriteItemType.boarding),
+                  const SizedBox(height: 5),
+                ],
+                Text('${favorite.provider.label} · 正在取得即時資訊'),
+              ],
+            ),
+          ),
+          trailing: const Icon(Icons.chevron_right_rounded),
+          onTap: () => openRouteDetailPage(
+            context,
+            routeKey: favorite.routeKey,
+            provider: favorite.provider,
+            routeIdHint: favorite.routeId,
+            routeNameHint: favorite.routeName,
+            initialPathId: favorite.pathId,
+            initialStopId: favorite.stopId,
+            initialDestinationPathId: favorite.destinationPathId,
+            initialDestinationStopId: favorite.destinationStopId,
+          ),
+        ),
+      ),
+    );
   }
 
   Future<void> _handleFavoriteDestinationAction(
@@ -629,6 +929,9 @@ class _FavoritesScreenState extends State<FavoritesScreen>
     final displayItems = currentGroupName == _loadedGroupName
         ? _items
         : const <FavoriteResolvedItem>[];
+    final references = currentGroupName == null
+        ? const <FavoriteItem>[]
+        : controller.favoritesInGroup(currentGroupName);
     final hasFavoritesBackgroundImage = hasBackgroundImageForPage(
       controller.settings,
       pageKey: 'favorites',
@@ -699,6 +1002,7 @@ class _FavoritesScreenState extends State<FavoritesScreen>
                 context,
                 controller,
                 currentGroupName: currentGroupName!,
+                references: references,
                 items: displayItems,
               ),
       ),
@@ -709,9 +1013,10 @@ class _FavoritesScreenState extends State<FavoritesScreen>
     BuildContext context,
     AppController controller, {
     required String currentGroupName,
+    required List<FavoriteItem> references,
     required List<FavoriteResolvedItem> items,
   }) {
-    if (_error != null && items.isEmpty) {
+    if (_error != null && references.isEmpty) {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
@@ -726,20 +1031,52 @@ class _FavoritesScreenState extends State<FavoritesScreen>
       );
     }
 
-    if (_isLoading && items.isEmpty) {
+    if (_isLoading && references.isEmpty) {
       return const Center(child: CircularProgressIndicator());
     }
 
-    if (items.isEmpty) {
-      return const _EmptyFavoritesState(message: '這個群組目前沒有站牌。');
+    if (references.isEmpty) {
+      return const _EmptyFavoritesState(message: '這個群組目前沒有收藏。');
     }
+
+    final resolvedByKey = {
+      for (final item in items) item.reference.stableKey: item,
+    };
 
     return ListView.separated(
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
-      itemCount: items.length,
+      itemCount: references.length,
       separatorBuilder: (_, _) => const SizedBox(height: 10),
       itemBuilder: (context, index) {
-        final item = items[index];
+        final reference = references[index];
+        if (reference is FavoriteRoute) {
+          return _buildRouteFavoriteCard(
+            context,
+            controller,
+            currentGroupName,
+            reference,
+          );
+        }
+        if (reference is FavoriteStation) {
+          return _buildStationFavoriteCard(
+            context,
+            controller,
+            currentGroupName,
+            reference,
+          );
+        }
+        if (reference is! FavoriteStop) {
+          return const SizedBox.shrink();
+        }
+        final item = resolvedByKey[reference.stableKey];
+        if (item == null) {
+          return _buildUnresolvedBoardingCard(
+            context,
+            controller,
+            currentGroupName,
+            reference,
+          );
+        }
         final destinationSummary =
             item.reference.destinationStopName?.trim().isNotEmpty == true
             ? item.reference.destinationStopName!.trim()
@@ -761,8 +1098,14 @@ class _FavoritesScreenState extends State<FavoritesScreen>
               color: Theme.of(context).colorScheme.onErrorContainer,
             ),
           ),
-          onDismissed: (_) =>
-              unawaited(_removeFavorite(controller, currentGroupName, item)),
+          onDismissed: (_) => unawaited(
+            _removeFavoriteItem(
+              controller,
+              currentGroupName,
+              item.reference,
+              item.stop.stopName,
+            ),
+          ),
           child: Card(
             child: ListTile(
               contentPadding: const EdgeInsets.all(14),
@@ -788,10 +1131,23 @@ class _FavoritesScreenState extends State<FavoritesScreen>
               ),
               subtitle: Padding(
                 padding: const EdgeInsets.only(top: 6),
-                child: Text(
-                  '${item.reference.provider.label} · '
-                  '${item.route.description.isEmpty ? "routeKey ${item.route.routeKey}" : item.route.description}'
-                  '${destinationSummary == null ? "" : "\n目的地：$destinationSummary"}',
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (controller.favoriteGroupKind(currentGroupName) ==
+                        FavoriteGroupKind.mixed) ...[
+                      _buildFavoriteTypeBadge(
+                        context,
+                        FavoriteItemType.boarding,
+                      ),
+                      const SizedBox(height: 5),
+                    ],
+                    Text(
+                      '${item.reference.provider.label} · '
+                      '${item.route.description.isEmpty ? "routeKey ${item.route.routeKey}" : item.route.description}'
+                      '${destinationSummary == null ? "" : "\n目的地：$destinationSummary"}',
+                    ),
+                  ],
                 ),
               ),
               trailing: controller.settings.enableRouteBackgroundMonitor

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -585,8 +585,8 @@ class _FavoritesScreenState extends State<FavoritesScreen>
   Widget _buildFavoriteTypeBadge(BuildContext context, FavoriteItemType type) {
     final label = switch (type) {
       FavoriteItemType.route => '路線',
-      FavoriteItemType.station => '站牌',
-      FavoriteItemType.boarding => '乘車點',
+      FavoriteItemType.station => '整站',
+      FavoriteItemType.boarding => '站牌',
     };
     final colorScheme = Theme.of(context).colorScheme;
     return Container(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -817,26 +817,23 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
     );
   }
 
-  /// Keep the route, stop and ETA visible in the first row. Secondary details
-  /// live below instead of competing for horizontal space on narrow phones.
+  /// ETA is the leading element when available. Route, stop and secondary
+  /// details stay in one vertical text block so narrow phones do not overflow.
   Widget _buildSmartTileRow({
     required BuildContext context,
     required IconData leadingIcon,
     required String title,
     String? stopName,
     List<String> metadata = const [],
-    required Widget etaBadge,
+    Widget? etaBadge,
   }) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
+    return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
+        etaBadge ??
             Container(
               width: 56,
               height: 56,
@@ -847,77 +844,55 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
               ),
               child: Icon(leadingIcon, color: colorScheme.onPrimaryContainer),
             ),
-            const SizedBox(width: 14),
-            Expanded(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: theme.textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.w700,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  if (stopName != null) ...[
-                    const SizedBox(height: 4),
-                    Text(
-                      stopName,
-                      style: theme.textTheme.bodyMedium,
-                      maxLines: 1,
+        const SizedBox(width: 14),
+        Expanded(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              if (stopName != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  stopName,
+                  style: theme.textTheme.bodyMedium,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+              if (metadata.isNotEmpty) ...[
+                const SizedBox(height: 6),
+                for (final line in metadata)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 3),
+                    child: Text(
+                      line,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                      maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                     ),
-                  ],
-                ],
-              ),
-            ),
-            const SizedBox(width: 12),
-            etaBadge,
-          ],
-        ),
-        if (metadata.isNotEmpty) ...[
-          const SizedBox(height: 12),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    for (final line in metadata)
-                      Padding(
-                        padding: const EdgeInsets.only(bottom: 3),
-                        child: Text(
-                          line,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-              const SizedBox(width: 8),
-              Icon(
-                Icons.chevron_right_rounded,
-                color: colorScheme.onSurfaceVariant,
-              ),
+                  ),
+              ],
             ],
           ),
-        ] else ...[
-          const SizedBox(height: 8),
-          Align(
-            alignment: Alignment.centerRight,
-            child: Icon(
-              Icons.chevron_right_rounded,
-              color: colorScheme.onSurfaceVariant,
-            ),
+        ),
+        const SizedBox(width: 8),
+        Padding(
+          padding: const EdgeInsets.only(top: 16),
+          child: Icon(
+            Icons.chevron_right_rounded,
+            color: colorScheme.onSurfaceVariant,
           ),
-        ],
+        ),
       ],
     );
   }
@@ -944,14 +919,13 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
       if (destinationLabel != null) '目的地：$destinationLabel',
       if (showDistance) '距離你約 ${formatDistance(suggestion.distanceMeters!)}',
     ];
-    const badgeSize = 64.0;
     final etaBadge = recommendedStop != null
         ? EtaBadge(
             stop: recommendedStop,
             alwaysShowSeconds: controller.settings.alwaysShowSeconds,
-            size: badgeSize,
+            size: 64,
           )
-        : SizedBox(width: badgeSize, height: badgeSize);
+        : null;
 
     return _buildRouteTile(
       context: context,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -817,114 +817,9 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
     );
   }
 
-  /// A wide row that fills the card's width in three balanced zones instead
-  /// of one big left text block floating next to a lone badge on the right:
-  /// leading icon | title + stop name | metadata | ETA badge + chevron.
+  /// Keep the route, stop and ETA visible in the first row. Secondary details
+  /// live below instead of competing for horizontal space on narrow phones.
   Widget _buildSmartTileRow({
-    required BuildContext context,
-    required IconData leadingIcon,
-    required String title,
-    String? stopName,
-    List<String> metadata = const [],
-    required Widget etaBadge,
-  }) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        Container(
-          width: 56,
-          height: 56,
-          alignment: Alignment.center,
-          decoration: BoxDecoration(
-            color: colorScheme.primaryContainer,
-            borderRadius: BorderRadius.circular(18),
-          ),
-          child: Icon(leadingIcon, color: colorScheme.onPrimaryContainer),
-        ),
-        const SizedBox(width: 14),
-        ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 220),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                title,
-                style: theme.textTheme.titleLarge?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              if (stopName != null) ...[
-                const SizedBox(height: 4),
-                Text(
-                  stopName,
-                  style: theme.textTheme.bodyMedium,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ],
-          ),
-        ),
-        if (metadata.isNotEmpty) ...[
-          const SizedBox(width: 14),
-          SizedBox(
-            height: 56,
-            child: VerticalDivider(
-              width: 1,
-              color: colorScheme.outlineVariant,
-            ),
-          ),
-          const SizedBox(width: 14),
-          ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 140),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                for (final line in metadata)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 3),
-                    child: Text(
-                      line,
-                      textAlign: TextAlign.right,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-              ],
-            ),
-          ),
-        ],
-        const SizedBox(width: 16),
-        Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            etaBadge,
-            const SizedBox(height: 10),
-            Icon(
-              Icons.chevron_right_rounded,
-              color: colorScheme.onSurfaceVariant,
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-
-  /// A compact, vertically-stacked card for when several recommendations sit
-  /// side by side: icon + ETA badge on top, then title/stop/metadata, then a
-  /// chevron pinned to the bottom-right corner.
-  Widget _buildSmartTileCard({
     required BuildContext context,
     required IconData leadingIcon,
     required String title,
@@ -940,73 +835,97 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Container(
-              width: 40,
-              height: 40,
+              width: 56,
+              height: 56,
               alignment: Alignment.center,
               decoration: BoxDecoration(
                 color: colorScheme.primaryContainer,
-                borderRadius: BorderRadius.circular(14),
+                borderRadius: BorderRadius.circular(18),
               ),
-              child: Icon(
-                leadingIcon,
-                size: 20,
-                color: colorScheme.onPrimaryContainer,
+              child: Icon(leadingIcon, color: colorScheme.onPrimaryContainer),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (stopName != null) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      stopName,
+                      style: theme.textTheme.bodyMedium,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ],
               ),
             ),
-            const Spacer(),
+            const SizedBox(width: 12),
             etaBadge,
           ],
         ),
-        const SizedBox(height: 12),
-        Text(
-          title,
-          style: theme.textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.w700,
-          ),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
-        if (stopName != null) ...[
-          const SizedBox(height: 4),
-          Text(
-            stopName,
-            style: theme.textTheme.bodySmall,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ],
         if (metadata.isNotEmpty) ...[
-          const SizedBox(height: 4),
-          Text(
-            metadata.first,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: colorScheme.onSurfaceVariant,
-            ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
+          const SizedBox(height: 12),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    for (final line in metadata)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 3),
+                        child: Text(
+                          line,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ],
           ),
-        ],
-        const SizedBox(height: 10),
-        Row(
-          children: [
-            const Spacer(),
-            Icon(
+        ] else ...[
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: Icon(
               Icons.chevron_right_rounded,
               color: colorScheme.onSurfaceVariant,
             ),
-          ],
-        ),
+          ),
+        ],
       ],
     );
   }
 
   Widget _buildSuggestionTile(
     BuildContext context,
-    SmartRouteSuggestion suggestion, {
-    bool compact = false,
-  }) {
+    SmartRouteSuggestion suggestion,
+  ) {
     final controller = widget.controller;
     final recommendedStop = suggestion.recommendedStop;
     final favorite = suggestion.favorite;
@@ -1025,7 +944,7 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
       if (destinationLabel != null) '目的地：$destinationLabel',
       if (showDistance) '距離你約 ${formatDistance(suggestion.distanceMeters!)}',
     ];
-    final badgeSize = compact ? 44.0 : 64.0;
+    const badgeSize = 64.0;
     final etaBadge = recommendedStop != null
         ? EtaBadge(
             stop: recommendedStop,
@@ -1037,23 +956,51 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
     return _buildRouteTile(
       context: context,
       onTap: () => _openSuggestion(suggestion),
-      child: compact
-          ? _buildSmartTileCard(
-              context: context,
-              leadingIcon: leadingIcon,
-              title: suggestion.profile.routeName,
-              stopName: recommendedStop?.stopName,
-              metadata: metadata,
-              etaBadge: etaBadge,
-            )
-          : _buildSmartTileRow(
-              context: context,
-              leadingIcon: leadingIcon,
-              title: suggestion.profile.routeName,
-              stopName: recommendedStop?.stopName,
-              metadata: metadata,
-              etaBadge: etaBadge,
+      child: _buildSmartTileRow(
+        context: context,
+        leadingIcon: leadingIcon,
+        title: suggestion.profile.routeName,
+        stopName: recommendedStop?.stopName,
+        metadata: metadata,
+        etaBadge: etaBadge,
+      ),
+    );
+  }
+
+  Widget _buildResponsiveTileList(List<Widget> tiles) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const spacing = 12.0;
+        const minimumTileWidth = 320.0;
+        final horizontal =
+            tiles.length > 1 &&
+            constraints.maxWidth >=
+                (tiles.length * minimumTileWidth) +
+                    ((tiles.length - 1) * spacing);
+
+        if (horizontal) {
+          return IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (var i = 0; i < tiles.length; i++) ...[
+                  if (i > 0) const SizedBox(width: spacing),
+                  Expanded(child: tiles[i]),
+                ],
+              ],
             ),
+          );
+        }
+
+        return Column(
+          children: [
+            for (var i = 0; i < tiles.length; i++) ...[
+              if (i > 0) const SizedBox(height: spacing),
+              tiles[i],
+            ],
+          ],
+        );
+      },
     );
   }
 
@@ -1061,8 +1008,7 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
     BuildContext context,
     List<SmartRouteSuggestion> suggestions,
   ) {
-    final horizontal = suggestions.length > 1;
-    final subtitle = horizontal
+    final subtitle = suggestions.length > 1
         ? '根據你的使用習慣，整理出你現在最可能要查的路線。'
         : suggestions.first.reason;
 
@@ -1074,40 +1020,24 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
         onPressed: _refresh,
         icon: const Icon(Icons.refresh_rounded),
       ),
-      child: horizontal
-          ? IntrinsicHeight(
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  for (var i = 0; i < suggestions.length; i++) ...[
-                    if (i > 0) const SizedBox(width: 12),
-                    Expanded(
-                      child: _buildSuggestionTile(
-                        context,
-                        suggestions[i],
-                        compact: true,
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            )
-          : _buildSuggestionTile(context, suggestions.first),
+      child: _buildResponsiveTileList([
+        for (final suggestion in suggestions)
+          _buildSuggestionTile(context, suggestion),
+      ]),
     );
   }
 
   Widget _buildNearbyFallbackTile(
     BuildContext context,
-    _NearbyFallbackData nearby, {
-    bool compact = false,
-  }) {
+    _NearbyFallbackData nearby,
+  ) {
     final controller = widget.controller;
     final stop = nearby.liveStop ?? nearby.result.stop;
     final metadata = [
       '距離你約 ${formatDistance(nearby.result.distanceMeters)}',
       if (nearby.path != null) '方向：${nearby.path!.name}',
     ];
-    final badgeSize = compact ? 44.0 : 64.0;
+    const badgeSize = 64.0;
     final etaBadge = EtaBadge(
       stop: stop,
       alwaysShowSeconds: controller.settings.alwaysShowSeconds,
@@ -1117,23 +1047,14 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
     return _buildRouteTile(
       context: context,
       onTap: () => _openNearbyFallback(nearby),
-      child: compact
-          ? _buildSmartTileCard(
-              context: context,
-              leadingIcon: Icons.directions_bus_filled_rounded,
-              title: nearby.result.route.routeName,
-              stopName: nearby.result.stop.stopName,
-              metadata: metadata,
-              etaBadge: etaBadge,
-            )
-          : _buildSmartTileRow(
-              context: context,
-              leadingIcon: Icons.directions_bus_filled_rounded,
-              title: nearby.result.route.routeName,
-              stopName: nearby.result.stop.stopName,
-              metadata: metadata,
-              etaBadge: etaBadge,
-            ),
+      child: _buildSmartTileRow(
+        context: context,
+        leadingIcon: Icons.directions_bus_filled_rounded,
+        title: nearby.result.route.routeName,
+        stopName: nearby.result.stop.stopName,
+        metadata: metadata,
+        etaBadge: etaBadge,
+      ),
     );
   }
 
@@ -1141,8 +1062,6 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
     BuildContext context,
     List<_NearbyFallbackData> nearbyList,
   ) {
-    final horizontal = nearbyList.length > 1;
-
     return _SmartRecommendationShell(
       title: '智慧推薦',
       subtitle: '最近的站點。',
@@ -1151,25 +1070,10 @@ class _SmartRecommendationCardState extends State<_SmartRecommendationCard> {
         onPressed: _refresh,
         icon: const Icon(Icons.refresh_rounded),
       ),
-      child: horizontal
-          ? IntrinsicHeight(
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  for (var i = 0; i < nearbyList.length; i++) ...[
-                    if (i > 0) const SizedBox(width: 12),
-                    Expanded(
-                      child: _buildNearbyFallbackTile(
-                        context,
-                        nearbyList[i],
-                        compact: true,
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            )
-          : _buildNearbyFallbackTile(context, nearbyList.first),
+      child: _buildResponsiveTileList([
+        for (final nearby in nearbyList)
+          _buildNearbyFallbackTile(context, nearby),
+      ]),
     );
   }
 

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -31,6 +31,7 @@ import '../widgets/cat_state_card.dart';
 import '../widgets/eta_badge.dart';
 import '../widgets/route_bus_map_sheet.dart';
 import '../widgets/ad_banner_widget.dart';
+import 'favorite_groups_screen.dart';
 
 class RouteDetailScreen extends StatefulWidget {
   const RouteDetailScreen({
@@ -3347,8 +3348,14 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           title: Text(stop.stopName),
           children: [
             SimpleDialogOption(
-              onPressed: () => Navigator.of(context).pop(_StopAction.favorite),
-              child: const Text('加入最愛'),
+              onPressed: () =>
+                  Navigator.of(context).pop(_StopAction.favoriteStation),
+              child: const Text('收藏此站牌'),
+            ),
+            SimpleDialogOption(
+              onPressed: () =>
+                  Navigator.of(context).pop(_StopAction.favoriteBoarding),
+              child: const Text('收藏此乘車點'),
             ),
             SimpleDialogOption(
               onPressed: () => Navigator.of(context).pop(),
@@ -3362,29 +3369,150 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       return;
     }
 
-    if (action == _StopAction.favorite) {
+    if (action == _StopAction.favoriteStation) {
+      await _handleStationFavorite(stop);
+    } else if (action == _StopAction.favoriteBoarding) {
       await _handleFavorite(stop);
     }
   }
 
+  Future<String?> _selectFavoriteGroup(FavoriteItemType itemType) async {
+    final controller = AppControllerScope.read(context);
+    final compatible = controller.compatibleFavoriteGroupNames(itemType);
+    String? selected;
+    if (compatible.isEmpty) {
+      selected = '__new__';
+    } else if (compatible.length == 1) {
+      selected = compatible.single;
+    } else {
+      selected = await _showGroupPicker(compatible);
+    }
+    if (!mounted || selected == null) {
+      return null;
+    }
+    if (selected != '__new__') {
+      return selected;
+    }
+
+    final draft = await showFavoriteGroupDialog(
+      context,
+      initialKind: switch (itemType) {
+        FavoriteItemType.route => FavoriteGroupKind.route,
+        FavoriteItemType.station => FavoriteGroupKind.station,
+        FavoriteItemType.boarding => FavoriteGroupKind.boarding,
+      },
+      compatibleItemType: itemType,
+    );
+    if (!mounted || draft == null) {
+      return null;
+    }
+    if (controller.favoriteGroups.containsKey(draft.name)) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('已有相同名稱的收藏群組。')));
+      return null;
+    }
+    await controller.addFavoriteGroup(draft.name, kind: draft.kind);
+    return draft.name;
+  }
+
+  Future<void> _handleRouteFavorite() async {
+    final route = _detail?.route;
+    if (route == null || route.routeId.trim().isEmpty) {
+      return;
+    }
+    final groupName = await _selectFavoriteGroup(FavoriteItemType.route);
+    if (!mounted || groupName == null) {
+      return;
+    }
+    try {
+      await AppControllerScope.read(context).addFavoriteItem(
+        FavoriteRoute(
+          provider: widget.provider,
+          routeKey: widget.routeKey,
+          routeId: route.routeId,
+          routeName: route.routeName,
+          routeDescription: route.description.trim().isEmpty
+              ? null
+              : route.description.trim(),
+        ),
+        groupName: groupName,
+      );
+    } on FavoriteGroupFullException catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('我的最愛已達上限 ${error.maxStops} 項，無法再加入')),
+      );
+      return;
+    }
+    if (!mounted) return;
+    _playSuccessHaptic();
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('已將路線加入 $groupName')));
+  }
+
+  Future<void> _handleStationFavorite(StopInfo stop) async {
+    final rawStopId = stop.rawStopId?.trim() ?? '';
+    if (rawStopId.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('這個站牌缺少可解析的站牌識別碼。')));
+      return;
+    }
+    final controller = AppControllerScope.read(context);
+    StationPassbyData? station;
+    try {
+      station = await controller.repository.resolveStation(
+        rawStopId,
+        provider: widget.provider,
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(friendlyErrorMessage(error))));
+      return;
+    }
+    if (!mounted) return;
+    if (station == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('後端目前找不到這個整站資料。')));
+      return;
+    }
+    final groupName = await _selectFavoriteGroup(FavoriteItemType.station);
+    if (!mounted || groupName == null) {
+      return;
+    }
+    try {
+      await controller.addFavoriteItem(
+        FavoriteStation(
+          provider: widget.provider,
+          stationId: station.stationId,
+          stationName: station.stationName,
+        ),
+        groupName: groupName,
+      );
+    } on FavoriteGroupFullException catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('我的最愛已達上限 ${error.maxStops} 項，無法再加入')),
+      );
+      return;
+    }
+    if (!mounted) return;
+    _playSuccessHaptic();
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('已將${station.stationName}加入 $groupName')),
+    );
+  }
+
   Future<void> _handleFavorite(StopInfo stop) async {
     final controller = AppControllerScope.read(context);
-    String? groupName;
-
-    if (controller.favoriteGroupNames.length > 1) {
-      groupName = await _showGroupPicker(controller.favoriteGroupNames);
-      if (!mounted || groupName == null) {
-        return;
-      }
-      if (groupName == '__new__') {
-        groupName = await _showAddGroupDialog();
-        if (!mounted || groupName == null || groupName.trim().isEmpty) {
-          return;
-        }
-        await controller.addFavoriteGroup(groupName);
-      }
-    } else if (controller.favoriteGroupNames.length == 1) {
-      groupName = controller.favoriteGroupNames.first;
+    final groupName = await _selectFavoriteGroup(FavoriteItemType.boarding);
+    if (!mounted || groupName == null) {
+      return;
     }
 
     final favorite = FavoriteStop(
@@ -3395,6 +3523,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       routeId: _detail?.route.routeId,
       routeName: _detail?.route.routeName,
       stopName: stop.stopName,
+      rawStopId: stop.rawStopId,
     );
     String selectedGroup;
     try {
@@ -3537,6 +3666,26 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     }
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(didPin ? '已送出主畫面捷徑要求。' : '這台裝置不支援主畫面捷徑。')),
+    );
+  }
+
+  Future<void> _handlePinnedRouteShortcut() async {
+    final route = _detail?.route;
+    if (route == null || route.routeId.trim().isEmpty) return;
+    final didPin = await AndroidHomeIntegration.pinFavoriteShortcut(
+      favorite: FavoriteRoute(
+        provider: widget.provider,
+        routeKey: widget.routeKey,
+        routeId: route.routeId,
+        routeName: route.routeName,
+        routeDescription: route.description.trim().isEmpty
+            ? null
+            : route.description.trim(),
+      ),
+    );
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(didPin ? '已送出路線捷徑要求。' : '這台裝置不支援主畫面捷徑。')),
     );
   }
 
@@ -3925,8 +4074,14 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           title: Text(stop.stopName),
           children: [
             SimpleDialogOption(
-              onPressed: () => Navigator.of(context).pop(_StopAction.favorite),
-              child: const Text('加入最愛'),
+              onPressed: () =>
+                  Navigator.of(context).pop(_StopAction.favoriteStation),
+              child: const Text('收藏此站牌'),
+            ),
+            SimpleDialogOption(
+              onPressed: () =>
+                  Navigator.of(context).pop(_StopAction.favoriteBoarding),
+              child: const Text('收藏此乘車點'),
             ),
             if (showDestinationAction)
               SimpleDialogOption(
@@ -3968,7 +4123,9 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
       return;
     }
 
-    if (action == _StopAction.favorite) {
+    if (action == _StopAction.favoriteStation) {
+      await _handleStationFavorite(stop);
+    } else if (action == _StopAction.favoriteBoarding) {
       await _handleFavorite(stop);
     } else if (action == _StopAction.destination) {
       await _handleDestinationAction(stop);
@@ -4151,36 +4308,6 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         );
       },
     );
-  }
-
-  Future<String?> _showAddGroupDialog() async {
-    final controller = TextEditingController();
-    final result = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: const Text('新增最愛群組'),
-          content: TextField(
-            controller: controller,
-            autofocus: true,
-            decoration: const InputDecoration(hintText: '輸入群組名稱'),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('取消'),
-            ),
-            FilledButton(
-              onPressed: () =>
-                  Navigator.of(context).pop(controller.text.trim()),
-              child: const Text('新增'),
-            ),
-          ],
-        );
-      },
-    );
-    controller.dispose();
-    return result;
   }
 
   Future<void> _openVehicleForum(String vehicleId) async {
@@ -5272,6 +5399,21 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         appBar: AppBar(
           title: Text(detail?.route.routeName ?? '公車資訊'),
           actions: [
+            IconButton(
+              onPressed: detail == null
+                  ? null
+                  : () => unawaited(_handleRouteFavorite()),
+              tooltip: '收藏路線',
+              icon: const Icon(Icons.favorite_border_rounded),
+            ),
+            if (_isAndroid)
+              IconButton(
+                onPressed: detail == null
+                    ? null
+                    : () => unawaited(_handlePinnedRouteShortcut()),
+                tooltip: '將路線新增到主畫面',
+                icon: const Icon(Icons.add_to_home_screen_rounded),
+              ),
             if (detail != null && currentPathId != null)
               IconButton(
                 onPressed: () {
@@ -6666,7 +6808,8 @@ class _RelatedStopRoutesSheetState extends State<_RelatedStopRoutesSheet> {
 }
 
 enum _StopAction {
-  favorite,
+  favoriteStation,
+  favoriteBoarding,
   destination,
   schedule,
   relatedRoutes,

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -422,6 +422,8 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           repository: AppControllerScope.read(context).repository,
           provider: widget.provider,
           routeKey: widget.routeKey,
+          onFavoriteRoute: _handleRouteFavorite,
+          onPinRoute: _isAndroid ? _handlePinnedRouteShortcut : null,
         );
       },
     );
@@ -5397,23 +5399,12 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
             ? _buildBackgroundTripMonitorDrawer(context)
             : null,
         appBar: AppBar(
-          title: Text(detail?.route.routeName ?? '公車資訊'),
+          title: Text(
+            detail?.route.routeName ?? '公車資訊',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
           actions: [
-            IconButton(
-              onPressed: detail == null
-                  ? null
-                  : () => unawaited(_handleRouteFavorite()),
-              tooltip: '收藏路線',
-              icon: const Icon(Icons.favorite_border_rounded),
-            ),
-            if (_isAndroid)
-              IconButton(
-                onPressed: detail == null
-                    ? null
-                    : () => unawaited(_handlePinnedRouteShortcut()),
-                tooltip: '將路線新增到主畫面',
-                icon: const Icon(Icons.add_to_home_screen_rounded),
-              ),
             if (detail != null && currentPathId != null)
               IconButton(
                 onPressed: () {
@@ -5712,6 +5703,8 @@ class _RouteInfoDialog extends StatefulWidget {
     required this.repository,
     required this.provider,
     required this.routeKey,
+    required this.onFavoriteRoute,
+    this.onPinRoute,
   });
 
   final RouteDetailData detail;
@@ -5719,6 +5712,8 @@ class _RouteInfoDialog extends StatefulWidget {
   final BusRepository repository;
   final BusProvider provider;
   final int routeKey;
+  final Future<void> Function() onFavoriteRoute;
+  final Future<void> Function()? onPinRoute;
 
   @override
   State<_RouteInfoDialog> createState() => _RouteInfoDialogState();
@@ -5795,6 +5790,29 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
               Text(route.description, style: theme.textTheme.bodyMedium),
               const SizedBox(height: 12),
             ],
+            Text('路線動作', style: theme.textTheme.titleSmall),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: () => _runRouteAction(widget.onFavoriteRoute),
+                  icon: const Icon(Icons.favorite_border_rounded, size: 18),
+                  label: const Text('收藏路線'),
+                ),
+                if (widget.onPinRoute case final onPinRoute?)
+                  OutlinedButton.icon(
+                    onPressed: () => _runRouteAction(onPinRoute),
+                    icon: const Icon(
+                      Icons.add_to_home_screen_rounded,
+                      size: 18,
+                    ),
+                    label: const Text('新增到主畫面'),
+                  ),
+              ],
+            ),
+            const Divider(height: 24),
             if (widget.alerts.isNotEmpty) ...[
               Row(
                 children: [
@@ -5874,6 +5892,11 @@ class _RouteInfoDialogState extends State<_RouteInfoDialog> {
         ),
       ],
     );
+  }
+
+  void _runRouteAction(Future<void> Function() action) {
+    Navigator.of(context).pop();
+    unawaited(action());
   }
 
   static const String _appBaseUrl = 'https://busapp.avianjay.sbs';

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -24,6 +24,7 @@ import '../core/live_activity_service.dart';
 import '../core/models.dart';
 import '../core/route_detail_launch_bridge.dart';
 import '../core/samsung_live_notification_prompt_service.dart';
+import '../core/stop_route_merge.dart';
 import '../core/trip_monitor_notifications.dart';
 import '../core/twbusforum.dart';
 import '../widgets/background_image_wrapper.dart';
@@ -3351,13 +3352,13 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           children: [
             SimpleDialogOption(
               onPressed: () =>
-                  Navigator.of(context).pop(_StopAction.favoriteStation),
-              child: const Text('收藏此站牌'),
+                  Navigator.of(context).pop(_StopAction.favoriteBoarding),
+              child: const Text('收藏此乘車點'),
             ),
             SimpleDialogOption(
               onPressed: () =>
-                  Navigator.of(context).pop(_StopAction.favoriteBoarding),
-              child: const Text('收藏此乘車點'),
+                  Navigator.of(context).pop(_StopAction.favoriteStation),
+              child: const Text('收藏此站牌'),
             ),
             SimpleDialogOption(
               onPressed: () => Navigator.of(context).pop(),
@@ -3478,9 +3479,18 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     }
     if (!mounted) return;
     if (station == null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('後端目前找不到這個整站資料。')));
+      // Not an error: the server answered, it just has no whole-station record
+      // for this stop yet (the station tables are filled by the static sync).
+      // Offer the boarding-point favorite, which never depends on that data.
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('伺服器還沒同步這一站的整站資料。'),
+          action: SnackBarAction(
+            label: '收藏此乘車點',
+            onPressed: () => unawaited(_handleFavorite(stop)),
+          ),
+        ),
+      );
       return;
     }
     final groupName = await _selectFavoriteGroup(FavoriteItemType.station);
@@ -3746,12 +3756,12 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     return value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), '');
   }
 
-  // Whether the routes currently shown in the related-stop-routes sheet came
-  // from the server passby endpoint (ETA already embedded) rather than the
-  // local name-based lookup. Read by [_fetchRelatedStopLiveMaps] to decide
-  // whether a follow-up realtime fetch is needed. Only one sheet is open at a
-  // time, so a single flag is sufficient.
-  bool _relatedStopRoutesFromPassby = false;
+  // Keys ([stopRouteMergeKey]) of the entries in the related-stop-routes sheet
+  // whose ETA arrived embedded in the passby response. Read by
+  // [_fetchRelatedStopLiveMaps] to skip them when requesting realtime data, and
+  // by [_applyLiveMapsToRelatedStopRoutes] to leave their values alone. Only
+  // one sheet is open at a time, so a single set is sufficient.
+  Set<String> _relatedStopPassbyRouteKeys = const <String>{};
 
   Future<List<StopRouteSearchResult>> _loadRelatedStopRoutes(
     StopInfo stop,
@@ -3761,48 +3771,73 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     }
 
     final controller = AppControllerScope.read(context);
-    _relatedStopRoutesFromPassby = false;
+    _relatedStopPassbyRouteKeys = const <String>{};
 
-    // Prefer the server-side passby endpoint keyed on the original TDX stop ID.
-    // It resolves the passing routes and returns only this stop's ETA per
-    // route, so the client avoids requesting a large batch of full realtime
-    // snapshots (one per route, each carrying every stop). The provider scopes
-    // the lookup to this route's authority — TDX stop IDs collide across
-    // cities — and the stop name lets the repository reject a mis-scoped
-    // response from servers that don't understand the scope parameter yet.
+    // Two sources, and both are needed.
+    //
+    // The server passby endpoint is keyed on one TDX stop ID and returns that
+    // stop's ETA per route, so it is cheap and authoritative — the client
+    // avoids requesting a batch of full realtime snapshots (one per route, each
+    // carrying every stop). But TDX publishes a *different* stop ID per route
+    // and direction at the same physical stop (捷運南屯站(文心路) is 21746 for
+    // 綠3, 21884 for 73, 24080 for 302), so passby only covers the routes
+    // sharing this stop's ID — often just the route already on screen. The
+    // local name-based lookup finds the sibling IDs but has no realtime data.
+    // Merging keeps the ETA and the complete route list.
+    //
+    // The provider scopes passby to this route's authority — TDX stop IDs
+    // collide across cities — and the stop name lets the repository reject a
+    // mis-scoped response from servers that don't understand the scope
+    // parameter yet.
+    final passby = <StopRouteSearchResult>[];
     final rawStopId = stop.rawStopId;
     if (rawStopId != null) {
       try {
-        final passby = await controller.repository.getStopPassby(
-          rawStopId,
-          provider: widget.provider,
-          expectedStopName: stop.stopName,
+        passby.addAll(
+          await controller.repository.getStopPassby(
+            rawStopId,
+            provider: widget.provider,
+            expectedStopName: stop.stopName,
+          ),
         );
-        if (passby.isNotEmpty) {
-          _relatedStopRoutesFromPassby = true;
-          return passby;
-        }
-        // An empty result can mean the stop isn't present in the server's
-        // database (e.g. data drift); fall through to the local lookup.
       } catch (error) {
         debugPrint('Stop passby load error: $error');
-        // Fall back to the local name-based lookup below.
+        // Silent: the local lookup below still produces a usable list.
       }
     }
 
     final normalizedStopName = _normalizeStopRouteLookupName(stop.stopName);
-    final results = await controller.searchRoutesByStop(
-      stop.stopName,
-      provider: widget.provider,
-    );
+    var local = const <StopRouteSearchResult>[];
+    Object? localError;
+    StackTrace? localStackTrace;
+    try {
+      final results = await controller.searchRoutesByStop(
+        stop.stopName,
+        provider: widget.provider,
+      );
+      local = results
+          .where(
+            (result) =>
+                _normalizeStopRouteLookupName(result.matchedStop.stopName) ==
+                normalizedStopName,
+          )
+          .toList(growable: false);
+    } catch (error, stackTrace) {
+      debugPrint('Related stop route local lookup error: $error');
+      localError = error;
+      localStackTrace = stackTrace;
+    }
 
-    return results
-        .where(
-          (result) =>
-              _normalizeStopRouteLookupName(result.matchedStop.stopName) ==
-              normalizedStopName,
-        )
-        .toList(growable: false);
+    // Preserve the previous failure surface: a local lookup that throws with
+    // nothing from passby must still reach the sheet's error state. When passby
+    // did return something, don't let the local failure discard it.
+    if (passby.isEmpty && localError != null) {
+      Error.throwWithStackTrace(localError, localStackTrace!);
+    }
+
+    final merged = mergeStopRouteResults(passby: passby, local: local);
+    _relatedStopPassbyRouteKeys = merged.passbyKeys;
+    return merged.results;
   }
 
   List<_RelatedStopRouteEta> _buildInitialRelatedStopRouteEtas(
@@ -3823,10 +3858,18 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
   Future<BatchLiveStopMap> _fetchRelatedStopLiveMaps(
     List<StopRouteSearchResult> routes,
   ) async {
-    // Passby results already carry each route's ETA in matchedStop, so there
-    // is nothing more to fetch — applyLiveMaps falls back to matchedStop when
-    // the map has no entry for a route.
-    if (_relatedStopRoutesFromPassby) {
+    // Passby entries already carry this stop's ETA in matchedStop. Only the
+    // entries that came from the local name lookup — the sibling stop IDs
+    // passby could not see — still need a realtime fetch. Filtering per entry
+    // rather than per route matters: one route can be passby-covered on path 1
+    // and locally sourced on path 0, and it must still reach the batch fetch.
+    final pending = routes
+        .where(
+          (result) =>
+              !_relatedStopPassbyRouteKeys.contains(stopRouteMergeKey(result)),
+        )
+        .toList(growable: false);
+    if (pending.isEmpty) {
       return const <String, LiveStopMap>{};
     }
 
@@ -3834,13 +3877,13 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     BatchLiveStopMap liveMaps = const <String, LiveStopMap>{};
     try {
       liveMaps = await controller.repository.getBatchLiveStopMaps(
-        routes.map((result) => result.route.routeId).toList(growable: false),
+        pending.map((result) => result.route.routeId).toList(growable: false),
       );
     } catch (error) {
       debugPrint('Related stop route ETA load error: $error');
     }
 
-    final missingRouteIds = routes
+    final missingRouteIds = pending
         .map((result) => result.route.routeId.trim())
         .where((id) => !liveMaps.containsKey(id))
         .toSet();
@@ -3872,6 +3915,16 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     BatchLiveStopMap liveMaps,
   ) {
     final items = routes.map((result) {
+      // A passby entry's matchedStop already holds this stop's ETA. Don't let a
+      // live-map hit keyed on the *requested* stop ID overwrite it: copyWith
+      // replaces sec/msg/t/buses but not etas, which would leave the two out of
+      // sync.
+      if (_relatedStopPassbyRouteKeys.contains(stopRouteMergeKey(result))) {
+        return _RelatedStopRouteEta(
+          result: result,
+          liveStop: result.matchedStop,
+        );
+      }
       final liveMap = liveMaps[result.route.routeId.trim()];
       final livePayload = liveMap?[_relatedStopRealtimeKey(result.matchedStop)];
       final liveStop = livePayload == null
@@ -4077,13 +4130,13 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
           children: [
             SimpleDialogOption(
               onPressed: () =>
-                  Navigator.of(context).pop(_StopAction.favoriteStation),
-              child: const Text('收藏此站牌'),
+                  Navigator.of(context).pop(_StopAction.favoriteBoarding),
+              child: const Text('收藏此乘車點'),
             ),
             SimpleDialogOption(
               onPressed: () =>
-                  Navigator.of(context).pop(_StopAction.favoriteBoarding),
-              child: const Text('收藏此乘車點'),
+                  Navigator.of(context).pop(_StopAction.favoriteStation),
+              child: const Text('收藏此站牌'),
             ),
             if (showDestinationAction)
               SimpleDialogOption(

--- a/lib/screens/route_detail_screen.dart
+++ b/lib/screens/route_detail_screen.dart
@@ -3353,12 +3353,12 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
             SimpleDialogOption(
               onPressed: () =>
                   Navigator.of(context).pop(_StopAction.favoriteBoarding),
-              child: const Text('收藏此乘車點'),
+              child: const Text('收藏此站牌'),
             ),
             SimpleDialogOption(
               onPressed: () =>
                   Navigator.of(context).pop(_StopAction.favoriteStation),
-              child: const Text('收藏此站牌'),
+              child: const Text('收藏整站'),
             ),
             SimpleDialogOption(
               onPressed: () => Navigator.of(context).pop(),
@@ -3460,7 +3460,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
     if (rawStopId.isEmpty) {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('這個站牌缺少可解析的站牌識別碼。')));
+      ).showSnackBar(const SnackBar(content: Text('這個站牌缺少可解析的識別碼，無法對應到整站。')));
       return;
     }
     final controller = AppControllerScope.read(context);
@@ -3486,7 +3486,7 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
         SnackBar(
           content: const Text('伺服器還沒同步這一站的整站資料。'),
           action: SnackBarAction(
-            label: '收藏此乘車點',
+            label: '收藏此站牌',
             onPressed: () => unawaited(_handleFavorite(stop)),
           ),
         ),
@@ -4131,12 +4131,12 @@ class _RouteDetailScreenState extends State<RouteDetailScreen>
             SimpleDialogOption(
               onPressed: () =>
                   Navigator.of(context).pop(_StopAction.favoriteBoarding),
-              child: const Text('收藏此乘車點'),
+              child: const Text('收藏此站牌'),
             ),
             SimpleDialogOption(
               onPressed: () =>
                   Navigator.of(context).pop(_StopAction.favoriteStation),
-              child: const Text('收藏此站牌'),
+              child: const Text('收藏整站'),
             ),
             if (showDestinationAction)
               SimpleDialogOption(

--- a/lib/screens/station_detail_screen.dart
+++ b/lib/screens/station_detail_screen.dart
@@ -1,0 +1,204 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+
+import '../app/bus_app.dart';
+import '../core/android_home_integration.dart';
+import '../core/app_routes.dart';
+import '../core/friendly_error.dart';
+import '../core/models.dart';
+import '../widgets/eta_badge.dart';
+
+class StationDetailScreen extends StatefulWidget {
+  const StationDetailScreen({
+    required this.provider,
+    required this.stationId,
+    this.stationName,
+    super.key,
+  });
+
+  final BusProvider provider;
+  final String stationId;
+  final String? stationName;
+
+  @override
+  State<StationDetailScreen> createState() => _StationDetailScreenState();
+}
+
+class _StationDetailScreenState extends State<StationDetailScreen> {
+  StationPassbyData? _station;
+  String? _error;
+  bool _loading = true;
+
+  bool get _isAndroid =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+
+  Future<void> _pinStationShortcut() async {
+    final station = _station;
+    final didPin = await AndroidHomeIntegration.pinFavoriteShortcut(
+      favorite: FavoriteStation(
+        provider: widget.provider,
+        stationId: widget.stationId,
+        stationName: station?.stationName ?? widget.stationName ?? '站牌',
+      ),
+    );
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(didPin ? '已送出站牌捷徑要求。' : '這台裝置不支援主畫面捷徑。')),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_station == null && _loading) {
+      unawaited(_load());
+    }
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final station = await AppControllerScope.read(context).repository
+          .getStationPassby(widget.stationId, provider: widget.provider);
+      if (!mounted) return;
+      setState(() {
+        _station = station;
+        _error = station == null ? '找不到這個站牌。' : null;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _error = friendlyErrorMessage(error));
+    } finally {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final station = _station;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(station?.stationName ?? widget.stationName ?? '站牌'),
+        actions: [
+          if (_isAndroid)
+            IconButton(
+              onPressed: () => unawaited(_pinStationShortcut()),
+              tooltip: '將站牌新增到主畫面',
+              icon: const Icon(Icons.add_to_home_screen_rounded),
+            ),
+          IconButton(
+            onPressed: _loading ? null : () => unawaited(_load()),
+            tooltip: '重新整理',
+            icon: const Icon(Icons.refresh_rounded),
+          ),
+        ],
+      ),
+      body: _loading && station == null
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null && station == null
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(_error!, textAlign: TextAlign.center),
+                    const SizedBox(height: 12),
+                    FilledButton.tonal(
+                      onPressed: () => unawaited(_load()),
+                      child: const Text('重試'),
+                    ),
+                  ],
+                ),
+              ),
+            )
+          : _buildStation(station!),
+    );
+  }
+
+  Widget _buildStation(StationPassbyData station) {
+    final sides = station.sides;
+    if (sides.isEmpty) {
+      return const Center(child: Text('這個站牌目前沒有可顯示的側別。'));
+    }
+    return DefaultTabController(
+      length: sides.length,
+      child: Column(
+        children: [
+          Material(
+            color: Theme.of(context).colorScheme.surface,
+            child: TabBar(
+              isScrollable: sides.length > 3,
+              tabs: [
+                for (final side in sides)
+                  Tab(
+                    text: side.direction?.isNotEmpty == true
+                        ? '${side.label} · ${side.direction}'
+                        : '${side.label} 側',
+                  ),
+              ],
+            ),
+          ),
+          if (_loading) const LinearProgressIndicator(minHeight: 2),
+          Expanded(
+            child: TabBarView(
+              children: [for (final side in sides) _buildSide(side)],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSide(StationSideData side) {
+    if (side.routes.isEmpty) {
+      return Center(child: Text('${side.label} 側目前沒有經過路線。'));
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView.separated(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+        itemCount: side.routes.length,
+        separatorBuilder: (_, _) => const SizedBox(height: 8),
+        itemBuilder: (context, index) {
+          final arrival = side.routes[index];
+          final route = arrival.result.route;
+          final stop = arrival.result.matchedStop;
+          return Card(
+            child: ListTile(
+              leading: EtaBadge(
+                stop: stop,
+                alwaysShowSeconds: AppControllerScope.read(
+                  context,
+                ).settings.alwaysShowSeconds,
+              ),
+              title: Text(route.routeName),
+              subtitle: Text(
+                route.description.trim().isNotEmpty
+                    ? route.description
+                    : (side.direction ?? '${side.label} 側'),
+              ),
+              trailing: const Icon(Icons.chevron_right_rounded),
+              onTap: () => Navigator.of(context).pushNamed(
+                AppRoutes.routeDetailPath(
+                  provider: widget.provider,
+                  routeKey: route.routeKey,
+                  routeId: route.routeId,
+                  pathId: stop.pathId,
+                  stopId: stop.stopId,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/station_detail_screen.dart
+++ b/lib/screens/station_detail_screen.dart
@@ -40,12 +40,12 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
       favorite: FavoriteStation(
         provider: widget.provider,
         stationId: widget.stationId,
-        stationName: station?.stationName ?? widget.stationName ?? '站牌',
+        stationName: station?.stationName ?? widget.stationName ?? '整站',
       ),
     );
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(didPin ? '已送出站牌捷徑要求。' : '這台裝置不支援主畫面捷徑。')),
+      SnackBar(content: Text(didPin ? '已送出整站捷徑要求。' : '這台裝置不支援主畫面捷徑。')),
     );
   }
 
@@ -68,7 +68,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
       if (!mounted) return;
       setState(() {
         _station = station;
-        _error = station == null ? '找不到這個站牌。' : null;
+        _error = station == null ? '找不到這一站的整站資料。' : null;
       });
     } catch (error) {
       if (!mounted) return;
@@ -85,12 +85,12 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
     final station = _station;
     return Scaffold(
       appBar: AppBar(
-        title: Text(station?.stationName ?? widget.stationName ?? '站牌'),
+        title: Text(station?.stationName ?? widget.stationName ?? '整站'),
         actions: [
           if (_isAndroid)
             IconButton(
               onPressed: () => unawaited(_pinStationShortcut()),
-              tooltip: '將站牌新增到主畫面',
+              tooltip: '將整站新增到主畫面',
               icon: const Icon(Icons.add_to_home_screen_rounded),
             ),
           IconButton(
@@ -126,7 +126,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
   Widget _buildStation(StationPassbyData station) {
     final sides = station.sides;
     if (sides.isEmpty) {
-      return const Center(child: Text('這個站牌目前沒有可顯示的側別。'));
+      return const Center(child: Text('這一站目前沒有可顯示的站牌。'));
     }
     return DefaultTabController(
       length: sides.length,
@@ -141,7 +141,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
                   Tab(
                     text: side.direction?.isNotEmpty == true
                         ? '${side.label} · ${side.direction}'
-                        : '${side.label} 側',
+                        : '站牌 ${side.label}',
                   ),
               ],
             ),
@@ -159,7 +159,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
 
   Widget _buildSide(StationSideData side) {
     if (side.routes.isEmpty) {
-      return Center(child: Text('${side.label} 側目前沒有經過路線。'));
+      return Center(child: Text('站牌 ${side.label} 目前沒有經過路線。'));
     }
     return RefreshIndicator(
       onRefresh: _load,
@@ -183,7 +183,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
               subtitle: Text(
                 route.description.trim().isNotEmpty
                     ? route.description
-                    : (side.direction ?? '${side.label} 側'),
+                    : (side.direction ?? '站牌 ${side.label}'),
               ),
               trailing: const Icon(Icons.chevron_right_rounded),
               onTap: () => Navigator.of(context).pushNamed(

--- a/test/app_routes_test.dart
+++ b/test/app_routes_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:taiwanbus_flutter/core/app_launch_service.dart';
 import 'package:taiwanbus_flutter/core/app_routes.dart';
 import 'package:taiwanbus_flutter/core/models.dart';
 
@@ -55,5 +56,31 @@ void main() {
     expect(location, '/route/tpe/123456?routeId=TPE12345');
     expect(intent.kind, AppRouteKind.routeDetail);
     expect(intent.routeId, 'TPE12345');
+  });
+
+  test('station detail routes preserve provider and station identity', () {
+    final location = AppRoutes.stationDetailPath(
+      provider: BusProvider.tpe,
+      stationId: 'TPE-STATION/01',
+    );
+    final intent = parseAppRoute(location);
+
+    expect(intent.kind, AppRouteKind.stationDetail);
+    expect(intent.provider, BusProvider.tpe);
+    expect(intent.stationId, 'TPE-STATION/01');
+  });
+
+  test('native station launch payload preserves station identity', () {
+    final action = AppLaunchAction.fromMap({
+      'target': 'station_detail',
+      'provider': 'tpe',
+      'stationId': 'TPE-STATION-1',
+    });
+
+    expect(action.target, AppLaunchTarget.stationDetail);
+    expect(action.provider, BusProvider.tpe);
+    expect(action.stationId, 'TPE-STATION-1');
+    expect(action.routeKey, isNull);
+    expect(action.stopId, isNull);
   });
 }

--- a/test/favorite_groups_sync_test.dart
+++ b/test/favorite_groups_sync_test.dart
@@ -74,13 +74,93 @@ void main() {
     await controller.syncAllAccountData();
 
     expect(syncService.favoritePayload, {
+      'groupKinds': {'New group': 'boarding'},
       'groups': {'New group': <dynamic>[]},
     });
+    expect(syncService.favoriteSchemaVersion, 2);
     expect(syncService.favoriteRestoreCount, 0);
     expect(controller.favoriteGroupNames, ['Old group', 'New group']);
     expect(controller.favoritesInGroup('Old group'), hasLength(1));
     expect(controller.favoritesInGroup('New group'), isEmpty);
   });
+
+  test(
+    'typed favorite groups enforce type, duplicate, and total limits',
+    () async {
+      final storage = StorageService();
+      final controller = AppController(
+        repository: BusRepository(),
+        storage: storage,
+        analytics: await AppAnalytics.initialize(),
+        buildInfo: AppBuildInfo(
+          version: '1.0.0',
+          buildNumber: '1',
+          gitSha: 'test',
+          defaultUpdateChannel: AppUpdateChannel.release,
+        ),
+        appUpdateService: AppUpdateService(
+          buildInfo: AppBuildInfo(
+            version: '1.0.0',
+            buildNumber: '1',
+            gitSha: 'test',
+            defaultUpdateChannel: AppUpdateChannel.release,
+          ),
+        ),
+        appUpdateInstaller: createAppUpdateInstaller(),
+        authService: _FakeAuthService(),
+        accountSyncService: _FakeAccountSyncService(),
+      );
+      addTearDown(controller.dispose);
+
+      await controller.addFavoriteGroup(
+        'Routes',
+        kind: FavoriteGroupKind.route,
+      );
+      await controller.addFavoriteGroup('Mixed', kind: FavoriteGroupKind.mixed);
+
+      const station = FavoriteStation(
+        provider: BusProvider.tpe,
+        stationId: 'TPE-STATION',
+        stationName: '臺北車站',
+      );
+      expect(
+        controller.addFavoriteItem(station, groupName: 'Routes'),
+        throwsA(isA<FavoriteGroupTypeMismatchException>()),
+      );
+
+      for (var index = 0; index < 25; index += 1) {
+        await controller.addFavoriteItem(
+          FavoriteRoute(
+            provider: BusProvider.tpe,
+            routeKey: index,
+            routeId: 'TPE-$index',
+            routeName: '$index',
+          ),
+          groupName: 'Routes',
+        );
+      }
+      await controller.addFavoriteItem(
+        const FavoriteRoute(
+          provider: BusProvider.tpe,
+          routeKey: 0,
+          routeId: 'TPE-0',
+          routeName: 'updated',
+        ),
+        groupName: 'Routes',
+      );
+
+      expect(controller.favoritesInGroup('Routes'), hasLength(25));
+      expect(
+        (controller.favoritesInGroup('Routes').first as FavoriteRoute)
+            .routeName,
+        'updated',
+      );
+      expect(
+        controller.addFavoriteItem(station, groupName: 'Mixed'),
+        throwsA(isA<FavoriteGroupFullException>()),
+      );
+    },
+  );
 }
 
 class _FakeAuthService extends AuthService {
@@ -129,6 +209,7 @@ class _FakeAccountSyncService extends AccountSyncService {
   };
 
   Map<String, dynamic>? favoritePayload;
+  int? favoriteSchemaVersion;
   int favoriteRestoreCount = 0;
 
   @override
@@ -174,9 +255,16 @@ class _FakeAccountSyncService extends AccountSyncService {
   }) async {
     if (namespace == AccountSyncNamespace.favorites) {
       favoritePayload = payload;
+      favoriteSchemaVersion = schemaVersion;
     }
     final documentPayload = namespace == AccountSyncNamespace.favorites
         ? {
+            'groupKinds': {
+              'Old group': 'boarding',
+              ...((payload['groupKinds'] as Map).map(
+                (key, value) => MapEntry(key.toString(), value),
+              )),
+            },
             'groups': {
               'Old group': [_oldFavorite],
               ...((payload['groups'] as Map).map(
@@ -200,7 +288,7 @@ class _FakeAccountSyncService extends AccountSyncService {
     return AccountSyncDocument(
       namespace: namespace,
       hasData: true,
-      schemaVersion: 1,
+      schemaVersion: namespace == AccountSyncNamespace.favorites ? 2 : 1,
       revision: 1,
       etag: 'test-etag',
       updatedAt: timestamp,

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -140,11 +140,7 @@ void main() {
           source: 'backfill_buses',
           estimated: true,
         ),
-        StopEta(
-          sec: 60,
-          vehicleId: 'AAA-0001',
-          source: 'tdx',
-        ),
+        StopEta(sec: 60, vehicleId: 'AAA-0001', source: 'tdx'),
       ],
     );
 
@@ -246,6 +242,73 @@ void main() {
     expect(updated.totalSelectionsAt(now: now), 2);
     expect(updated.selectionCountAtHour(18, now: now), 2);
   });
+
+  test('legacy favorite json migrates to a boarding item', () {
+    final favorite = FavoriteItem.fromJson(const {
+      'provider': 'tpe',
+      'routeKey': 12,
+      'pathId': 1,
+      'stopId': 1001,
+      'routeName': '12',
+      'stopName': '臺北車站',
+    });
+
+    expect(favorite, isA<FavoriteStop>());
+    expect(favorite.type, FavoriteItemType.boarding);
+    expect(favorite.stableKey, 'tpe:12:1:1001');
+    expect(favorite.toJson()['type'], 'boarding');
+  });
+
+  test('favorite identities are explicit and type aware', () {
+    const route = FavoriteRoute(
+      provider: BusProvider.tpe,
+      routeKey: 12,
+      routeId: 'TPE12',
+      routeName: '12',
+    );
+    const station = FavoriteStation(
+      provider: BusProvider.tpe,
+      stationId: 'TPE-STATION-12',
+      stationName: '臺北車站',
+    );
+    const boarding = FavoriteStop(
+      provider: BusProvider.tpe,
+      routeKey: 12,
+      pathId: 1,
+      stopId: 1001,
+      rawStopId: 'TPE1001',
+    );
+
+    expect(route.stableKey, 'route:tpe:TPE12');
+    expect(station.stableKey, 'station:tpe:TPE-STATION-12');
+    expect(boarding.stableKey, 'tpe:12:1:1001');
+    expect(route.sameAs(station), isFalse);
+    expect(station.sameAs(boarding), isFalse);
+    expect(boarding.toJson()['rawStopId'], 'TPE1001');
+  });
+
+  test(
+    'typed favorite groups reject other item types while mixed accepts all',
+    () {
+      const route = FavoriteRoute(
+        provider: BusProvider.tpe,
+        routeKey: 12,
+        routeId: 'TPE12',
+        routeName: '12',
+      );
+      const station = FavoriteStation(
+        provider: BusProvider.tpe,
+        stationId: 'TPE-STATION-12',
+        stationName: '臺北車站',
+      );
+
+      expect(FavoriteGroupKind.route.accepts(route), isTrue);
+      expect(FavoriteGroupKind.route.accepts(station), isFalse);
+      expect(FavoriteGroupKind.mixed.accepts(route), isTrue);
+      expect(FavoriteGroupKind.mixed.accepts(station), isTrue);
+      expect(FavoriteGroupKind.fromJson(null), FavoriteGroupKind.boarding);
+    },
+  );
 
   test('account sync local state preserves namespace metadata', () {
     final state = AccountSyncLocalState.empty()

--- a/test/station_passby_test.dart
+++ b/test/station_passby_test.dart
@@ -1,0 +1,208 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:taiwanbus_flutter/app/bus_app.dart';
+import 'package:taiwanbus_flutter/core/account_sync_service.dart';
+import 'package:taiwanbus_flutter/core/app_analytics.dart';
+import 'package:taiwanbus_flutter/core/app_build_info.dart';
+import 'package:taiwanbus_flutter/core/app_controller.dart';
+import 'package:taiwanbus_flutter/core/app_update_installer.dart';
+import 'package:taiwanbus_flutter/core/app_update_service.dart';
+import 'package:taiwanbus_flutter/core/auth_service.dart';
+import 'package:taiwanbus_flutter/core/bus_repository.dart';
+import 'package:taiwanbus_flutter/core/models.dart';
+import 'package:taiwanbus_flutter/core/storage_service.dart';
+import 'package:taiwanbus_flutter/screens/station_detail_screen.dart';
+
+Map<String, Object?> _stationPayload() => {
+  'city': 'TPE',
+  'station_id': 'TPE-STATION-1',
+  'station_name': '市政府',
+  'station_name_en': 'City Hall',
+  'lat': 25.04,
+  'lon': 121.56,
+  'sides': [
+    {
+      'side_id': 'TPE-STOP-A',
+      'label': 'A',
+      'direction': '往台北車站',
+      'stop_uid': 'TPE-STOP-A',
+      'stopid': 'STOP-A',
+      'lat': 25.041,
+      'lon': 121.561,
+      'routes': [
+        {
+          'routeid': 'TPE0001',
+          'route_name': '307',
+          'route_name_en': '307',
+          'pathid': 0,
+          'path_name': '往撫遠街',
+          'path_name_en': 'Outbound',
+          'seq': 2,
+          'stopid': 'STOP-A',
+          'eta': 120,
+          'message': '',
+          'updated_at': 1000,
+          'buses': <Object?>[],
+          'etas': <Object?>[],
+        },
+      ],
+    },
+    {
+      'side_id': 'TPE-STOP-B',
+      'label': 'B',
+      'direction': '往信義區',
+      'stop_uid': 'TPE-STOP-B',
+      'stopid': 'STOP-B',
+      'lat': 25.039,
+      'lon': 121.559,
+      'routes': [
+        {
+          'routeid': 'TPE0002',
+          'route_name': '藍1',
+          'route_name_en': 'BL1',
+          'pathid': 1,
+          'path_name': '往南港',
+          'path_name_en': 'Nangang',
+          'seq': 5,
+          'stopid': 'STOP-B',
+          'eta': 60,
+          'message': '',
+          'updated_at': 1000,
+          'buses': <Object?>[],
+          'etas': <Object?>[],
+        },
+      ],
+    },
+  ],
+};
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('resolveStation sends authority and raw stop ID', () async {
+    Uri? requestedUri;
+    final repository = BusRepository(
+      client: MockClient((request) async {
+        requestedUri = request.url;
+        return http.Response(
+          jsonEncode(_stationPayload()),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }),
+    );
+
+    final station = await repository.resolveStation(
+      'STOP-B',
+      provider: BusProvider.tpe,
+    );
+
+    expect(requestedUri?.path, '/api/v1/stations/resolve');
+    expect(requestedUri?.queryParameters, {'city': 'TPE', 'stopid': 'STOP-B'});
+    expect(station?.stationId, 'TPE-STATION-1');
+    expect(station?.sides.map((side) => side.label), ['A', 'B']);
+    expect(station?.nextArrival?.sideLabel, 'B');
+    expect(station?.nextArrival?.result.route.routeName, '藍1');
+    expect(station?.nextArrival?.result.matchedStop.sec, 60);
+  });
+
+  test('getStationPassby rejects cross-city response', () async {
+    final payload = _stationPayload()..['city'] = 'KHH';
+    final repository = BusRepository(
+      client: MockClient(
+        (_) async => http.Response(
+          jsonEncode(payload),
+          200,
+          headers: {'content-type': 'application/json'},
+        ),
+      ),
+    );
+
+    final station = await repository.getStationPassby(
+      'TPE-STATION-1',
+      provider: BusProvider.tpe,
+    );
+
+    expect(station, isNull);
+  });
+
+  test('station lookup returns null on 404', () async {
+    final repository = BusRepository(
+      client: MockClient((_) async => http.Response('{}', 404)),
+    );
+
+    expect(
+      await repository.resolveStation('UNKNOWN', provider: BusProvider.tpe),
+      isNull,
+    );
+  });
+
+  testWidgets('station detail renders routes for every stable side', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    final client = MockClient(
+      (_) async => http.Response(
+        jsonEncode(_stationPayload()),
+        200,
+        headers: {'content-type': 'application/json'},
+      ),
+    );
+    const buildInfo = AppBuildInfo(
+      version: '1.0.0',
+      buildNumber: '1',
+      gitSha: 'test',
+      defaultUpdateChannel: AppUpdateChannel.release,
+    );
+    final controller = AppController(
+      repository: BusRepository(client: client),
+      storage: StorageService(),
+      analytics: await AppAnalytics.initialize(),
+      buildInfo: buildInfo,
+      appUpdateService: AppUpdateService(buildInfo: buildInfo, client: client),
+      appUpdateInstaller: createAppUpdateInstaller(),
+      authService: AuthService(),
+      accountSyncService: AccountSyncService(client: client),
+    );
+    addTearDown(controller.dispose);
+
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AppControllerScope(
+            controller: controller,
+            child: const StationDetailScreen(
+              provider: BusProvider.tpe,
+              stationId: 'TPE-STATION-1',
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('市政府'), findsOneWidget);
+      expect(find.text('A · 往台北車站'), findsOneWidget);
+      expect(find.text('B · 往信義區'), findsOneWidget);
+      expect(find.text('307'), findsOneWidget);
+
+      await tester.tap(find.text('B · 往信義區'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('藍1'), findsOneWidget);
+      expect(find.text('往南港'), findsOneWidget);
+    } finally {
+      await tester.pumpWidget(const SizedBox.shrink());
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}

--- a/test/stop_passby_test.dart
+++ b/test/stop_passby_test.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:taiwanbus_flutter/core/bus_repository.dart';
 import 'package:taiwanbus_flutter/core/models.dart';
+import 'package:taiwanbus_flutter/core/stop_route_merge.dart';
 
 http.Response _passbyResponse({
   required String stopId,
@@ -22,6 +23,7 @@ Map<String, Object?> _passbyRoute(
   String routeId, {
   int pathId = 0,
   int? eta,
+  String stopId = '39',
 }) {
   return {
     'routeid': routeId,
@@ -31,7 +33,7 @@ Map<String, Object?> _passbyRoute(
     'path_name': 'Outbound',
     'path_name_en': 'Outbound',
     'seq': 3,
-    'stopid': '39',
+    'stopid': stopId,
     'eta': eta,
     'message': '',
     'updated_at': 1000,
@@ -145,5 +147,46 @@ void main() {
     );
 
     expect(results, isEmpty);
+  });
+
+  test('every passby route carries the requested stop id, not its own', () async {
+    // The server resolves all passing routes from one stop id and stamps that
+    // id on each of them, so two paths of the same route come back sharing a
+    // stop id and differing only by pathid. This is why stopRouteMergeKey uses
+    // routeId+pathId — the local name lookup carries each route's own stop id
+    // (21826 for 綠3's other direction), so stop ids cannot identify an entry
+    // across the two sources.
+    final client = MockClient((request) async {
+      return _passbyResponse(
+        stopId: '21746',
+        stopName: '捷運南屯站(文心路)',
+        routes: [
+          _passbyRoute('TXG4030', pathId: 1, eta: 120, stopId: '21746'),
+          _passbyRoute('TXG4030', pathId: 0, eta: 600, stopId: '21746'),
+        ],
+      );
+    });
+
+    final repository = BusRepository(client: client);
+    final results = await repository.getStopPassby(
+      '21746',
+      provider: BusProvider.txg,
+      expectedStopName: '捷運南屯站(文心路)',
+    );
+
+    expect(results, hasLength(2));
+    expect(
+      results.map((result) => result.matchedStop.stopId).toSet(),
+      hasLength(1),
+      reason: 'both entries are stamped with the requested stop id',
+    );
+    expect(
+      results.map((result) => result.matchedStop.pathId).toList(),
+      <int>[1, 0],
+    );
+    expect(
+      results.map(stopRouteMergeKey).toList(),
+      <String>['TXG4030:1', 'TXG4030:0'],
+    );
   });
 }

--- a/test/stop_route_merge_test.dart
+++ b/test/stop_route_merge_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:taiwanbus_flutter/core/models.dart';
+import 'package:taiwanbus_flutter/core/stop_route_merge.dart';
+
+StopRouteSearchResult _result(
+  String routeId, {
+  int pathId = 0,
+  required int stopId,
+  int? sec,
+}) {
+  return StopRouteSearchResult(
+    route: RouteSummary(
+      sourceProvider: 'txg',
+      hashMd5: '',
+      routeKey: routeId.hashCode,
+      routeId: routeId,
+      routeName: routeId,
+      officialRouteName: routeId,
+      description: '',
+      category: '',
+      sequence: 0,
+      rtrip: 0,
+    ),
+    matchedStop: StopInfo(
+      routeKey: routeId.hashCode,
+      pathId: pathId,
+      stopId: stopId,
+      rawStopId: '$stopId',
+      stopName: '捷運南屯站(文心路)',
+      sequence: 1,
+      lon: 0,
+      lat: 0,
+      sec: sec,
+    ),
+  );
+}
+
+void main() {
+  test('merges disjoint passby and local results without duplicates', () {
+    final merged = mergeStopRouteResults(
+      passby: [_result('TXG4030', pathId: 1, stopId: 21746, sec: 120)],
+      local: [
+        _result('TXG73', stopId: 21884),
+        _result('TXG3020', pathId: 1, stopId: 24080),
+      ],
+    );
+
+    expect(
+      merged.results.map((result) => result.route.routeId),
+      containsAll(<String>['TXG4030', 'TXG73', 'TXG3020']),
+    );
+    expect(merged.results, hasLength(3));
+    expect(merged.passbyKeys, <String>{'TXG4030:1'});
+  });
+
+  test('passby wins over local for the same route and path', () {
+    // The server stamps the requested stop id (21746) on every route it
+    // returns, while the local lookup carries the route's own id — so the same
+    // entry legitimately arrives with two different stop ids.
+    final merged = mergeStopRouteResults(
+      passby: [_result('TXG4030', pathId: 1, stopId: 21746, sec: 120)],
+      local: [_result('TXG4030', pathId: 1, stopId: 99999)],
+    );
+
+    expect(merged.results, hasLength(1));
+    expect(merged.results.single.matchedStop.stopId, 21746);
+    expect(merged.results.single.matchedStop.sec, 120);
+    expect(merged.passbyKeys, contains('TXG4030:1'));
+  });
+
+  test('keeps both paths of one route and marks only the passby path', () {
+    final merged = mergeStopRouteResults(
+      passby: [_result('TXG4030', pathId: 1, stopId: 21746, sec: 120)],
+      local: [_result('TXG4030', stopId: 21826)],
+    );
+
+    expect(merged.results, hasLength(2));
+    expect(
+      merged.results.map((result) => result.matchedStop.pathId),
+      containsAll(<int>[0, 1]),
+    );
+    expect(merged.passbyKeys, <String>{'TXG4030:1'});
+  });
+
+  test('dedupes route ids that differ only by surrounding whitespace', () {
+    final merged = mergeStopRouteResults(
+      passby: [_result('TXG4030', stopId: 21746, sec: 60)],
+      local: [_result(' TXG4030 ', stopId: 21826)],
+    );
+
+    expect(merged.results, hasLength(1));
+    expect(merged.results.single.matchedStop.sec, 60);
+  });
+
+  test('passes local results through when passby is empty', () {
+    final merged = mergeStopRouteResults(
+      passby: const <StopRouteSearchResult>[],
+      local: [
+        _result('TXG73', stopId: 21884),
+        _result('TXG365', stopId: 24127),
+      ],
+    );
+
+    expect(merged.results, hasLength(2));
+    expect(merged.passbyKeys, isEmpty);
+  });
+}


### PR DESCRIPTION
## 摘要

- 將收藏項目明確分為 `route`、`station`、`boarding`，不再以 `stopId: null` 判斷類型
- 新增路線、站牌、乘車點及綜合群組，並保留既有 boarding 收藏遷移與智慧推薦
- 新增整站詳情頁、A/B/C 側路線與 ETA，以及 `/station/{provider}/{stationId}` deep link
- 擴充 Android Widget、Wear OS、Android 捷徑及 iOS Widget/App Intent 的三類型開啟與顯示能力
- Account Sync 改用 favorites schema v2，支援 groupKinds 與舊版 App 的安全投影

## 後端相依

後端 schema v2、station identity、靜態同步及 resolve/passby API 已完成於：
- https://github.com/AvianJay/busapiserver/commit/16ca7d9cc43efdb8384a80b71230295f68814f93

## 驗證

- `flutter analyze`
- `flutter test`：96 passed
- `:app:testDebugUnitTest :wearos:testDebugUnitTest`：BUILD SUCCESSFUL
- 後端 focused tests：29 passed
- 後端完整 tests：232 passed
- App 與後端 `git diff --check` 通過

## 尚待平台／實機驗證

- iOS decoder、Widget 與 App Intent 需由 macOS CI 編譯驗證
- 新舊 App 同帳號交錯同步、Android/iOS Widget、Wear 與三類捷徑需實機驗證

Closes #43