### PR TITLE
feat: App Bar 天氣顯示與完整預報頁面（中央氣象署 API）

### DIFF
--- a/lib/core/app_controller.dart
+++ b/lib/core/app_controller.dart
@@ -1727,6 +1727,12 @@ class AppController extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> updateShowWeatherInAppBar(bool value) async {
+    _settings = _settings.copyWith(showWeatherInAppBar: value);
+    await _persistSettings();
+    notifyListeners();
+  }
+
   Future<void> updateEnableSmartRecommendations(bool value) async {
     _settings = _settings.copyWith(enableSmartRecommendations: value);
     await _persistSettings();
@@ -3047,6 +3053,7 @@ class AppController extends ChangeNotifier {
       _copyKnownKey(appearance, merged, 'homeBackgroundOpacity');
       _copyKnownKey(appearance, merged, 'overlayOpacity');
       _copyKnownKey(appearance, merged, 'enableCompactMode');
+      _copyKnownKey(appearance, merged, 'showWeatherInAppBar');
     }
 
     final usage = _stringMap(root['usage']);
@@ -3252,6 +3259,7 @@ Map<String, dynamic> _preferencesSyncPayloadFromSettings(AppSettings settings) {
       'homeBackgroundOpacity': json['homeBackgroundOpacity'],
       'overlayOpacity': json['overlayOpacity'],
       'enableCompactMode': json['enableCompactMode'],
+      'showWeatherInAppBar': json['showWeatherInAppBar'],
     },
     'usage': {
       'alwaysShowSeconds': json['alwaysShowSeconds'],

--- a/lib/core/models.dart
+++ b/lib/core/models.dart
@@ -327,6 +327,7 @@ class AppSettings {
     required this.alwaysShowSeconds,
     required this.enableHapticFeedback,
     required this.enableCompactMode,
+    required this.showWeatherInAppBar,
     required this.enableSmartRecommendations,
     required this.enableAutoFavoriteFrequentStops,
     required this.enableSmartRouteNotifications,
@@ -368,6 +369,7 @@ class AppSettings {
       alwaysShowSeconds: false,
       enableHapticFeedback: true,
       enableCompactMode: false,
+      showWeatherInAppBar: true,
       enableSmartRecommendations: true,
       enableAutoFavoriteFrequentStops: true,
       enableSmartRouteNotifications: false,
@@ -468,6 +470,7 @@ class AppSettings {
       alwaysShowSeconds: json['alwaysShowSeconds'] as bool? ?? false,
       enableHapticFeedback: json['enableHapticFeedback'] as bool? ?? true,
       enableCompactMode: json['enableCompactMode'] as bool? ?? false,
+      showWeatherInAppBar: json['showWeatherInAppBar'] as bool? ?? true,
       enableSmartRecommendations:
           json['enableSmartRecommendations'] as bool? ?? true,
       enableAutoFavoriteFrequentStops:
@@ -545,6 +548,7 @@ class AppSettings {
   final bool alwaysShowSeconds;
   final bool enableHapticFeedback;
   final bool enableCompactMode;
+  final bool showWeatherInAppBar;
   final bool enableSmartRecommendations;
   final bool enableAutoFavoriteFrequentStops;
   final bool enableSmartRouteNotifications;
@@ -585,6 +589,7 @@ class AppSettings {
     bool? alwaysShowSeconds,
     bool? enableHapticFeedback,
     bool? enableCompactMode,
+    bool? showWeatherInAppBar,
     bool? enableSmartRecommendations,
     bool? enableAutoFavoriteFrequentStops,
     bool? enableSmartRouteNotifications,
@@ -628,6 +633,7 @@ class AppSettings {
       alwaysShowSeconds: alwaysShowSeconds ?? this.alwaysShowSeconds,
       enableHapticFeedback: enableHapticFeedback ?? this.enableHapticFeedback,
       enableCompactMode: enableCompactMode ?? this.enableCompactMode,
+      showWeatherInAppBar: showWeatherInAppBar ?? this.showWeatherInAppBar,
       enableSmartRecommendations:
           enableSmartRecommendations ?? this.enableSmartRecommendations,
       enableAutoFavoriteFrequentStops:
@@ -690,6 +696,7 @@ class AppSettings {
       'alwaysShowSeconds': alwaysShowSeconds,
       'enableHapticFeedback': enableHapticFeedback,
       'enableCompactMode': enableCompactMode,
+      'showWeatherInAppBar': showWeatherInAppBar,
       'enableSmartRecommendations': enableSmartRecommendations,
       'enableAutoFavoriteFrequentStops': enableAutoFavoriteFrequentStops,
       'enableSmartRouteNotifications': enableSmartRouteNotifications,

--- a/lib/core/weather_service.dart
+++ b/lib/core/weather_service.dart
@@ -1,0 +1,478 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import 'api_user_agent.dart';
+import 'http_error_utils.dart';
+
+/// A single "current weather" reading for one location.
+class WeatherSnapshot {
+  const WeatherSnapshot({
+    required this.temperatureC,
+    required this.weatherCode,
+    required this.fetchedAt,
+  });
+
+  final double temperatureC;
+
+  /// WMO weather interpretation code, or null when the provider omitted it.
+  final int? weatherCode;
+
+  final DateTime fetchedAt;
+
+  /// Temperature rounded for display, e.g. `32` for `32.4`.
+  int get displayTemperature => temperatureC.round();
+}
+
+/// One hourly forecast slot.
+///
+/// [time] carries wall clock at the forecast location inside a UTC flagged
+/// [DateTime], so `.hour` reads the local hour there and comparisons never
+/// pick up the device's own timezone offset.
+class WeatherHourly {
+  const WeatherHourly({
+    required this.time,
+    required this.temperatureC,
+    required this.weatherCode,
+    required this.precipitationProbability,
+  });
+
+  final DateTime time;
+  final double temperatureC;
+  final int? weatherCode;
+
+  /// Chance of precipitation, 0-100.
+  final int precipitationProbability;
+
+  int get displayTemperature => temperatureC.round();
+}
+
+/// One day of the weekly forecast. [date] follows [WeatherHourly.time].
+class WeatherDaily {
+  const WeatherDaily({
+    required this.date,
+    required this.highC,
+    required this.lowC,
+    required this.weatherCode,
+    required this.precipitationProbability,
+  });
+
+  final DateTime date;
+  final double highC;
+  final double lowC;
+  final int? weatherCode;
+
+  /// Highest chance of precipitation that day, 0-100.
+  final int precipitationProbability;
+
+  int get displayHigh => highC.round();
+  int get displayLow => lowC.round();
+}
+
+/// Everything the weather screen renders: current conditions plus the hourly
+/// and daily forecasts.
+class WeatherForecast {
+  const WeatherForecast({
+    required this.current,
+    required this.apparentTemperatureC,
+    required this.relativeHumidity,
+    required this.windSpeedKph,
+    required this.hourly,
+    required this.daily,
+    required this.sunrise,
+    required this.sunset,
+  });
+
+  final WeatherSnapshot current;
+
+  /// "Feels like" temperature in Celsius.
+  final double? apparentTemperatureC;
+
+  /// Relative humidity in percent.
+  final int? relativeHumidity;
+
+  /// Wind speed in km/h, Open-Meteo's default unit.
+  final double? windSpeedKph;
+
+  /// Upcoming hours, starting with the hour already in progress.
+  final List<WeatherHourly> hourly;
+
+  /// Upcoming days, starting with today.
+  final List<WeatherDaily> daily;
+
+  final DateTime? sunrise;
+  final DateTime? sunset;
+
+  DateTime get fetchedAt => current.fetchedAt;
+}
+
+/// WMO weather interpretation codes used by Open-Meteo.
+/// https://open-meteo.com/en/docs#weathervariables
+const Map<int, String> _wmoLabels = {
+  0: '晴',
+  1: '晴時多雲',
+  2: '多雲',
+  3: '陰',
+  45: '霧',
+  48: '霧',
+  51: '小雨',
+  53: '雨',
+  55: '大雨',
+  56: '凍雨',
+  57: '凍雨',
+  61: '小雨',
+  63: '雨',
+  65: '大雨',
+  66: '凍雨',
+  67: '凍雨',
+  71: '小雪',
+  73: '雪',
+  75: '大雪',
+  77: '雪',
+  80: '陣雨',
+  81: '陣雨',
+  82: '大陣雨',
+  85: '陣雪',
+  86: '大陣雪',
+  95: '雷陣雨',
+  96: '雷陣雨伴冰雹',
+  99: '雷陣雨伴冰雹',
+};
+
+/// Human readable condition for a WMO code, falling back to 多雲 like the
+/// upstream weather app does for unmapped codes.
+String weatherConditionLabel(int? code) => _wmoLabels[code] ?? '多雲';
+
+/// Rounds a coordinate to ~1.1km. Applied before anything leaves the device.
+double roundCoordinate(double value) => (value * 100).roundToDouble() / 100;
+
+/// Fetches current conditions and forecasts from Open-Meteo.
+///
+/// Open-Meteo needs no API key and sends `Access-Control-Allow-Origin: *`,
+/// so the same calls work on web without a proxy.
+class WeatherService {
+  WeatherService({http.Client? client}) : _client = client ?? http.Client();
+
+  /// Shared instance so the cache survives remounts and is reused between the
+  /// app bar chip and the weather screen.
+  static final WeatherService shared = WeatherService();
+
+  final http.Client _client;
+
+  static const _host = 'api.open-meteo.com';
+  static const _path = '/v1/forecast';
+  static const _timeout = Duration(seconds: 10);
+
+  /// How long a reading stays fresh before another request is made.
+  static const cacheTtl = Duration(minutes: 15);
+
+  /// Hours kept from the hourly forecast.
+  static const forecastHourCount = 24;
+
+  /// Days requested from the daily forecast.
+  static const forecastDayCount = 7;
+
+  WeatherSnapshot? _cached;
+  String? _cachedKey;
+  Future<WeatherSnapshot>? _inFlight;
+  String? _inFlightKey;
+
+  WeatherForecast? _cachedForecast;
+  String? _cachedForecastKey;
+  Future<WeatherForecast>? _inFlightForecast;
+  String? _inFlightForecastKey;
+
+  /// Current temperature and weather code only — the cheap call behind the
+  /// app bar chip.
+  Future<WeatherSnapshot> fetchCurrent({
+    required double latitude,
+    required double longitude,
+    bool force = false,
+  }) {
+    // The rounded pair doubles as the cache key.
+    final lat = roundCoordinate(latitude);
+    final lon = roundCoordinate(longitude);
+    final key = '$lat,$lon';
+
+    final cached = _cached;
+    if (!force &&
+        cached != null &&
+        _cachedKey == key &&
+        DateTime.now().difference(cached.fetchedAt) < cacheTtl) {
+      return Future.value(cached);
+    }
+
+    final inFlight = _inFlight;
+    if (inFlight != null && _inFlightKey == key) {
+      return inFlight;
+    }
+
+    final request = _fetch(lat: lat, lon: lon, key: key);
+    _inFlight = request;
+    _inFlightKey = key;
+    return request.whenComplete(() {
+      _inFlight = null;
+      _inFlightKey = null;
+    });
+  }
+
+  /// Current conditions plus hourly and daily forecasts — the heavier call
+  /// behind the weather screen.
+  Future<WeatherForecast> fetchForecast({
+    required double latitude,
+    required double longitude,
+    bool force = false,
+  }) {
+    final lat = roundCoordinate(latitude);
+    final lon = roundCoordinate(longitude);
+    final key = '$lat,$lon';
+
+    final cached = _cachedForecast;
+    if (!force &&
+        cached != null &&
+        _cachedForecastKey == key &&
+        DateTime.now().difference(cached.fetchedAt) < cacheTtl) {
+      return Future.value(cached);
+    }
+
+    final inFlight = _inFlightForecast;
+    if (inFlight != null && _inFlightForecastKey == key) {
+      return inFlight;
+    }
+
+    final request = _fetchForecast(lat: lat, lon: lon, key: key);
+    _inFlightForecast = request;
+    _inFlightForecastKey = key;
+    return request.whenComplete(() {
+      _inFlightForecast = null;
+      _inFlightForecastKey = null;
+    });
+  }
+
+  Future<WeatherSnapshot> _fetch({
+    required double lat,
+    required double lon,
+    required String key,
+  }) async {
+    final decoded = await _getJson(
+      Uri.https(_host, _path, {
+        'latitude': '$lat',
+        'longitude': '$lon',
+        'current': 'temperature_2m,weather_code',
+      }),
+    );
+
+    final snapshot = _currentFrom(decoded);
+    _cached = snapshot;
+    _cachedKey = key;
+    return snapshot;
+  }
+
+  Future<WeatherForecast> _fetchForecast({
+    required double lat,
+    required double lon,
+    required String key,
+  }) async {
+    final decoded = await _getJson(
+      Uri.https(_host, _path, {
+        'latitude': '$lat',
+        'longitude': '$lon',
+        'current':
+            'temperature_2m,relative_humidity_2m,apparent_temperature,'
+            'weather_code,wind_speed_10m',
+        'hourly': 'temperature_2m,precipitation_probability,weather_code',
+        'daily':
+            'temperature_2m_max,temperature_2m_min,weather_code,'
+            'precipitation_probability_max,sunrise,sunset',
+        'timezone': 'auto',
+        'forecast_days': '$forecastDayCount',
+      }),
+    );
+
+    final snapshot = _currentFrom(decoded);
+    // One reading serves both the chip and the screen.
+    _cached = snapshot;
+    _cachedKey = key;
+
+    final current = decoded['current'];
+    final currentMap = current is Map<Object?, Object?>
+        ? current
+        : const <Object?, Object?>{};
+
+    // With timezone=auto Open-Meteo reports the location's wall clock, so
+    // "now" has to be expressed the same way for the comparison below.
+    final offsetSeconds = _asInt(decoded['utc_offset_seconds']) ?? 0;
+    final locationNow = DateTime.now().toUtc().add(
+      Duration(seconds: offsetSeconds),
+    );
+    // Keep the hour already in progress rather than jumping to the next one.
+    final earliest = locationNow.subtract(const Duration(hours: 1));
+
+    final hourly = <WeatherHourly>[];
+    final hourlyMap = decoded['hourly'];
+    if (hourlyMap is Map<Object?, Object?>) {
+      final times = _asList(hourlyMap['time']);
+      final temperatures = _asList(hourlyMap['temperature_2m']);
+      final codes = _asList(hourlyMap['weather_code']);
+      final rain = _asList(hourlyMap['precipitation_probability']);
+      for (var i = 0; i < times.length; i++) {
+        if (hourly.length >= forecastHourCount) {
+          break;
+        }
+        final time = _parseLocationWallClock(_at(times, i));
+        final temperature = _asDouble(_at(temperatures, i));
+        if (time == null || temperature == null || time.isBefore(earliest)) {
+          continue;
+        }
+        hourly.add(
+          WeatherHourly(
+            time: time,
+            temperatureC: temperature,
+            weatherCode: _asInt(_at(codes, i)),
+            precipitationProbability: _asPercent(_at(rain, i)),
+          ),
+        );
+      }
+    }
+
+    final daily = <WeatherDaily>[];
+    DateTime? sunrise;
+    DateTime? sunset;
+    final dailyMap = decoded['daily'];
+    if (dailyMap is Map<Object?, Object?>) {
+      final times = _asList(dailyMap['time']);
+      final highs = _asList(dailyMap['temperature_2m_max']);
+      final lows = _asList(dailyMap['temperature_2m_min']);
+      final codes = _asList(dailyMap['weather_code']);
+      final rain = _asList(dailyMap['precipitation_probability_max']);
+      for (var i = 0; i < times.length && i < forecastDayCount; i++) {
+        final date = _parseLocationWallClock(_at(times, i));
+        final high = _asDouble(_at(highs, i));
+        final low = _asDouble(_at(lows, i));
+        if (date == null || high == null || low == null) {
+          continue;
+        }
+        daily.add(
+          WeatherDaily(
+            date: date,
+            highC: high,
+            lowC: low,
+            weatherCode: _asInt(_at(codes, i)),
+            precipitationProbability: _asPercent(_at(rain, i)),
+          ),
+        );
+      }
+      sunrise = _parseLocationWallClock(_at(_asList(dailyMap['sunrise']), 0));
+      sunset = _parseLocationWallClock(_at(_asList(dailyMap['sunset']), 0));
+    }
+
+    final forecast = WeatherForecast(
+      current: snapshot,
+      apparentTemperatureC: _asDouble(currentMap['apparent_temperature']),
+      relativeHumidity: _asInt(currentMap['relative_humidity_2m']),
+      windSpeedKph: _asDouble(currentMap['wind_speed_10m']),
+      hourly: List<WeatherHourly>.unmodifiable(hourly),
+      daily: List<WeatherDaily>.unmodifiable(daily),
+      sunrise: sunrise,
+      sunset: sunset,
+    );
+    _cachedForecast = forecast;
+    _cachedForecastKey = key;
+    return forecast;
+  }
+
+  Future<Map<Object?, Object?>> _getJson(Uri uri) async {
+    // Built by hand on purpose: ApiUserAgent.applyTo would attach the signed
+    // in user's bearer token, and Open-Meteo is a third party.
+    final response = await _client
+        .get(
+          uri,
+          headers: <String, String>{
+            'Accept': 'application/json',
+            // User-Agent is a forbidden header in browsers.
+            if (!kIsWeb) 'User-Agent': ApiUserAgent.value,
+          },
+        )
+        .timeout(_timeout);
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception(
+        httpStatusMessage(response.statusCode, '天氣資料載入失敗。'),
+      );
+    }
+
+    final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+    if (decoded is! Map<Object?, Object?>) {
+      throw const FormatException('天氣資料格式錯誤。');
+    }
+    return decoded;
+  }
+
+  WeatherSnapshot _currentFrom(Map<Object?, Object?> decoded) {
+    final current = decoded['current'];
+    if (current is! Map<Object?, Object?>) {
+      throw const FormatException('天氣資料格式錯誤。');
+    }
+
+    // Open-Meteo returns 26 (int) or 26.4 (double) depending on the value.
+    final temperature = _asDouble(current['temperature_2m']);
+    if (temperature == null) {
+      throw const FormatException('天氣資料缺少氣溫。');
+    }
+
+    return WeatherSnapshot(
+      temperatureC: temperature,
+      weatherCode: _asInt(current['weather_code']),
+      fetchedAt: DateTime.now(),
+    );
+  }
+}
+
+double? _asDouble(Object? value) => value is num ? value.toDouble() : null;
+
+int? _asInt(Object? value) => value is num ? value.toInt() : null;
+
+/// Reads a 0-100 percentage, clamping anything out of range to the ends.
+int _asPercent(Object? value) {
+  final parsed = _asInt(value);
+  if (parsed == null || parsed < 0) {
+    return 0;
+  }
+  return parsed > 100 ? 100 : parsed;
+}
+
+List<Object?> _asList(Object? value) =>
+    value is List<Object?> ? value : const <Object?>[];
+
+Object? _at(List<Object?> values, int index) =>
+    index >= 0 && index < values.length ? values[index] : null;
+
+final RegExp _wallClockPattern = RegExp(
+  r'^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2}))?',
+);
+
+/// Parses one of Open-Meteo's `timezone=auto` timestamps, which arrive as
+/// naive local times such as `2026-09-06T15:00`.
+///
+/// The digits are read straight into a UTC value so it always reads back as
+/// wall clock at the forecast location, whatever the device's timezone is.
+/// `DateTime.parse` is deliberately not used: it would build a local time, and
+/// a wall clock inside the device's own DST spring-forward gap gets normalised
+/// an hour forward, which would print one hour twice and skip another.
+DateTime? _parseLocationWallClock(Object? value) {
+  if (value is! String) {
+    return null;
+  }
+  final match = _wallClockPattern.firstMatch(value.trim());
+  if (match == null) {
+    return null;
+  }
+  return DateTime.utc(
+    int.parse(match.group(1)!),
+    int.parse(match.group(2)!),
+    int.parse(match.group(3)!),
+    int.parse(match.group(4) ?? '0'),
+    int.parse(match.group(5) ?? '0'),
+  );
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -14,12 +14,14 @@ import '../core/route_direction_label.dart';
 import '../widgets/eta_badge.dart';
 import '../widgets/transit_station_map.dart';
 import '../widgets/transit_drawer.dart';
+import '../widgets/weather_app_bar_title.dart';
 import 'adaptive_settings_presenter.dart';
 import 'database_settings_screen.dart';
 import 'favorites_screen.dart';
 import 'nearby_screen.dart';
 import 'route_detail_navigation.dart';
 import 'search_screen.dart';
+import 'weather_screen.dart';
 import '../widgets/ad_banner_widget.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -276,7 +278,16 @@ class HomeScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: hasBusBackgroundImage ? Colors.transparent : null,
       appBar: AppBar(
-        title: const Text('YABus'),
+        title: WeatherAppBarTitle(
+          title: 'YABus',
+          // The chip already has a fix; pass it on so the page loads at once.
+          onTap: (latitude, longitude) => Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (_) =>
+                  WeatherScreen(latitude: latitude, longitude: longitude),
+            ),
+          ),
+        ),
         leading:
             MediaQuery.sizeOf(context).width >= kDesktopNavigationRailBreakpoint
             ? null

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -277,6 +277,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           value: controller.settings.enableCompactMode,
                           onChanged: controller.updateEnableCompactMode,
                         ),
+                        SwitchListTile(
+                          contentPadding: EdgeInsets.zero,
+                          title: const Text('顯示天氣'),
+                          subtitle: const Text(
+                            '在首頁標題旁顯示目前氣溫，點一下可開啟完整預報；'
+                            '需要已授權的定位權限，不會另外詢問。位置會傳送至 Open-Meteo。',
+                          ),
+                          value: controller.settings.showWeatherInAppBar,
+                          onChanged: controller.updateShowWeatherInAppBar,
+                        ),
                         if (isAndroid || isIOS) ...[
                           const SizedBox(height: 12),
                           DropdownButtonFormField<MobileMapProvider>(

--- a/lib/screens/weather_screen.dart
+++ b/lib/screens/weather_screen.dart
@@ -1,0 +1,557 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+
+import '../core/friendly_error.dart';
+import '../core/weather_service.dart';
+import '../widgets/weather_app_bar_title.dart';
+
+/// Full weather page: current conditions, 24 hour forecast and a week ahead.
+///
+/// Data comes from Open-Meteo, the same source as the app bar chip, through
+/// the shared [WeatherService] so opening this page right after the chip
+/// refreshed reuses that reading instead of making another request.
+class WeatherScreen extends StatefulWidget {
+  const WeatherScreen({
+    this.latitude,
+    this.longitude,
+    this.serviceOverride,
+    this.locationOverride,
+    super.key,
+  });
+
+  /// Position the caller already resolved, so the page can skip a second
+  /// location lookup. Both must be provided together.
+  final double? latitude;
+  final double? longitude;
+
+  @visibleForTesting
+  final WeatherService? serviceOverride;
+
+  @visibleForTesting
+  final PassiveLocationResolver? locationOverride;
+
+  @override
+  State<WeatherScreen> createState() => _WeatherScreenState();
+}
+
+class _WeatherScreenState extends State<WeatherScreen> {
+  WeatherForecast? _forecast;
+  String? _error;
+  bool _loading = true;
+  bool _locationUnavailable = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  WeatherService get _service => widget.serviceOverride ?? WeatherService.shared;
+
+  Future<void> _load({bool force = false}) async {
+    if (mounted) {
+      setState(() {
+        _loading = true;
+        _error = null;
+        _locationUnavailable = false;
+      });
+    }
+
+    double? latitude = widget.latitude;
+    double? longitude = widget.longitude;
+    if (latitude == null || longitude == null) {
+      final resolve = widget.locationOverride ?? resolvePassivePosition;
+      final Position? position = await resolve();
+      latitude = position?.latitude;
+      longitude = position?.longitude;
+    }
+
+    if (!mounted) {
+      return;
+    }
+    if (latitude == null || longitude == null) {
+      setState(() {
+        _loading = false;
+        _locationUnavailable = true;
+      });
+      return;
+    }
+
+    try {
+      final forecast = await _service.fetchForecast(
+        latitude: latitude,
+        longitude: longitude,
+        force: force,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _forecast = forecast;
+        _loading = false;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _loading = false;
+        // Strips exception prefixes and translates network/timeout errors,
+        // like every other screen in the app.
+        _error = friendlyErrorMessage(error, fallback: _genericWeatherError);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final forecast = _forecast;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('天氣'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: '重新整理',
+            onPressed: _loading ? null : () => _load(force: true),
+          ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: () => _load(force: true),
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+          children: [
+            if (forecast != null) ..._content(context, forecast),
+            if (forecast == null && _loading)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 96),
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            if (forecast == null && !_loading) _placeholder(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _content(BuildContext context, WeatherForecast forecast) {
+    return [
+      _currentCard(context, forecast),
+      if (forecast.hourly.isNotEmpty) ...[
+        const SizedBox(height: 24),
+        _sectionTitle(context, '逐時'),
+        const SizedBox(height: 8),
+        _hourlyStrip(context, forecast.hourly),
+      ],
+      if (forecast.daily.isNotEmpty) ...[
+        const SizedBox(height: 24),
+        _sectionTitle(context, '一週'),
+        const SizedBox(height: 8),
+        _weeklyList(context, forecast.daily),
+      ],
+      if (forecast.sunrise != null || forecast.sunset != null) ...[
+        const SizedBox(height: 24),
+        _sunRow(context, forecast),
+      ],
+      const SizedBox(height: 24),
+      _footer(context, forecast),
+      // Errors while a forecast is already on screen keep the stale data.
+      if (_error != null) ...[
+        const SizedBox(height: 12),
+        Text(
+          _error!,
+          textAlign: TextAlign.center,
+          style: TextStyle(color: Theme.of(context).colorScheme.error),
+        ),
+      ],
+    ];
+  }
+
+  Widget _currentCard(BuildContext context, WeatherForecast forecast) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final current = forecast.current;
+    final today = forecast.daily.isNotEmpty ? forecast.daily.first : null;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+        child: Column(
+          children: [
+            Icon(
+              weatherConditionIcon(current.weatherCode),
+              size: 72,
+              color: colorScheme.primary,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              '${current.displayTemperature}°C',
+              style: theme.textTheme.displaySmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              weatherConditionLabel(current.weatherCode),
+              style: theme.textTheme.titleMedium,
+            ),
+            if (today != null) ...[
+              const SizedBox(height: 4),
+              Text(
+                '最高 ${today.displayHigh}° · 最低 ${today.displayLow}°',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            const SizedBox(height: 16),
+            Wrap(
+              alignment: WrapAlignment.center,
+              spacing: 12,
+              runSpacing: 8,
+              children: [
+                if (forecast.apparentTemperatureC != null)
+                  _metric(
+                    context,
+                    Icons.thermostat,
+                    '體感',
+                    '${forecast.apparentTemperatureC!.round()}°',
+                  ),
+                if (forecast.relativeHumidity != null)
+                  _metric(
+                    context,
+                    Icons.water_drop_outlined,
+                    '濕度',
+                    '${forecast.relativeHumidity}%',
+                  ),
+                if (forecast.windSpeedKph != null)
+                  _metric(
+                    context,
+                    Icons.air,
+                    '風速',
+                    '${forecast.windSpeedKph!.round()} km/h',
+                  ),
+                if (today != null)
+                  _metric(
+                    context,
+                    Icons.umbrella_outlined,
+                    '降雨',
+                    '${today.precipitationProbability}%',
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _metric(
+    BuildContext context,
+    IconData icon,
+    String label,
+    String value,
+  ) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: theme.colorScheme.onSurfaceVariant),
+        const SizedBox(width: 4),
+        Text(
+          '$label $value',
+          style: theme.textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+
+  Widget _sectionTitle(BuildContext context, String text) {
+    return Text(
+      text,
+      style: Theme.of(
+        context,
+      ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+    );
+  }
+
+  Widget _hourlyStrip(BuildContext context, List<WeatherHourly> hours) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      height: 132,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: hours.length,
+        separatorBuilder: (context, index) => const SizedBox(width: 4),
+        itemBuilder: (context, index) {
+          final hour = hours[index];
+          return SizedBox(
+            width: 64,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  index == 0 ? '現在' : '${hour.time.hour}時',
+                  style: theme.textTheme.bodySmall,
+                ),
+                const SizedBox(height: 8),
+                Icon(
+                  weatherConditionIcon(hour.weatherCode),
+                  size: 24,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  '${hour.displayTemperature}°',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '${hour.precipitationProbability}%',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _weeklyList(BuildContext context, List<WeatherDaily> days) {
+    var weekLow = days.first.lowC;
+    var weekHigh = days.first.highC;
+    for (final day in days) {
+      weekLow = math.min(weekLow, day.lowC);
+      weekHigh = math.max(weekHigh, day.highC);
+    }
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Column(
+          children: [
+            for (var index = 0; index < days.length; index++)
+              _weeklyRow(context, days[index], index, weekLow, weekHigh),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _weeklyRow(
+    BuildContext context,
+    WeatherDaily day,
+    int index,
+    double weekLow,
+    double weekHigh,
+  ) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 44,
+            child: Text(
+              dayLabel(day.date, index),
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+          Icon(
+            weatherConditionIcon(day.weatherCode),
+            size: 20,
+            color: theme.colorScheme.primary,
+          ),
+          SizedBox(
+            width: 44,
+            child: Text(
+              '${day.precipitationProbability}%',
+              textAlign: TextAlign.end,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.primary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          SizedBox(
+            width: 32,
+            child: Text(
+              '${day.displayLow}°',
+              textAlign: TextAlign.end,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(child: _rangeBar(context, day, weekLow, weekHigh)),
+          const SizedBox(width: 8),
+          SizedBox(
+            width: 32,
+            child: Text(
+              '${day.displayHigh}°',
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _rangeBar(
+    BuildContext context,
+    WeatherDaily day,
+    double weekLow,
+    double weekHigh,
+  ) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final span = weekHigh - weekLow;
+    final start = span <= 0 ? 0.0 : (day.lowC - weekLow) / span;
+    final end = span <= 0 ? 1.0 : (day.highC - weekLow) / span;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final barWidth = math.max(6.0, math.min(width, width * (end - start)));
+        final left = math.max(0.0, math.min(width * start, width - barWidth));
+        return SizedBox(
+          height: 6,
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: colorScheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                ),
+              ),
+              Positioned(
+                left: left,
+                top: 0,
+                bottom: 0,
+                width: barWidth,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: colorScheme.primary,
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _sunRow(BuildContext context, WeatherForecast forecast) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            _metric(
+              context,
+              Icons.wb_twilight,
+              '日出',
+              clockLabel(forecast.sunrise),
+            ),
+            _metric(
+              context,
+              Icons.nightlight_outlined,
+              '日落',
+              clockLabel(forecast.sunset),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _footer(BuildContext context, WeatherForecast forecast) {
+    final theme = Theme.of(context);
+    return Text(
+      '資料來源：Open-Meteo · 更新於 ${clockLabel(forecast.fetchedAt)}',
+      textAlign: TextAlign.center,
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+    );
+  }
+
+  Widget _placeholder(BuildContext context) {
+    final theme = Theme.of(context);
+    final message = _locationUnavailable
+        ? '無法取得目前位置，因此無法顯示天氣。請確認定位服務與定位權限已開啟。'
+        : (_error ?? _genericWeatherError);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 72, horizontal: 24),
+      child: Column(
+        children: [
+          Icon(
+            _locationUnavailable
+                ? Icons.location_off_outlined
+                : Icons.cloud_off_outlined,
+            size: 48,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          FilledButton.tonal(
+            onPressed: () => _load(force: true),
+            child: const Text('重試'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Zero padded `HH:MM`, or `--:--` when the time is unknown.
+///
+/// Forecast times already carry the location's wall clock, so no timezone
+/// conversion happens here.
+String clockLabel(DateTime? time) {
+  if (time == null) {
+    return '--:--';
+  }
+  final hour = time.hour.toString().padLeft(2, '0');
+  final minute = time.minute.toString().padLeft(2, '0');
+  return '$hour:$minute';
+}
+
+const List<String> _weekdayNames = ['一', '二', '三', '四', '五', '六', '日'];
+
+/// `今天` / `明天` for the first two days, then `週三` style labels.
+String dayLabel(DateTime date, int index) {
+  if (index == 0) {
+    return '今天';
+  }
+  if (index == 1) {
+    return '明天';
+  }
+  // DateTime.weekday is 1 (Monday) through 7 (Sunday).
+  return '週${_weekdayNames[date.weekday - 1]}';
+}
+
+const String _genericWeatherError = '無法載入天氣資料，請稍後再試。';

--- a/lib/widgets/weather_app_bar_title.dart
+++ b/lib/widgets/weather_app_bar_title.dart
@@ -1,0 +1,367 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+
+import '../app/bus_app.dart';
+import '../core/weather_service.dart';
+
+typedef PassiveLocationResolver = Future<Position?> Function();
+
+/// Called when the chip is tapped, with the fix the chip already resolved so
+/// the caller can hand it straight to the weather screen. Either coordinate is
+/// null when no fix was available.
+typedef WeatherChipTapCallback =
+    void Function(double? latitude, double? longitude);
+
+const double kWeatherChipGap = 8;
+const double kWeatherChipIconSize = 16;
+const double kWeatherChipIconGap = 4;
+const double kWeatherChipHPad = 4;
+
+/// Width the weather chip needs for a temperature label of [labelWidth].
+double weatherChipWidth(double labelWidth) =>
+    kWeatherChipIconSize + kWeatherChipIconGap + labelWidth + kWeatherChipHPad * 2;
+
+/// Whether title plus chip still fit inside the app bar's title slot.
+bool weatherChipFits({
+  required double slotWidth,
+  required double titleWidth,
+  required double chipWidth,
+}) => titleWidth + kWeatherChipGap + chipWidth <= slotWidth;
+
+/// Icon for a WMO weather interpretation code.
+///
+/// Ported from the sibling weather app, which maps ranges rather than exact
+/// codes so intermediate codes (52, 62, 74, ...) still resolve.
+IconData weatherConditionIcon(int? code) {
+  if (code == null) {
+    return Icons.cloud_outlined;
+  }
+  if (code == 0) {
+    return Icons.wb_sunny;
+  }
+  if (code == 1 || code == 2) {
+    return Icons.wb_cloudy;
+  }
+  if (code == 3) {
+    return Icons.cloud;
+  }
+  if (code == 45 || code == 48) {
+    return Icons.blur_on;
+  }
+  if (code >= 51 && code <= 57) {
+    return Icons.grain;
+  }
+  if (code >= 61 && code <= 67) {
+    return Icons.opacity;
+  }
+  if (code >= 71 && code <= 77) {
+    return Icons.ac_unit;
+  }
+  if (code >= 80 && code <= 82) {
+    return Icons.grain;
+  }
+  if (code >= 85 && code <= 86) {
+    return Icons.ac_unit;
+  }
+  if (code >= 95) {
+    return Icons.flash_on;
+  }
+  return Icons.wb_cloudy;
+}
+
+/// Reads the device location without ever prompting for permission.
+///
+/// The weather chip is a passive nicety, so it only uses a fix the app is
+/// already allowed to read; asking here would hijack the app's own
+/// permission flow.
+Future<Position?> resolvePassivePosition() async {
+  try {
+    if (!await Geolocator.isLocationServiceEnabled()) {
+      return null;
+    }
+  } catch (_) {
+    return null;
+  }
+
+  LocationPermission permission;
+  try {
+    permission = await Geolocator.checkPermission();
+  } catch (_) {
+    return null;
+  }
+  if (permission == LocationPermission.denied ||
+      permission == LocationPermission.deniedForever) {
+    return null;
+  }
+
+  Position? lastKnown;
+  try {
+    lastKnown = await Geolocator.getLastKnownPosition();
+  } catch (_) {
+    lastKnown = null;
+  }
+  if (lastKnown != null) {
+    return lastKnown;
+  }
+
+  try {
+    return await Geolocator.getCurrentPosition(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.low,
+        timeLimit: Duration(seconds: 5),
+      ),
+    );
+  } catch (_) {
+    return null;
+  }
+}
+
+/// App bar title that renders `YABus  ☀ 32°C` when weather is available.
+///
+/// Falls back to the plain title when the setting is off, the location is
+/// unavailable, or the title slot is too narrow for both.
+class WeatherAppBarTitle extends StatelessWidget {
+  const WeatherAppBarTitle({
+    required this.title,
+    this.onTap,
+    this.serviceOverride,
+    this.locationOverride,
+    super.key,
+  });
+
+  final String title;
+
+  /// Tapping the chip opens the full weather page. Null leaves it decorative.
+  final WeatherChipTapCallback? onTap;
+
+  @visibleForTesting
+  final WeatherService? serviceOverride;
+
+  @visibleForTesting
+  final PassiveLocationResolver? locationOverride;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = AppControllerScope.of(context);
+    if (!controller.settings.showWeatherInAppBar) {
+      return Text(title);
+    }
+    return _WeatherChipHost(
+      title: title,
+      onTap: onTap,
+      serviceOverride: serviceOverride,
+      locationOverride: locationOverride,
+    );
+  }
+}
+
+class _WeatherChipHost extends StatefulWidget {
+  const _WeatherChipHost({
+    required this.title,
+    this.onTap,
+    this.serviceOverride,
+    this.locationOverride,
+  });
+
+  final String title;
+  final WeatherChipTapCallback? onTap;
+  final WeatherService? serviceOverride;
+  final PassiveLocationResolver? locationOverride;
+
+  @override
+  State<_WeatherChipHost> createState() => _WeatherChipHostState();
+}
+
+class _WeatherChipHostState extends State<_WeatherChipHost>
+    with WidgetsBindingObserver {
+  static const _refreshInterval = Duration(minutes: 15);
+
+  WeatherSnapshot? _snapshot;
+  Position? _position;
+  Timer? _timer;
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    unawaited(_load());
+    _timer = Timer.periodic(_refreshInterval, (_) => unawaited(_load()));
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Timers are frozen while backgrounded, so refresh on resume. The
+    // service's TTL keeps this from turning into a request per resume.
+    if (state == AppLifecycleState.resumed) {
+      unawaited(_load());
+    }
+  }
+
+  Future<void> _load() async {
+    if (_loading) {
+      return;
+    }
+    _loading = true;
+    try {
+      final resolve = widget.locationOverride ?? resolvePassivePosition;
+      final position = await resolve();
+      if (position == null) {
+        return;
+      }
+      // Handed to the weather screen on tap so it skips its own lookup.
+      _position = position;
+      final service = widget.serviceOverride ?? WeatherService.shared;
+      final snapshot = await service.fetchCurrent(
+        latitude: position.latitude,
+        longitude: position.longitude,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() => _snapshot = snapshot);
+    } catch (_) {
+      // Weather is decorative; keep whatever is already on screen.
+    } finally {
+      _loading = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final snapshot = _snapshot;
+    if (snapshot == null) {
+      return Text(widget.title);
+    }
+
+    final baseStyle = DefaultTextStyle.of(context).style;
+    final chipStyle = baseStyle.copyWith(
+      fontSize: 14,
+      fontWeight: FontWeight.w600,
+    );
+    final textScaler = MediaQuery.textScalerOf(context);
+    final textDirection = Directionality.of(context);
+    final label = '${snapshot.displayTemperature}°C';
+
+    final titleWidth = _measure(
+      widget.title,
+      baseStyle,
+      textScaler,
+      textDirection,
+    );
+    final chipWidth = weatherChipWidth(
+      _measure(label, chipStyle, textScaler, textDirection),
+    );
+
+    final onTap = widget.onTap;
+    // Padding is part of the tap target, so it stays inside the InkWell and
+    // weatherChipWidth keeps accounting for it either way.
+    final Widget chipBody = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: kWeatherChipHPad),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            weatherConditionIcon(snapshot.weatherCode),
+            size: kWeatherChipIconSize,
+          ),
+          const SizedBox(width: kWeatherChipIconGap),
+          Flexible(
+            child: Text(
+              label,
+              maxLines: 1,
+              softWrap: false,
+              overflow: TextOverflow.ellipsis,
+              style: chipStyle,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    final chip = Semantics(
+      button: onTap != null,
+      label: '目前天氣 ${weatherConditionLabel(snapshot.weatherCode)}'
+          ' ${snapshot.displayTemperature} 度',
+      child: Tooltip(
+        message: onTap == null
+            ? weatherConditionLabel(snapshot.weatherCode)
+            : '${weatherConditionLabel(snapshot.weatherCode)} · 查看天氣',
+        child: onTap == null
+            ? chipBody
+            : InkWell(
+                onTap: () => onTap(_position?.latitude, _position?.longitude),
+                borderRadius: BorderRadius.circular(8),
+                child: chipBody,
+              ),
+      ),
+    );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final slotWidth = constraints.maxWidth;
+        final fits =
+            !slotWidth.isFinite ||
+            weatherChipFits(
+              slotWidth: slotWidth,
+              titleWidth: titleWidth,
+              chipWidth: chipWidth,
+            );
+        if (!fits) {
+          return Text(
+            widget.title,
+            maxLines: 1,
+            softWrap: false,
+            overflow: TextOverflow.ellipsis,
+          );
+        }
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Flexible(
+              child: Text(
+                widget.title,
+                maxLines: 1,
+                softWrap: false,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            const SizedBox(width: kWeatherChipGap),
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: slotWidth.isFinite ? slotWidth : double.infinity,
+              ),
+              child: chip,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  double _measure(
+    String text,
+    TextStyle style,
+    TextScaler textScaler,
+    TextDirection textDirection,
+  ) {
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: textDirection,
+      textScaler: textScaler,
+      maxLines: 1,
+    )..layout();
+    final width = painter.width;
+    painter.dispose();
+    return width;
+  }
+}

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -193,6 +193,21 @@ void main() {
     expect(restored.mobileMapProvider, MobileMapProvider.osm);
   });
 
+  test('app settings persist the app bar weather toggle', () {
+    final settings = AppSettings.defaults().copyWith(
+      showWeatherInAppBar: false,
+    );
+
+    final restored = AppSettings.fromJson(settings.toJson());
+
+    expect(restored.showWeatherInAppBar, isFalse);
+    // Settings saved before this feature existed must still load.
+    expect(
+      AppSettings.fromJson(const <String, dynamic>{}).showWeatherInAppBar,
+      isTrue,
+    );
+  });
+
   test('app settings persist wear os sync preferences', () {
     final settings = AppSettings.defaults().copyWith(
       wearSyncEnabled: true,

--- a/test/weather_service_test.dart
+++ b/test/weather_service_test.dart
@@ -1,0 +1,578 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:taiwanbus_flutter/core/auth_token_store.dart';
+import 'package:taiwanbus_flutter/core/weather_service.dart';
+import 'package:taiwanbus_flutter/screens/weather_screen.dart';
+import 'package:taiwanbus_flutter/widgets/weather_app_bar_title.dart';
+
+http.Response _okResponse(Object body) =>
+    http.Response(jsonEncode(body), 200, headers: const {
+      'content-type': 'application/json; charset=utf-8',
+    });
+
+String _two(int value) => value.toString().padLeft(2, '0');
+
+/// Open-Meteo's `timezone=auto` shape: naive local time, no offset suffix.
+String _isoMinute(DateTime time) =>
+    '${time.year}-${_two(time.month)}-${_two(time.day)}'
+    'T${_two(time.hour)}:${_two(time.minute)}';
+
+String _isoDate(DateTime time) =>
+    '${time.year}-${_two(time.month)}-${_two(time.day)}';
+
+const int _taipeiOffsetSeconds = 8 * 3600;
+
+/// Top of the current hour in Taipei, as the service will compute it.
+///
+/// If the hour is about to roll over, wait it out — otherwise the payload and
+/// the service's own clock read could land in different hours.
+Future<DateTime> _locationHour() async {
+  const offset = Duration(seconds: _taipeiOffsetSeconds);
+  var now = DateTime.now().toUtc().add(offset);
+  if (now.minute == 59 && now.second >= 55) {
+    await Future<void>.delayed(const Duration(seconds: 6));
+    now = DateTime.now().toUtc().add(offset);
+  }
+  return DateTime.utc(now.year, now.month, now.day, now.hour);
+}
+
+void main() {
+  tearDown(() {
+    AuthTokenStore.token = null;
+  });
+
+  test('fetchCurrent requests only current temperature and weather code', () async {
+    late Uri captured;
+    final service = WeatherService(
+      client: MockClient((request) async {
+        captured = request.url;
+        return _okResponse({
+          'current': {'temperature_2m': 32.4, 'weather_code': 0},
+        });
+      }),
+    );
+
+    final snapshot = await service.fetchCurrent(
+      latitude: 25.03746,
+      longitude: 121.56398,
+    );
+
+    expect(captured.host, 'api.open-meteo.com');
+    expect(captured.path, '/v1/forecast');
+    expect(captured.queryParameters['current'], 'temperature_2m,weather_code');
+    // Coordinates are rounded to ~1.1km before leaving the device.
+    expect(captured.queryParameters['latitude'], '25.04');
+    expect(captured.queryParameters['longitude'], '121.56');
+    expect(captured.queryParameters.containsKey('hourly'), isFalse);
+    expect(captured.queryParameters.containsKey('daily'), isFalse);
+    expect(snapshot.temperatureC, 32.4);
+    expect(snapshot.displayTemperature, 32);
+    expect(snapshot.weatherCode, 0);
+  });
+
+  test('fetchCurrent never sends the signed-in auth token to Open-Meteo', () async {
+    AuthTokenStore.token = 'test-token';
+    Map<String, String> captured = const {};
+    final service = WeatherService(
+      client: MockClient((request) async {
+        captured = request.headers;
+        return _okResponse({
+          'current': {'temperature_2m': 20.0, 'weather_code': 3},
+        });
+      }),
+    );
+
+    await service.fetchCurrent(latitude: 25.0, longitude: 121.5);
+
+    expect(captured['Authorization'] ?? captured['authorization'], isNull);
+  });
+
+  test('fetchCurrent accepts a whole-number temperature', () async {
+    final service = WeatherService(
+      client: MockClient(
+        (request) async => _okResponse({
+          'current': {'temperature_2m': 26, 'weather_code': 61},
+        }),
+      ),
+    );
+
+    final snapshot = await service.fetchCurrent(
+      latitude: 25.0,
+      longitude: 121.5,
+    );
+
+    expect(snapshot.temperatureC, 26.0);
+    expect(snapshot.displayTemperature, 26);
+  });
+
+  test('fetchCurrent tolerates a missing weather code', () async {
+    final service = WeatherService(
+      client: MockClient(
+        (request) async => _okResponse({
+          'current': {'temperature_2m': 18.2},
+        }),
+      ),
+    );
+
+    final snapshot = await service.fetchCurrent(
+      latitude: 25.0,
+      longitude: 121.5,
+    );
+
+    expect(snapshot.weatherCode, isNull);
+  });
+
+  test('fetchCurrent serves the cache within the TTL and refetches on force', () async {
+    var calls = 0;
+    final service = WeatherService(
+      client: MockClient((request) async {
+        calls += 1;
+        return _okResponse({
+          'current': {'temperature_2m': 30.0, 'weather_code': 0},
+        });
+      }),
+    );
+
+    await service.fetchCurrent(latitude: 25.0, longitude: 121.5);
+    await service.fetchCurrent(latitude: 25.001, longitude: 121.502);
+    expect(calls, 1);
+
+    await service.fetchCurrent(
+      latitude: 25.0,
+      longitude: 121.5,
+      force: true,
+    );
+    expect(calls, 2);
+  });
+
+  test('fetchCurrent refetches when the rounded location changes', () async {
+    var calls = 0;
+    final service = WeatherService(
+      client: MockClient((request) async {
+        calls += 1;
+        return _okResponse({
+          'current': {'temperature_2m': 30.0, 'weather_code': 0},
+        });
+      }),
+    );
+
+    await service.fetchCurrent(latitude: 25.0, longitude: 121.5);
+    await service.fetchCurrent(latitude: 22.63, longitude: 120.3);
+
+    expect(calls, 2);
+  });
+
+  test('fetchCurrent throws a readable error on a failed response', () async {
+    final service = WeatherService(
+      client: MockClient((request) async => http.Response('nope', 503)),
+    );
+
+    await expectLater(
+      service.fetchCurrent(latitude: 25.0, longitude: 121.5),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('天氣'),
+        ),
+      ),
+    );
+  });
+
+  test('fetchCurrent throws on malformed payloads', () async {
+    Future<void> expectRejects(String body) async {
+      final service = WeatherService(
+        client: MockClient((request) async => http.Response(body, 200)),
+      );
+      await expectLater(
+        service.fetchCurrent(latitude: 25.0, longitude: 121.5),
+        throwsA(isA<Exception>()),
+      );
+    }
+
+    await expectRejects('not json');
+    await expectRejects('{}');
+    await expectRejects('{"current":"x"}');
+    await expectRejects('{"current":{"temperature_2m":"warm"}}');
+  });
+
+  test('weatherConditionLabel ports the WMO mapping', () {
+    expect(weatherConditionLabel(0), '晴');
+    expect(weatherConditionLabel(1), '晴時多雲');
+    expect(weatherConditionLabel(3), '陰');
+    expect(weatherConditionLabel(45), '霧');
+    expect(weatherConditionLabel(51), '小雨');
+    expect(weatherConditionLabel(61), '小雨');
+    expect(weatherConditionLabel(56), '凍雨');
+    expect(weatherConditionLabel(75), '大雪');
+    expect(weatherConditionLabel(82), '大陣雨');
+    expect(weatherConditionLabel(99), '雷陣雨伴冰雹');
+    // Unmapped and null codes fall back instead of throwing.
+    expect(weatherConditionLabel(52), '多雲');
+    expect(weatherConditionLabel(null), '多雲');
+  });
+
+  test('weatherConditionIcon covers the ported ranges', () {
+    expect(weatherConditionIcon(null), Icons.cloud_outlined);
+    expect(weatherConditionIcon(0), Icons.wb_sunny);
+    expect(weatherConditionIcon(2), Icons.wb_cloudy);
+    expect(weatherConditionIcon(3), Icons.cloud);
+    expect(weatherConditionIcon(48), Icons.blur_on);
+    // Codes the label map omits still resolve because the icon map is ranged.
+    expect(weatherConditionIcon(52), Icons.grain);
+    expect(weatherConditionIcon(64), Icons.opacity);
+    expect(weatherConditionIcon(74), Icons.ac_unit);
+    expect(weatherConditionIcon(81), Icons.grain);
+    expect(weatherConditionIcon(86), Icons.ac_unit);
+    expect(weatherConditionIcon(95), Icons.flash_on);
+  });
+
+  test('fetchForecast asks for current, hourly and daily in one call', () async {
+    late Uri captured;
+    final service = WeatherService(
+      client: MockClient((request) async {
+        captured = request.url;
+        return _okResponse({
+          'utc_offset_seconds': _taipeiOffsetSeconds,
+          'current': {'temperature_2m': 32.4, 'weather_code': 0},
+        });
+      }),
+    );
+
+    await service.fetchForecast(latitude: 25.03746, longitude: 121.56398);
+
+    final query = captured.queryParameters;
+    expect(captured.host, 'api.open-meteo.com');
+    expect(captured.path, '/v1/forecast');
+    // Coordinates stay rounded on the heavier call too.
+    expect(query['latitude'], '25.04');
+    expect(query['longitude'], '121.56');
+    expect(query['current'], contains('apparent_temperature'));
+    expect(query['current'], contains('relative_humidity_2m'));
+    expect(query['current'], contains('wind_speed_10m'));
+    expect(query['hourly'], 'temperature_2m,precipitation_probability,weather_code');
+    expect(query['daily'], contains('temperature_2m_max'));
+    expect(query['daily'], contains('precipitation_probability_max'));
+    expect(query['daily'], contains('sunrise'));
+    expect(query['timezone'], 'auto');
+    expect(query['forecast_days'], '7');
+  });
+
+  test('fetchForecast reads current conditions beyond the temperature', () async {
+    final service = WeatherService(
+      client: MockClient(
+        (request) async => _okResponse({
+          'utc_offset_seconds': _taipeiOffsetSeconds,
+          'current': {
+            'temperature_2m': 32.4,
+            'weather_code': 1,
+            'apparent_temperature': 35.1,
+            'relative_humidity_2m': 68,
+            'wind_speed_10m': 12.3,
+          },
+        }),
+      ),
+    );
+
+    final forecast = await service.fetchForecast(
+      latitude: 25.0,
+      longitude: 121.5,
+    );
+
+    expect(forecast.current.displayTemperature, 32);
+    expect(forecast.current.weatherCode, 1);
+    expect(forecast.apparentTemperatureC, 35.1);
+    expect(forecast.relativeHumidity, 68);
+    expect(forecast.windSpeedKph, 12.3);
+    // Missing hourly/daily blocks degrade to empty rather than throwing.
+    expect(forecast.hourly, isEmpty);
+    expect(forecast.daily, isEmpty);
+    expect(forecast.sunrise, isNull);
+  });
+
+  test('fetchForecast keeps the hour in progress and caps at 24 hours', () async {
+    final base = await _locationHour();
+    // Two stale slots, then the hour in progress plus 29 future hours.
+    final times = <String>[
+      _isoMinute(base.subtract(const Duration(hours: 3))),
+      _isoMinute(base.subtract(const Duration(hours: 2))),
+      for (var i = 0; i < 30; i++) _isoMinute(base.add(Duration(hours: i))),
+    ];
+
+    final service = WeatherService(
+      client: MockClient(
+        (request) async => _okResponse({
+          'utc_offset_seconds': _taipeiOffsetSeconds,
+          'current': {'temperature_2m': 30.0, 'weather_code': 0},
+          'hourly': {
+            'time': times,
+            'temperature_2m': [
+              for (var i = 0; i < times.length; i++) 20.0 + i,
+            ],
+            'weather_code': [for (var i = 0; i < times.length; i++) 0],
+            'precipitation_probability': [
+              for (var i = 0; i < times.length; i++) i,
+            ],
+          },
+        }),
+      ),
+    );
+
+    final forecast = await service.fetchForecast(
+      latitude: 25.0,
+      longitude: 121.5,
+    );
+
+    expect(forecast.hourly, hasLength(WeatherService.forecastHourCount));
+    expect(forecast.hourly.first.time, base);
+    expect(
+      forecast.hourly.last.time,
+      base.add(const Duration(hours: 23)),
+    );
+    // Index 2 of the payload is the first kept slot.
+    expect(forecast.hourly.first.temperatureC, 22.0);
+    expect(forecast.hourly.first.precipitationProbability, 2);
+    // Stale slots never make it through.
+    expect(
+      forecast.hourly.any(
+        (hour) => hour.time.isBefore(base.subtract(const Duration(hours: 1))),
+      ),
+      isFalse,
+    );
+  });
+
+  test('forecast times stay on the location wall clock', () async {
+    final service = WeatherService(
+      client: MockClient(
+        (request) async => _okResponse({
+          // Deliberately not the test machine's offset.
+          'utc_offset_seconds': -8 * 3600,
+          'current': {'temperature_2m': 18.0, 'weather_code': 3},
+          'daily': {
+            'time': ['2026-09-06'],
+            'temperature_2m_max': [24.0],
+            'temperature_2m_min': [15.0],
+            'weather_code': [3],
+            'precipitation_probability_max': [10],
+            'sunrise': ['2026-09-06T05:42'],
+            'sunset': ['2026-09-06T19:07'],
+          },
+        }),
+      ),
+    );
+
+    final forecast = await service.fetchForecast(
+      latitude: 37.77,
+      longitude: -122.42,
+    );
+
+    // The digits are preserved exactly, whatever timezone the test runs in.
+    expect(forecast.sunrise, DateTime.utc(2026, 9, 6, 5, 42));
+    expect(forecast.sunset, DateTime.utc(2026, 9, 6, 19, 7));
+    expect(clockLabel(forecast.sunrise), '05:42');
+    expect(clockLabel(forecast.sunset), '19:07');
+    expect(forecast.daily.single.date, DateTime.utc(2026, 9, 6));
+  });
+
+  test('forecast times survive wall clocks inside a DST gap', () async {
+    // 2026-03-08T02:30 does not exist in US timezones (spring forward) and
+    // 2026-03-29T02:30 does not exist in most of Europe. Parsing either as a
+    // local time would shift it an hour, duplicating one hourly slot and
+    // dropping another for anyone in those zones.
+    final service = WeatherService(
+      client: MockClient(
+        (request) async => _okResponse({
+          'utc_offset_seconds': -5 * 3600,
+          'current': {'temperature_2m': 8.0, 'weather_code': 3},
+          'daily': {
+            'time': ['2026-03-08'],
+            'temperature_2m_max': [12.0],
+            'temperature_2m_min': [3.0],
+            'weather_code': [3],
+            'precipitation_probability_max': [20],
+            'sunrise': ['2026-03-08T02:30'],
+            'sunset': ['2026-03-29T02:30'],
+          },
+        }),
+      ),
+    );
+
+    final forecast = await service.fetchForecast(
+      latitude: 40.71,
+      longitude: -74.01,
+    );
+
+    expect(forecast.sunrise, DateTime.utc(2026, 3, 8, 2, 30));
+    expect(forecast.sunset, DateTime.utc(2026, 3, 29, 2, 30));
+    expect(clockLabel(forecast.sunrise), '02:30');
+  });
+
+  test('fetchForecast caps the week and clamps rain percentages', () async {
+    final start = DateTime.utc(2026, 9, 6);
+    final service = WeatherService(
+      client: MockClient(
+        (request) async => _okResponse({
+          'utc_offset_seconds': _taipeiOffsetSeconds,
+          'current': {'temperature_2m': 30.0, 'weather_code': 0},
+          'daily': {
+            'time': [
+              for (var i = 0; i < 10; i++)
+                _isoDate(start.add(Duration(days: i))),
+            ],
+            'temperature_2m_max': [
+              for (var i = 0; i < 10; i++) 30.0 + i,
+            ],
+            'temperature_2m_min': [for (var i = 0; i < 10; i++) 24.0],
+            'weather_code': [for (var i = 0; i < 10; i++) 61],
+            // Out of range, negative, absent and non-numeric all normalise.
+            'precipitation_probability_max': [150, -20, null, 'x', 40],
+          },
+        }),
+      ),
+    );
+
+    final forecast = await service.fetchForecast(
+      latitude: 25.0,
+      longitude: 121.5,
+    );
+
+    expect(forecast.daily, hasLength(WeatherService.forecastDayCount));
+    expect(forecast.daily.first.date, start);
+    expect(forecast.daily.first.displayHigh, 30);
+    expect(forecast.daily.first.displayLow, 24);
+    expect(
+      forecast.daily.map((day) => day.precipitationProbability).toList(),
+      [100, 0, 0, 0, 40, 0, 0],
+    );
+  });
+
+  test('fetchForecast caches and honours force', () async {
+    var calls = 0;
+    final service = WeatherService(
+      client: MockClient((request) async {
+        calls += 1;
+        return _okResponse({
+          'utc_offset_seconds': _taipeiOffsetSeconds,
+          'current': {'temperature_2m': 30.0, 'weather_code': 0},
+        });
+      }),
+    );
+
+    await service.fetchForecast(latitude: 25.0, longitude: 121.5);
+    await service.fetchForecast(latitude: 25.001, longitude: 121.502);
+    expect(calls, 1);
+
+    await service.fetchForecast(
+      latitude: 25.0,
+      longitude: 121.5,
+      force: true,
+    );
+    expect(calls, 2);
+
+    await service.fetchForecast(latitude: 22.63, longitude: 120.3);
+    expect(calls, 3);
+  });
+
+  test('a forecast also satisfies the app bar chip', () async {
+    var calls = 0;
+    final service = WeatherService(
+      client: MockClient((request) async {
+        calls += 1;
+        return _okResponse({
+          'utc_offset_seconds': _taipeiOffsetSeconds,
+          'current': {'temperature_2m': 28.6, 'weather_code': 2},
+        });
+      }),
+    );
+
+    await service.fetchForecast(latitude: 25.0, longitude: 121.5);
+    final snapshot = await service.fetchCurrent(
+      latitude: 25.0,
+      longitude: 121.5,
+    );
+
+    expect(calls, 1);
+    expect(snapshot.displayTemperature, 29);
+    expect(snapshot.weatherCode, 2);
+  });
+
+  test('fetchForecast surfaces failed responses', () async {
+    final service = WeatherService(
+      client: MockClient((request) async => http.Response('nope', 503)),
+    );
+
+    await expectLater(
+      service.fetchForecast(latitude: 25.0, longitude: 121.5),
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('天氣'),
+        ),
+      ),
+    );
+  });
+
+  testWidgets('weather screen shows failures without exception noise', (
+    tester,
+  ) async {
+    final service = WeatherService(
+      client: MockClient((request) async => http.Response('nope', 503)),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WeatherScreen(
+          latitude: 25.0,
+          longitude: 121.5,
+          serviceOverride: service,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('天氣資料載入失敗。'), findsOneWidget);
+    expect(find.textContaining('Exception'), findsNothing);
+  });
+
+  test('weather screen labels avoid needing a date formatting package', () {
+    expect(clockLabel(null), '--:--');
+    expect(clockLabel(DateTime.utc(2026, 9, 6, 7, 5)), '07:05');
+
+    // The first two days read as words; the rest use the weekday.
+    expect(dayLabel(DateTime.utc(2026, 9, 6), 0), '今天');
+    expect(dayLabel(DateTime.utc(2026, 9, 7), 1), '明天');
+    // 2026-09-08 is a Tuesday, 2026-09-13 a Sunday.
+    expect(dayLabel(DateTime.utc(2026, 9, 8), 2), '週二');
+    expect(dayLabel(DateTime.utc(2026, 9, 13), 6), '週日');
+  });
+
+  test('weather chip fit arithmetic', () {
+    final chipWidth = weatherChipWidth(40);
+    expect(chipWidth, kWeatherChipIconSize + kWeatherChipIconGap + 40 + kWeatherChipHPad * 2);
+    // Wider labels need more room.
+    expect(weatherChipWidth(60), greaterThan(chipWidth));
+
+    expect(
+      weatherChipFits(slotWidth: 968, titleWidth: 68, chipWidth: chipWidth),
+      isTrue,
+    );
+    expect(
+      weatherChipFits(slotWidth: 88, titleWidth: 68, chipWidth: chipWidth),
+      isFalse,
+    );
+    // Exactly filling the slot still counts as fitting.
+    expect(
+      weatherChipFits(
+        slotWidth: 68 + kWeatherChipGap + chipWidth,
+        titleWidth: 68,
+        chipWidth: chipWidth,
+      ),
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
Closes #33

在首頁 App Bar 標題旁顯示「天氣圖示 + 氣溫」（例如 `YABus ☀️ 32°C`），點一下開啟完整天氣頁面（目前天氣、逐時、一週預報、日出日落）。資料全部來自**中央氣象署開放資料平臺**。

## 改了什麼

| 檔案 | 內容 |
|---|---|
| `lib/core/weather_service.dart` | CWA 資料來源：`O-A0003-001`（現在天氣觀測）＋ `F-D0047-{NNN}` / `{NNN+2}`（鄉鎮 3 日 / 一週預報）。含快取、TTL、`force` 重新整理 |
| `lib/core/cwa_geo_index.dart` | 離線測站／鄉鎮索引（363 個測站 + 全台鄉鎮），在裝置端把座標解析成「測站代碼 + 鄉鎮名稱」 |
| `lib/screens/weather_screen.dart` | 完整天氣頁面 |
| `lib/widgets/weather_app_bar_title.dart` | App Bar 上的天氣 chip，含寬度不足時的降級顯示 |
| `lib/core/models.dart`、`app_controller.dart`、`settings_screen.dart` | 新增「App Bar 天氣」開關（預設關閉）與說明文案 |
| `test/weather_service_test.dart` | 40+ 個測試：解析、快取、時區、日出日落、UI |

## 幾個設計上的取捨（想請你看一下）

**1. 座標不出裝置。** 預報 dataset 是以鄉鎮為單位、觀測是以測站為單位，所以我把測站與鄉鎮的座標做成離線索引，在本機算最近的測站／鄉鎮，只把**測站代碼與鄉鎮名稱**送給氣象署。順帶的好處是流量從「整包 ~440 KB 觀測 + 160–400 KB 預報」降到「~2 KB + 24 KB + 9.5 KB」。

**2. 不會把使用者的 bearer token 送給第三方。** `_getJson` 用的是 `ApiUserAgent.githubApplyTo(apiJsonHeaders)` 而不是 `applyTo` —— 前者只帶 User-Agent，不帶登入 token。有測試（`fetchCurrent never sends the signed-in auth token to CWA`）鎖住這個行為。

**3. ⚠️ CWA API key 目前是寫死在 `weather_service.dart` 裡的**（`kCwaApiKey`）。這把 key 是我自己申請的、可以公開，但如果你想改成 build-time `--dart-define`（像 `YABUS_GOOGLE_WEB_CLIENT_ID` 那樣走 workflow env）我可以馬上調整，告訴我偏好即可。

**4. 時間一律以台灣牆鐘解析。** CWA 回的是 `+08:00` 字串，如果用 `toLocal()` 解析，在 UTC runner 上會掉到前一天。測試用 2036 年兩個 spring-forward 的星期日（US `2036-03-09`、EU `2036-03-30`）把這件事釘住。

**5. 日出日落是本機用 NOAA 公式算的**，不另外打 API；極區（如 Svalbard 冬天）會回 `null` 並隱藏該列。

## 其他

- 沿用 repo 既有慣例：`api_http.dart` 的 `apiGet` / `apiJsonHeaders` / `apiDecodeJsonResponse`（brotli-aware）與 `apiRequestTimeout`，錯誤訊息走 `friendlyErrorMessage` / `httpStatusMessage`。
- 功能預設**關閉**，在設定頁開啟；需要已授權的定位權限，不會另外跳出詢問。

## 驗證

`build.yml` 在 fork 上以 workflow_dispatch 跑過，8/8 全綠（Verify / Linux / Web / Wear OS / macOS / Android APK / iOS IPA / Windows）：
https://github.com/Axoled-Student/yetanotherbusapp/actions/runs/34806824343

`flutter analyze` 無警告，`flutter test` 172 passed。